### PR TITLE
Ignore files with single extension when building

### DIFF
--- a/lib/middleman/builder.rb
+++ b/lib/middleman/builder.rb
@@ -87,7 +87,8 @@ module Middleman
         next if File.directory?(file_source)
         next if file_source.include?('layout')
         next unless file_source.split('/').select { |p| p[0,1] == '_' }.empty?
-        
+        next unless file_source.split('/').last.split('.').length == 3
+      
         file_extension = File.extname(file_source)
         file_destination = File.join(given_destination, file_source.gsub(source, '.'))
         file_destination.gsub!('/./', '/')


### PR DESCRIPTION
This is a 1-line hack that resolves #25. All it does is tell Tilt to ignore files with only a single extension, e.g. `foo.sass`, while supporting those with multiple extensions, e.g. `foo.sass.css`. I'm not sure whether it's the best solution, and I wasn't able to run the Cucumber tests on my system, but it does fix the serious error I was encountering.
