### PR TITLE
Error on Windows platform: "The system cannot find the path specified."

### DIFF
--- a/lib/middleman/templates/local.rb
+++ b/lib/middleman/templates/local.rb
@@ -1,6 +1,6 @@
 module Middleman
   def self.templates_path
-    File.join(`cd ~ && pwd`.chomp, ".middleman")
+    File.join(File.expand_path("~/"), ".middleman")
   end
 end
 


### PR DESCRIPTION
On Windows the templates_path function is broken. Tested with Ruby 1.9.2.
