### PR TITLE
Build handels files prefixed with 2 consecutive underscores

### DIFF
--- a/lib/middleman/builder.rb
+++ b/lib/middleman/builder.rb
@@ -111,8 +111,8 @@ module Middleman
     
   protected
     def handle_path(file_source)
-      # Skip partials prefixed with an underscore
-      return unless file_source.gsub(SHARED_SERVER.root, '').split('/').select { |p| p[0,1] == '_' }.empty?
+      # Skip partials prefixed with an underscore while still handling files prefixed with 2 consecutive underscores
+      return unless file_source.gsub(SHARED_SERVER.root, '').split('/').select { |p| p[/^_[^_]/] }.empty?
       
       file_extension = File.extname(file_source)
       file_destination = File.join(given_destination, file_source.gsub(source, '.'))


### PR DESCRIPTION
Hi Thomas,

I fixed a issue I had where middleman skipped some required files durring the build phase.

The server I'm using requires some special files that are prefixed with 2 underscores "__" so middleman skipped right over them thinking there where partials. I don't have the ability to rename or move them, wish I did.

I just tweaked your array select to match anything starting with a underscore followed by anything other then another underscore.

`select { |p| p[0,1] == '_' }.empty?
select { |p| p[/^_[^_]/] }.empty?`

Thanks and keep up the good work.

Arron
