### PR TITLE
Fixing: a Gem scoping bug.

### DIFF
--- a/lib/middleman.rb
+++ b/lib/middleman.rb
@@ -163,10 +163,10 @@ module Middleman
   
   def self.rubygems_latest_specs
     # If newer Rubygems
-    if Gem::Specification.respond_to? :latest_specs
-      Gem::Specification.latest_specs
+    if ::Gem::Specification.respond_to? :latest_specs
+      ::Gem::Specification.latest_specs
     else
-      Gem.source_index.latest_specs
+      ::Gem.source_index.latest_specs
     end
   end
   


### PR DESCRIPTION
I just wrote a rack middleware gem I'm using in middleman, and when I add it to my projects gem file. (note: I don't even require it or use it in the config file)

And I'm not sure why but I get this error

```
/Users/arron/code/middleman/lib/middleman.rb:166:in `rubygems_latest_specs': uninitialized constant Middleman::Gem::Specification (NameError)
        from /Users/arron/code/middleman/lib/middleman.rb:154:in `load_extensions_in_path'
        from /Users/arron/code/middleman/lib/middleman.rb:202:in `<top (required)>'
        from /Users/arron/code/middleman/bin/middleman:51:in `require'
        from /Users/arron/code/middleman/bin/middleman:51:in `start_cli!'
        from /Users/arron/code/middleman/bin/middleman:72:in `<top (required)>'
        from /Users/arron/.rvm/gems/ruby-1.9.2-p180@encountercreative.com/bin/middleman:19:in `load'
        from /Users/arron/.rvm/gems/ruby-1.9.2-p180@encountercreative.com/bin/middleman:19:in `<main>'
```

In this fix I just had to prefix `Gem::Specification` with `::` not sure why this fixes it. I guess it some kind of scoping problem.

I ran all the tests and they pass, so I guess it's ok.
