### PR TITLE
change comment to point to convore user gp instead of google

### DIFF
--- a/lib/middleman.rb
+++ b/lib/middleman.rb
@@ -48,7 +48,7 @@
 #
 # [Visit the website]:     http://middlemanapp.com
 # [Read the wiki]:         https://github.com/tdreyno/middleman/wiki
-# [Email the users group]: http://groups.google.com/group/middleman-users
+# [Email the users group]: https://convore.com/middleman/
 # [Submit bug reports]:    https://github.com/tdreyno/middleman/issues
 
 # Setup our load paths


### PR DESCRIPTION
Trivial but useful: update comments to point to convore users group instead of google group.

Not sure if the google group is still alive, but Convore is where the discussion is...  Reject if need be!
