### PR TITLE
Include .htaccess files when building a site

### DIFF
--- a/features/builder.feature
+++ b/features/builder.feature
@@ -15,6 +15,7 @@ Feature: Builder
     Then "spaces in file.html" should exist at "test-app" and include "spaces"
     Then "images/Read me (example).txt" should exist at "test-app"
     Then "images/Child folder/regular_file(example).txt" should exist at "test-app"
+    Then ".htaccess" should exist at "test-app"
     
   Scenario: Build glob
     Given a built app at "glob-app" with flags "--glob '*.css'"

--- a/fixtures/test-app/source/.htaccess
+++ b/fixtures/test-app/source/.htaccess
@@ -1,0 +1,1 @@
+# I'm an htaccess file!

--- a/lib/middleman/sitemap/store.rb
+++ b/lib/middleman/sitemap/store.rb
@@ -101,7 +101,7 @@ module Middleman::Sitemap
     def touch_file(file)
       return false if file == @source ||
                       file.match(/^\./) ||
-                      file.match(/\/\./) ||
+                      (file.match(/\/\./) && !file.match(/\/\.htaccess/)) ||
                       (file.match(/\/_/) && !file.match(/\/__/)) ||
                       File.directory?(file)
                      


### PR DESCRIPTION
I noticed that .htaccess files weren't being copied across when I built my site - this should fix that. I chose to explicitly whitelist .htaccess rather than allowing dotfiles and filtering out .svn/.DS_Store and such because htaccess seems like the most common thing people would want.
