### PR TITLE
Fix partials with locals

### DIFF
--- a/features/partials.feature
+++ b/features/partials.feature
@@ -28,3 +28,8 @@ Feature: Provide Sane Defaults for Partial Behavior
     Given the Server is running at "partials-app"
     When I go to "/sub/index.html"
     Then I should see "Local Partial"
+
+  Scenario: Partials can be passed locals
+    Given the Server is running at "partials-app"
+    When I go to "/locals.html"
+    Then I should see "Local var is bar"

--- a/fixtures/partials-app/source/_locals.erb
+++ b/fixtures/partials-app/source/_locals.erb
@@ -1,0 +1,1 @@
+Local var is <%= foo %>

--- a/fixtures/partials-app/source/locals.html.erb
+++ b/fixtures/partials-app/source/locals.html.erb
@@ -1,0 +1,1 @@
+<%= partial 'locals', :locals => { :foo => 'bar' } %>

--- a/lib/middleman/core_extensions/rendering.rb
+++ b/lib/middleman/core_extensions/rendering.rb
@@ -57,8 +57,10 @@ module Middleman::CoreExtensions::Rendering
     end
     
     # Sinatra/Padrino render method signature.
-    def render(engine, data, options={}, locals={}, &block)
+    def render(engine, data, options={}, &block)
       data = data.to_s
+
+      locals = options[:locals]
 
       found_partial = false
       engine        = nil


### PR DESCRIPTION
The Padrino "partial" helper was dying when used with a :locals hash. This should fix it. My apologies for overloading your existing partials Cucumber feature to test this - I can create a separate feature for this if you'd like.
