### PR TITLE
Frontmatter was not being removed from template source

### DIFF
--- a/features/front-matter.feature
+++ b/features/front-matter.feature
@@ -5,3 +5,4 @@ Feature: YAML Front Matter
     Given the Server is running at "test-app"
     When I go to "/front-matter.html"
     Then I should see "<h1>This is the title</h1>"
+    Then I should not see "---"


### PR DESCRIPTION
I hit into a problem where the frontmatter YAML block was not being removed from the template source, causing errors in the template engines or unwanted text in the page. I think what was happening was that the FrontMatter extension running before the Rendering extension, and Rendering removes the template source from the cache when files update, while FrontMatter inserts corrected source into the cache when files update, so the good source from FrontMatter was getting obliterated. Reversing the order of registering the extensions in Middleman::Base fixes it, though I suspect a more robust solution could be achieved. Perhaps all cached values related to a path should be purged whenever it is updated independently of extensions, and then they don't have to do it themselves?
