### PR TITLE
Build .htaccess files (and other things in the sitemap) directly even when directory-indexes are on

### DIFF
--- a/features/directory_index.feature
+++ b/features/directory_index.feature
@@ -11,6 +11,7 @@ Feature: Directory Index
     Then "needs_index.html" should not exist at "indexable-app"
     Then "a_folder/needs_index.html" should not exist at "indexable-app"
     Then "leave_me_alone/index.html" should not exist at "indexable-app"
+    Then ".htaccess" should exist at "indexable-app"
     
   Scenario: Preview normal file
     Given the Server is running at "indexable-app"

--- a/fixtures/indexable-app/source/.htaccess
+++ b/fixtures/indexable-app/source/.htaccess
@@ -1,0 +1,1 @@
+# I'm an htaccess file!

--- a/lib/middleman/extensions/directory_indexes.rb
+++ b/lib/middleman/extensions/directory_indexes.rb
@@ -4,6 +4,8 @@ module Middleman::Extensions
       def registered(app)
         app.send :include, InstanceMethods
         app.before do
+          next if sitemap.exists?(@original_path)
+
           prefix         = @original_path.sub(/\/$/, "")
           indexed_path   = prefix + "/" + index_file
         
@@ -25,9 +27,7 @@ module Middleman::Extensions
         app.build_reroute do |destination, request_path|
           index_ext      = File.extname(index_file)
           new_index_path = "/#{index_file}"
-      
-          indexed_path = request_path.sub(/\/$/, "") + index_ext
-        
+
           if ignored_directory_indexes.include?(request_path)
             false
           elsif request_path =~ /#{new_index_path}$/


### PR DESCRIPTION
I realized my earlier fix for htaccess files wasn't sufficient - they still didn't get built when directory-indexes were on. This change fixes that, and should also fix anything else that's mapped as a path to be built that the sitemap already knows about. I've also removed one line of dead code that I noticed.
