### PR TITLE
A slight speedup in the sitemap extension by only scanning the source directory

### DIFF
--- a/lib/middleman/core_extensions/front_matter.rb
+++ b/lib/middleman/core_extensions/front_matter.rb
@@ -52,7 +52,7 @@ module Middleman::CoreExtensions::FrontMatter
   class FrontMatter
     class << self
       def matcher
-        %r{source/.*\.html}
+        %r{^source/.*\.html}
       end
     end
     

--- a/lib/middleman/core_extensions/sitemap.rb
+++ b/lib/middleman/core_extensions/sitemap.rb
@@ -12,12 +12,12 @@ module Middleman::CoreExtensions::Sitemap
   module InstanceMethods
     def initialize
       super
-    
-      file_changed do |file|
+
+      file_changed %r{^source/} do |file|
         sitemap.touch_file(file)
       end
-    
-      file_deleted do |file|
+
+      file_deleted %r{^source/} do |file|
         sitemap.remove_file(file)
       end
     end


### PR DESCRIPTION
This way sitemap will not scan through all the files in your project (including .git files and such) when it doesn't ever need to know about those files. This also includes a slight tightening of the regex for filtering paths for front_matter.
