### PR TITLE
Remove metadata caching so that changes to front matter show up in the preview server

### DIFF
--- a/features/front-matter.feature
+++ b/features/front-matter.feature
@@ -6,3 +6,27 @@ Feature: YAML Front Matter
     When I go to "/front-matter.html"
     Then I should see "<h1>This is the title</h1>"
     Then I should not see "---"
+
+  Scenario: A template changes frontmatter during preview
+    Given the Server is running at "test-app"
+    And the file "source/front-matter-change.html.erb" has the contents
+      """
+      ---
+      title: Hello World
+      layout: false
+      ---
+      <%= data.page.title %>
+      """
+    When I go to "/front-matter-change.html"
+    Then I should see "Hello World"
+    And the file "source/front-matter-change.html.erb" has the contents
+      """
+      ---
+      title: Hola Mundo
+      layout: false
+      ---
+      <%= data.page.title %>
+      """
+    When I go to "/front-matter-change.html"
+    Then I should see "Hola Mundo"
+    

--- a/lib/middleman/sitemap/template.rb
+++ b/lib/middleman/sitemap/template.rb
@@ -31,15 +31,13 @@ module Middleman::Sitemap
     end
 
     def metadata
-      app.cache.fetch(:metadata, source_file) do
-        metadata = { :options => {}, :locals => {} }
-        app.provides_metadata.each do |callback, matcher|
-          next if !matcher.nil? && !source_file.match(matcher)
-          result = app.instance_exec(source_file, &callback)
-          metadata = metadata.deep_merge(result)
-        end
-        metadata
+      metadata = { :options => {}, :locals => {} }
+      app.provides_metadata.each do |callback, matcher|
+        next if !matcher.nil? && !source_file.match(matcher)
+        result = app.instance_exec(source_file, &callback)
+        metadata = metadata.deep_merge(result)
       end
+      metadata
     end
 
     def render(opts={}, locs={}, &block)


### PR DESCRIPTION
I don't think the caching was helping a lot anyway - the frontmatter extension already caches the frontmatter data whenever files are changed, and I don't see another example of provides_metadata being used. If you still wanted the caching, there'd need to be some nice way of clearing the metadata cache every time the file changed - I didn't know exactly where that should go.
