### PR TITLE
Make rdiscount a runtime dependency now that it's the default

### DIFF
--- a/middleman.gemspec
+++ b/middleman.gemspec
@@ -36,13 +36,13 @@ Gem::Specification.new do |s|
   s.add_dependency("sprockets", ["~> 2.1.2"])
   s.add_dependency("sprockets-sass", ["~> 0.5.0"])
   s.add_dependency("guard", ["~> 0.8.8"])
+  s.add_dependency("rdiscount")
   
   # OSX
   s.add_dependency("rb-fsevent")
   
   # Development and test
   s.add_development_dependency("slim")
-  s.add_development_dependency("rdiscount")
   s.add_development_dependency("sinatra")
   s.add_development_dependency("coffee-filter", ["~> 0.1.1"])
   s.add_development_dependency("liquid", ["~> 2.2.0"])


### PR DESCRIPTION
Running "bundle exec middleman server" with some markdown files in my project caused an error because no markdown engine had been stated.
