### PR TITLE
Validate the template option for "middleman init"

### DIFF
--- a/lib/middleman/cli.rb
+++ b/lib/middleman/cli.rb
@@ -41,7 +41,7 @@ module Middleman
     def init(name)
       key = options[:template].to_sym
       unless Middleman::Templates.registered.has_key?(key)
-        key = :default
+        raise Thor::Error.new "Unknown project template '#{key}'"
       end
       
       thor_group = Middleman::Templates.registered[key]


### PR DESCRIPTION
This way if somebody messes up the template name, or chooses an unavailable template, middleman won't just give them the default instead.
