### PR TITLE
Disabling: guard's cli interactions.

### DIFF
--- a/lib/middleman/guard.rb
+++ b/lib/middleman/guard.rb
@@ -21,7 +21,8 @@ module Middleman::Guard
           watch(%r{(.*)})
         end
       },
-      :watch_all_modifications => true
+      :watch_all_modifications => true,
+      :no_interactions => true
     })
   end
 end


### PR DESCRIPTION
Fixes the input lag problem when using ruby-debug or pry.
