### PR TITLE
Page generated for non-default layout files

### DIFF
--- a/features/builder.feature
+++ b/features/builder.feature
@@ -21,6 +21,7 @@ Feature: Builder
       | _partial                                      |
       | _liquid_partial                               |
       | layout                                        |
+      | other_layout                                  |
       | layouts/custom                                |
       | layouts/content_for                           |
       

--- a/fixtures/test-app/source/other_layout.erb
+++ b/fixtures/test-app/source/other_layout.erb
@@ -1,0 +1,1 @@
+This is another layout!


### PR DESCRIPTION
It looks like if you create other layouts as recommended by the guides (http://middlemanapp.com/guides/templates-layouts-partials) Middleman will generate a page for those layouts!

For example, take this structure:

```
source/
  layout.haml
  other_layout.haml
  index.html.haml
```

I thought naming files with just the template extension was what marked them as layouts. What'll happen in this scenario is that two files will be generated: `index.html` and `other_layout`. I'd expect only `index.html` to generate.

This pull request includes a failing test case for this issue - I'm not sure right away how to fix it. If the recommendation is just to put all layouts in `layouts/` I'd actually be cool with that, but the docs would need to be updated.
