### PR TITLE
Preview server doesn't reload stylesheets when a Sass partial changes

### DIFF
--- a/features/sass_partials.feature
+++ b/features/sass_partials.feature
@@ -1,0 +1,17 @@
+Feature: Sass Partials
+  Scenario: The preview server should update stylesheets when Sass partials change
+  Given the Server is running at "preview-app"
+    And the file "source/stylesheets/_partial.sass" has the contents
+      """
+      body
+        font-size: 14px
+      """
+    When I go to "/stylesheets/main.css"
+    Then I should see "font-size: 14px"
+    And the file "source/stylesheets/_partial.sass" has the contents
+      """
+      body
+        font-size: 18px
+      """
+    When I go to "/stylesheets/main.css"
+    Then I should see "font-size: 18px"

--- a/fixtures/preview-app/source/stylesheets/_partial.sass
+++ b/fixtures/preview-app/source/stylesheets/_partial.sass
@@ -1,0 +1,2 @@
+body
+  font-size: 18px

--- a/fixtures/preview-app/source/stylesheets/main.css.sass
+++ b/fixtures/preview-app/source/stylesheets/main.css.sass
@@ -1,0 +1,1 @@
+@import partial.sass


### PR DESCRIPTION
My Sass files are organized into a bunch of partials, which I assemble using Sass' `@import` feature (I don't use Sprockets' weird require thing). However, `middleman server` won't reload my styles when I update a partial - I have to quit and restart the server to see the right thing. This makes it really hard to iterate on styles.

This pull request includes a failing test case - I'm not sure right away how to fix it.
