### PR TITLE
Remove reference to unknown instance variable @context_map

### DIFF
--- a/lib/middleman/sitemap/store.rb
+++ b/lib/middleman/sitemap/store.rb
@@ -83,7 +83,6 @@ module Middleman::Sitemap
       
       path = path.sub(/^\//, "")
       @pages.delete(path) if @pages.has_key?(path)
-      @context_map.delete(path) if @context_map.has_key?(path)
     end
     
     def file_to_path(file)


### PR DESCRIPTION
I think this was left over when something got refactored?
