### PR TITLE
Feature test for setting page setting through frontmatter

### DIFF
--- a/middleman-core/features/frontmatter_page_settings.feature
+++ b/middleman-core/features/frontmatter_page_settings.feature
@@ -1,0 +1,10 @@
+Feature: Setting page settings through frontmatter
+  Scenario: Setting layout, ignoring, and disabling directory indexes through frontmatter
+    Given a successfully built app at "frontmatter-settings-app"
+    Then the following files should exist:
+      | build/proxied/index.html |
+      | build/no_index.html |
+    And the file "build/alternate_layout/index.html" should contain "Alternate layout"
+    And the following files should not exist:
+      | build/ignored/index.html |
+      | build/no_index/index.html |

--- a/middleman-core/fixtures/frontmatter-settings-app/config.rb
+++ b/middleman-core/fixtures/frontmatter-settings-app/config.rb
@@ -1,0 +1,4 @@
+activate :directory_indexes
+
+# Proxy ignored.html, which should ignore itself through a frontmatter
+page 'proxied.html', :proxy => 'ignored.html'

--- a/middleman-core/fixtures/frontmatter-settings-app/source/alternate.erb
+++ b/middleman-core/fixtures/frontmatter-settings-app/source/alternate.erb
@@ -1,0 +1,3 @@
+Alternate layout!
+
+<%= yield %>

--- a/middleman-core/fixtures/frontmatter-settings-app/source/alternate_layout.html.erb
+++ b/middleman-core/fixtures/frontmatter-settings-app/source/alternate_layout.html.erb
@@ -1,0 +1,5 @@
+---
+layout: alternate
+---
+
+This uses an alternate layout

--- a/middleman-core/fixtures/frontmatter-settings-app/source/ignored.html.erb
+++ b/middleman-core/fixtures/frontmatter-settings-app/source/ignored.html.erb
@@ -1,0 +1,5 @@
+---
+ignored: true
+---
+
+This file ignores itself! But it can still be proxied.

--- a/middleman-core/fixtures/frontmatter-settings-app/source/no_index.html.erb
+++ b/middleman-core/fixtures/frontmatter-settings-app/source/no_index.html.erb
@@ -1,0 +1,5 @@
+---
+directory_index: false
+---
+
+This should not be put in no_index/index.html - it goes to no_index.html


### PR DESCRIPTION
New (failing) feature describing what it would look like to set some page features through frontmatter.

This tests the ability to set layout, ignore, and diable directory_index. Pertains to issue #194.
