### PR TITLE
grammar fix; changed erroneous “it's” to “its”

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A full set of in-depth instructional guides are available on the official websit
 
   http://middlemanapp.com/
 
-The community maintains it's own collection of tips and tricks in the GitHub wiki:
+The community maintains its own collection of tips and tricks in the GitHub wiki:
 
   https://github.com/middleman/middleman/wiki
 


### PR DESCRIPTION
“its own collection” is the collection belonging to it (the community). The old “it's” meant “it is own collection”.
