### PR TITLE
Update version so path-based Gemfile dependencies work

### DIFF
--- a/middleman-core/lib/middleman-core/version.rb
+++ b/middleman-core/lib/middleman-core/version.rb
@@ -4,7 +4,7 @@ require "rubygems"
 module Middleman
   # Current Version
   # @return [String]
-  VERSION = '3.0.0.beta.1' unless const_defined?(:VERSION)
+  VERSION = '3.0.0.beta.2' unless const_defined?(:VERSION)
   
   # Parsed version for RubyGems
   # @private


### PR DESCRIPTION
I found that if your local copy of Middleman is the same version as a published gem, Bundler seems to use the dependencies from rubygems.org even when you tell it to use a local path. Only by bumping the version number for the in-development gem was I able to get it to correctly understand that I needed the newest Compass.
