### PR TITLE
Haml should be a development dependency, along with Compass.

### DIFF
--- a/middleman-more/lib/middleman-more/renderers/haml.rb
+++ b/middleman-more/lib/middleman-more/renderers/haml.rb
@@ -1,6 +1,3 @@
-# Require gem
-require "haml"
-  
 # Haml Renderer
 module Middleman::Renderers::Haml
   
@@ -8,13 +5,19 @@ module Middleman::Renderers::Haml
   class << self
     # Once registered
     def registered(app)
-      # Add haml helpers to context
-      app.send :include, ::Haml::Helpers
-      
-      # Setup haml helper paths
-      app.ready do
-        init_haml_helpers
-      end
+      begin
+				# Require gem
+				require "haml"
+				
+				# Add haml helpers to context
+				app.send :include, ::Haml::Helpers
+
+				# Setup haml helper paths
+				app.ready do
+					init_haml_helpers
+				end
+			rescue LoadError
+			end
     end
     alias :included :registered
   end

--- a/middleman-more/middleman-more.gemspec
+++ b/middleman-more/middleman-more.gemspec
@@ -20,13 +20,14 @@ Gem::Specification.new do |s|
 
   s.add_dependency("middleman-core", Middleman::VERSION)
   s.add_dependency("uglifier", ["~> 1.2.0"])
-  s.add_dependency("haml", ["~> 3.1.0"])
   s.add_dependency("sass", ["~> 3.1.7"])
-  s.add_dependency("compass", ["0.12.rc.1"])
   s.add_dependency("coffee-script", ["~> 2.2.0"])
   s.add_dependency("execjs", ["~> 1.2"])
   s.add_dependency("sprockets", ["~> 2.1"])
   s.add_dependency("sprockets-sass", ["~> 0.7.0"])
   s.add_dependency("redcarpet", ["~> 2.1.0"])
+
+	s.add_development_dependency("haml", ["~> 3.1.0"])
+	s.add_development_dependency("compass", ["0.12.rc.1"])
 end
 


### PR DESCRIPTION
I doubt every middleman user requires Haml and Compass. So let's not install them by default.
