### PR TITLE
A url helper that strips directory indexes

### DIFF
--- a/middleman-core/lib/middleman-core/sitemap/page.rb
+++ b/middleman-core/lib/middleman-core/sitemap/page.rb
@@ -182,6 +182,13 @@ module Middleman::Sitemap
       # TODO: Seems like .html shouldn't be hardcoded here
     end
     
+    # A path without the directory index - so foo/index.html becomes
+    # just foo. Best for linking.
+    # @return [String]
+    def url
+      '/' + destination_path.sub(/#{Regexp.escape(app.index_file)}$/, '')
+    end
+
     # Get the relative path from the source
     # @return [String]
     def relative_path


### PR DESCRIPTION
This helper on `Sitemap::Page` will make it easier to create nice links - now instead of getting `foo/index.html`, you'll get `/foo/`.
