### PR TITLE
Rename gzip_assets to just gzip since it does HTML too

### DIFF
--- a/middleman-more/fixtures/gzip-app/config.rb
+++ b/middleman-more/fixtures/gzip-app/config.rb
@@ -1,1 +1,1 @@
-activate :gzip_assets
+activate :gzip

--- a/middleman-more/lib/middleman-more.rb
+++ b/middleman-more/lib/middleman-more.rb
@@ -45,8 +45,8 @@ module Middleman
     # MinifyJavascript uses the YUI compressor to shrink JS files
     autoload :MinifyJavascript,    "middleman-more/extensions/minify_javascript"
 
-    # GZIP assets during build
-    autoload :GzipAssets,    "middleman-more/extensions/gzip_assets"
+    # GZIP assets and pages during build
+    autoload :Gzip,    "middleman-more/extensions/gzip"
   end
   
   # Setup renderers

--- a/middleman-more/lib/middleman-more/extensions/gzip.rb
+++ b/middleman-more/lib/middleman-more/extensions/gzip.rb
@@ -4,8 +4,8 @@ require 'find'
 
 module Middleman::Extensions
   
-  # This extension Gzips assets when building. 
-  # Gzipped assets can be served directly by Apache or
+  # This extension Gzips assets and pages when building. 
+  # Gzipped assets and pages can be served directly by Apache or
   # Nginx with the proper configuration, and pre-zipping means that we
   # can use a more agressive compression level at no CPU cost per request.
   #
@@ -15,7 +15,7 @@ module Middleman::Extensions
   # Pass the :exts options to customize which file extensions get zipped (defaults
   # to .html, .htm, .js and .css.
   #
-  module GzipAssets
+  module Gzip
     class << self
       def registered(app, options={})
         exts = options[:exts] || %w(.js .css .html .htm)


### PR DESCRIPTION
Seems less confusing to not call it `gzip_assets` since it tries to gzip any non-binary file type.
