### PR TITLE
Load extension gems even when only using middleman-core

### DIFF
--- a/middleman-core/bin/middleman
+++ b/middleman-core/bin/middleman
@@ -46,6 +46,9 @@ rescue LoadError
   end
 end
 
+# Automatically discover extensions in RubyGems
+Middleman.load_extensions_in_path
+
 # Change directory to the root
 Dir.chdir(ENV["MM_ROOT"] || Dir.pwd) do
   

--- a/middleman-core/lib/middleman-core.rb
+++ b/middleman-core/lib/middleman-core.rb
@@ -196,12 +196,16 @@ module Middleman
     #
     # @private
     def load_extensions_in_path
-      extensions = rubygems_latest_specs.select do |spec|
-        spec_has_file?(spec, EXTENSION_FILE)
-      end
+      if defined?(Bundler)
+        Bundler.require
+      else
+        extensions = rubygems_latest_specs.select do |spec|
+          spec_has_file?(spec, EXTENSION_FILE)
+        end
 
-      extensions.each do |spec|
-        require spec.name
+        extensions.each do |spec|
+          require spec.name
+        end
       end
     end
 

--- a/middleman/lib/middleman.rb
+++ b/middleman/lib/middleman.rb
@@ -3,6 +3,3 @@ require "middleman-more"
 
 # Make the VERSION string available
 require "middleman-core/version"
-
-# Automatically discover extensions in RubyGems
-Middleman.load_extensions_in_path


### PR DESCRIPTION
Also, use Bundler.require when available rather than scanning gems for extensions ourselves.
