### PR TITLE
Include middleman-core's template path in the list of source_paths

### DIFF
--- a/middleman-core/lib/middleman-core/templates.rb
+++ b/middleman-core/lib/middleman-core/templates.rb
@@ -29,20 +29,16 @@ module Middleman::Templates
   class Base < ::Thor::Group
     include Thor::Actions
     
+    def initialize(names, options)
+      super
+      source_paths << File.join(File.dirname(__FILE__), 'templates')
+    end
+
     # Required path for the new project to be generated
     argument :location, :type => :string
     
     # Name of the template being used to generate the project.
     class_option :template, :default => "default"
-    
-    # What to call the directory which CSS will be searched for.
-    class_option :css_dir#, :default => "stylesheets"
-    
-    # What to call the directory which JS will be searched for.
-    class_option :js_dir#, :default => "javascripts"
-    
-    # What to call the directory which images will be searched for.
-    class_option :images_dir#, :default => "images"
     
     # Output a config.ru file for Rack if --rack is passed
     class_option :rack, :type => :boolean, :default => false


### PR DESCRIPTION
So that inherited templates in other gems can still use the Gemfile and config.ru from the main middleman gem. This actually fixes middleman/middleman-blog#20 though I plan on still making a custom Gemfile for the blog extension.

Also, default to setting up new projects with Bundler. I've seen a number of issues and support requests that could have been avoided if people were using a Gemfile.
