### PR TITLE
Fix watcher to be more selective about what it ignores

### DIFF
--- a/middleman-core/features/builder.feature
+++ b/middleman-core/features/builder.feature
@@ -14,6 +14,7 @@ Feature: Builder
       | images/Read me (example).txt                  |
       | images/Child folder/regular_file(example).txt |
       | .htaccess                                     |
+      | feed.xml                                      |
     Then the following files should not exist:
       | _partial                                      |
       | layout                                        |

--- a/middleman-core/fixtures/large-build-app/source/feed.xml.builder
+++ b/middleman-core/fixtures/large-build-app/source/feed.xml.builder
@@ -1,0 +1,4 @@
+xml.instruct!
+xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
+  xml.title "Not a feed, really"
+end

--- a/middleman-core/lib/middleman-core/watcher.rb
+++ b/middleman-core/lib/middleman-core/watcher.rb
@@ -17,12 +17,13 @@ module Middleman
       
       def ignore_list
         [
-          /\.sass-cache/,
+          /\.sass-cache\//,
           /\.git/,
-          /\.DS_Store/,
-          /build/,
-          /\.rbenv-version/,
-          /Gemfile/,
+          /\.DS_Store$/,
+          /build\//,
+          /\.rbenv-version$/,
+          /Gemfile$/,
+          /Gemfile\.lock$/,
           /\.mm-pid/
         ]
       end


### PR DESCRIPTION
Some rather broad path regexes in `Watcher` were causing files like `feed.xml.builder` to be ignored because they contain the text "build".
