### PR TITLE
Fix ignore with a regex

### DIFF
--- a/middleman-core/features/ignore.feature
+++ b/middleman-core/features/ignore.feature
@@ -33,6 +33,26 @@ Feature: Ignoring paths
       | build/reports/another.html |
       | build/images/icons/messages.png |
 
+  Scenario: Ignore a regex
+    Given a fixture app "ignore-app"
+    And a file named "config.rb" with:
+      """
+      ignore /^.*\.erb/
+      ignore /^reports\/.*/
+      ignore /^images\.*\.png/
+      """
+    And a successfully built app at "ignore-app"
+    Then the following files should exist:
+      | build/plain.html |
+      | build/images/portrait.jpg |
+      | build/images/pic.png |
+    And the following files should not exist:
+      | build/about.html |
+      | build/index.html |
+      | build/reports/index.html |
+      | build/reports/another.html |
+      | build/images/icons/messages.png |
+
   Scenario: Ignore with directory indexes (source file)
     Given a fixture app "ignore-app"
     And a file named "config.rb" with:


### PR DESCRIPTION
Turns out we never had a test for using `ignore` with a regex.

This change also consolidates ignores into a single list of callbacks instead of having a bunch of different lists that had to be looked through to figure out if something should be ignored.
