### PR TITLE
Make frontmatter always return a hash, and freeze it

### DIFF
--- a/middleman-core/lib/middleman-core/core_extensions/front_matter.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/front_matter.rb
@@ -139,7 +139,7 @@ module Middleman::CoreExtensions::FrontMatter
         
       if result
         data, content = result
-        data = ::Middleman.recursively_enhance(data)
+        data = ::Middleman.recursively_enhance(data).freeze
         file = file.sub(@app.source_dir, "")
         @local_data[file] = [data, content]
         path = File.join(@app.source_dir, file)
@@ -164,12 +164,12 @@ module Middleman::CoreExtensions::FrontMatter
     
     # Get the frontmatter for a given path
     # @param [String] path
-    # @return [Hash, nil]
+    # @return [Hash]
     def data(path)
       if @local_data.has_key?(path.to_s)
         @local_data[path.to_s]
       else
-        nil
+        {}.freeze
       end
     end
     

--- a/middleman-core/lib/middleman-core/sitemap/page.rb
+++ b/middleman-core/lib/middleman-core/sitemap/page.rb
@@ -204,10 +204,9 @@ module Middleman::Sitemap
     end
     
     # This page's frontmatter
-    # @return [Hash, nil]
+    # @return [Hash]
     def data
-      data, content = app.frontmatter(relative_path)
-      data || nil
+      app.frontmatter(relative_path).first
     end
     
     # This page's parent page
@@ -216,7 +215,6 @@ module Middleman::Sitemap
       parts = path.split("/")
       if path.include?(app.index_file)
         parts.pop
-      else
       end
       
       return nil if parts.length < 1


### PR DESCRIPTION
This reduces the need for nil checks and prevents users from accidentally trying to modify frontmatter data which may be cached elsewhere.
