### PR TITLE
Introduce a cache tied to individual sitemap pages

### DIFF
--- a/middleman-core/lib/middleman-core/sitemap/page.rb
+++ b/middleman-core/lib/middleman-core/sitemap/page.rb
@@ -113,18 +113,6 @@ module Middleman::Sitemap
       store.ignore(self.path)
     end
     
-    # If this is a template, refresh contents
-    # @return [void]
-    def touch
-      template.touch if template?
-    end
-    
-    # If this is a template, remove contents
-    # @return [void]
-    def delete
-      template.delete if template?
-    end
-    
     # Render this page
     # @return [String]
     def render(*args, &block)
@@ -249,6 +237,26 @@ module Middleman::Sitemap
     def siblings
       return [] unless parent
       parent.children.reject { |p| p == self }
+    end
+
+    # A cache for extensions and internals to use to store
+    # information about this page. The cache is cleared whenever
+    # the page changes.
+    # @return [Middleman::Cache]
+    def cache
+      @cache ||= Middleman::Cache.new
+    end
+
+    # Clear out the cache whenever this page changes
+    # @return [void]
+    def touch
+      cache.clear
+    end
+    
+    # Clear the cache if the file is deleted
+    # @return [void]
+    def delete
+      cache.clear
     end
     
   protected

--- a/middleman-core/lib/middleman-core/sitemap/template.rb
+++ b/middleman-core/lib/middleman-core/sitemap/template.rb
@@ -31,22 +31,10 @@ module Middleman::Sitemap
     # Simple aliases
     delegate :path, :source_file, :store, :app, :ext, :to => :page
     
-    # Clear internal frontmatter cache for file if it changes
-    # @return [void]
-    def touch
-      app.cache.remove(:metadata, source_file)
-    end
-    
-    # Clear internal frontmatter cache for file if it is deleted
-    # @return [void]
-    def delete
-      app.cache.remove(:metadata, source_file)
-    end
-    
     # Get the metadata for both the current source_file and the current path
     # @return [Hash]
     def metadata
-      metadata = app.cache.fetch(:metadata, source_file) do
+      metadata = @page.cache.fetch(:metadata) do
         data = { :options => {}, :locals => {}, :page => {}, :blocks => [] }
         
         app.provides_metadata.each do |callback, matcher|

--- a/middleman-more/lib/middleman-more/extensions/asset_hash.rb
+++ b/middleman-more/lib/middleman-more/extensions/asset_hash.rb
@@ -8,7 +8,7 @@ module Middleman::Extensions
         app.after_configuration do
           sitemap.reroute do |destination, page|
             if exts.include? page.ext
-              app.cache.fetch(:asset_hash, page.path) do
+              page.cache.fetch(:asset_hash) do
                 digest    = Digest::SHA1.file(page.source_file).hexdigest[0..7]
                 destination.sub(/\.(\w+)$/) { |ext| "-#{digest}#{ext}" }
               end


### PR DESCRIPTION
This helps individual extensions avoid having to implement methods to clear the cache whenever a page changes. I had hoped to use this for frontmatter, but the way it stores its information (and how its population of `:raw_template` interacts with the renderer) turned out too be complicated - I'll leave that for another time.
