### PR TITLE
asset_hash considers output file contents for hash

### DIFF
--- a/middleman-core/lib/middleman-core/cli/build.rb
+++ b/middleman-core/lib/middleman-core/cli/build.rb
@@ -98,10 +98,10 @@ module Middleman::Cli
     # Render a page to a file.
     #
     # @param [Middleman::Sitemap::Page] page
-    # @return [void]
+    # @return [String] The full path of the file that was written
     def render_to_file(page)
       build_dir = self.class.shared_instance.build_dir
-      output_file = File.join(self.class.shared_instance.build_dir, page.destination_path)
+      output_file = File.join(build_dir, page.destination_path)
 
       begin
         response = self.class.shared_rack.get(page.request_path.gsub(/\s/, "%20"))
@@ -114,6 +114,8 @@ module Middleman::Cli
         say_status :error, output_file, :red
         raise Thor::Error.new $!
       end
+
+      output_file
     end
   end
   
@@ -219,9 +221,8 @@ module Middleman::Cli
         next if page.ignored?
         next if @config[:glob] && !File.fnmatch(@config[:glob], page.path)
 
-        base.render_to_file(page)
+        output_path = base.render_to_file(page)
 
-        output_path = File.join(@destination, page.destination_path)
         @cleaning_queue.delete(Pathname.new(output_path).realpath) if cleaning?
       end
     end

--- a/middleman-core/lib/middleman-core/sitemap/store.rb
+++ b/middleman-core/lib/middleman-core/sitemap/store.rb
@@ -94,7 +94,6 @@ module Middleman::Sitemap
     # @param [String] The destination (output) path of a page.
     # @return [Middleman::Sitemap::Page]
     def page_by_destination(destination_path)
-      # TODO: memoize this
       destination_path = normalize_path(destination_path)
       pages.find do |p|
         p.destination_path == destination_path ||

--- a/middleman-more/features/asset_hash.feature
+++ b/middleman-more/features/asset_hash.feature
@@ -7,8 +7,8 @@ Feature: Assets get a file hash appended to their and references to them are upd
       | images/100px-1242c368.png |
       | images/100px-5fd6fb90.jpg |
       | images/100px-5fd6fb90.gif |
-      | javascripts/application-1d8d5276.js |
-      | stylesheets/site-8c28fde3.css |
+      | javascripts/application-570e5d45.js |
+      | stylesheets/site-d9d84711.css |
       | index.html |
       | subdir/index.html |
       | other/index.html |
@@ -19,48 +19,66 @@ Feature: Assets get a file hash appended to their and references to them are upd
       | javascripts/application.js |
       | stylesheets/site.css |
       
-    And the file "javascripts/application-1d8d5276.js" should contain "img.src = '/images/100px-5fd6fb90.jpg'"
-    And the file "stylesheets/site-8c28fde3.css" should contain "background-image: url('../images/100px-5fd6fb90.jpg')"
-    And the file "index.html" should contain 'href="stylesheets/site-8c28fde3.css"'
-    And the file "index.html" should contain 'src="javascripts/application-1d8d5276.js"'
+    And the file "javascripts/application-570e5d45.js" should contain "img.src = '/images/100px-5fd6fb90.jpg'"
+    And the file "stylesheets/site-d9d84711.css" should contain "background-image: url('../images/100px-5fd6fb90.jpg')"
+    And the file "index.html" should contain 'href="stylesheets/site-d9d84711.css"'
+    And the file "index.html" should contain 'src="javascripts/application-570e5d45.js"'
     And the file "index.html" should contain 'src="images/100px-5fd6fb90.jpg"'
-    And the file "subdir/index.html" should contain 'href="../stylesheets/site-8c28fde3.css"'
-    And the file "subdir/index.html" should contain 'src="../javascripts/application-1d8d5276.js"'
+    And the file "subdir/index.html" should contain 'href="../stylesheets/site-d9d84711.css"'
+    And the file "subdir/index.html" should contain 'src="../javascripts/application-570e5d45.js"'
     And the file "subdir/index.html" should contain 'src="../images/100px-5fd6fb90.jpg"'
-    And the file "other/index.html" should contain 'href="../stylesheets/site-8c28fde3.css"'
-    And the file "other/index.html" should contain 'src="../javascripts/application-1d8d5276.js"'
+    And the file "other/index.html" should contain 'href="../stylesheets/site-d9d84711.css"'
+    And the file "other/index.html" should contain 'src="../javascripts/application-570e5d45.js"'
     And the file "other/index.html" should contain 'src="../images/100px-5fd6fb90.jpg"'
     
   Scenario: Hashed assets work in preview server
     Given the Server is running at "asset-hash-app"
     When I go to "/"
-    Then I should see 'href="stylesheets/site-8c28fde3.css"'
-    And I should see 'src="javascripts/application-1d8d5276.js"'
+    Then I should see 'href="stylesheets/site-d9d84711.css"'
+    And I should see 'src="javascripts/application-570e5d45.js"'
     And I should see 'src="images/100px-5fd6fb90.jpg"'
     When I go to "/subdir/"
-    Then I should see 'href="../stylesheets/site-8c28fde3.css"'
-    And I should see 'src="../javascripts/application-1d8d5276.js"'
+    Then I should see 'href="../stylesheets/site-d9d84711.css"'
+    And I should see 'src="../javascripts/application-570e5d45.js"'
     And I should see 'src="../images/100px-5fd6fb90.jpg"'
     When I go to "/other/"
-    Then I should see 'href="../stylesheets/site-8c28fde3.css"'
-    And I should see 'src="../javascripts/application-1d8d5276.js"'
+    Then I should see 'href="../stylesheets/site-d9d84711.css"'
+    And I should see 'src="../javascripts/application-570e5d45.js"'
     And I should see 'src="../images/100px-5fd6fb90.jpg"'
-    When I go to "/javascripts/application-1d8d5276.js"
+    When I go to "/javascripts/application-570e5d45.js"
     Then I should see "img.src = '/images/100px-5fd6fb90.jpg'"
-    When I go to "/stylesheets/site-8c28fde3.css"
+    When I go to "/stylesheets/site-d9d84711.css"
     Then I should see "background-image: url('../images/100px-5fd6fb90.jpg')"
 
   Scenario: Enabling an asset host still produces hashed files and references  
     Given the Server is running at "asset-hash-host-app"
     When I go to "/"
-    Then I should see 'href="http://middlemanapp.com/stylesheets/site-8c28fde3.css"'
+    Then I should see 'href="http://middlemanapp.com/stylesheets/site-0ac82771.css"'
     And I should see 'src="http://middlemanapp.com/images/100px-5fd6fb90.jpg"'
     When I go to "/subdir/"
-    Then I should see 'href="http://middlemanapp.com/stylesheets/site-8c28fde3.css"'
+    Then I should see 'href="http://middlemanapp.com/stylesheets/site-0ac82771.css"'
     And I should see 'src="http://middlemanapp.com/images/100px-5fd6fb90.jpg"'
     When I go to "/other/"
-    Then I should see 'href="http://middlemanapp.com/stylesheets/site-8c28fde3.css"'
+    Then I should see 'href="http://middlemanapp.com/stylesheets/site-0ac82771.css"'
     And I should see 'src="http://middlemanapp.com/images/100px-5fd6fb90.jpg"'
     # Asset helpers don't appear to work from Compass right now
-    # When I go to "/stylesheets/site-8c28fde3.css"
+    # When I go to "/stylesheets/site-0ac82771.css"
     # Then I should see "background-image: url('http://middlemanapp.com/images/100px-5fd6fb90.jpg')"
+
+  Scenario: The asset hash should change when a SASS or Sprockets partial changes
+    Given the Server is running at "asset-hash-app"
+    And the file "source/stylesheets/_partial.sass" has the contents
+      """
+      body
+        font-size: 14px
+      """
+    When I go to "/partials/"
+    Then I should see 'href="../stylesheets/uses_partials-e81dd9b4.css'
+    And the file "source/stylesheets/_partial.sass" has the contents
+      """
+      body
+        font-size: 18px !important
+      """
+    When I go to "/partials/"
+    Then I should see 'href="../stylesheets/uses_partials-ba3ef309.css'
+    

--- a/middleman-more/fixtures/asset-hash-app/source/partials.html.erb
+++ b/middleman-more/fixtures/asset-hash-app/source/partials.html.erb
@@ -1,0 +1,1 @@
+<%= stylesheet_link_tag 'uses_partials' %>

--- a/middleman-more/fixtures/asset-hash-app/source/stylesheets/_partial.sass
+++ b/middleman-more/fixtures/asset-hash-app/source/stylesheets/_partial.sass
@@ -1,0 +1,2 @@
+body
+  font-size: 18px

--- a/middleman-more/fixtures/asset-hash-app/source/stylesheets/uses_partials.css.sass
+++ b/middleman-more/fixtures/asset-hash-app/source/stylesheets/uses_partials.css.sass
@@ -1,0 +1,4 @@
+@import partial.sass
+
+red
+  color: blue


### PR DESCRIPTION
Fix the `asset_hash` extension to operate on the hash of the rendered output rather than just the source file. This prevents generating the same hash for a file when partials it uses change, or if a helper it uses produces different output. As part of this change I removed the caching from `Sitemap::Page#destination_path` and asset_hash since they were preventing recalculation of path/hash when partials changed, and I rewrote the Sprockets extension to expose the Sprockets environment to other extensions, which included consolidating the JS and CSS Sprockets environments into one.

This took a few dead ends and a lot of reading through the Rails and Sprockets source code, but I'm glad we didn't release `asset_hash`, even in a beta, without it. This fixes issue #337.
