### PR TITLE
Provide a stack trace for build errors

### DIFF
--- a/middleman-core/lib/middleman-core/cli/build.rb
+++ b/middleman-core/lib/middleman-core/cli/build.rb
@@ -110,9 +110,9 @@ module Middleman::Cli
         else
           raise Thor::Error.new response.body
         end
-      rescue
+      rescue => e
         say_status :error, output_file, :red
-        raise Thor::Error.new $!
+        raise Thor::Error.new "#{e}\n#{e.backtrace.join("\n")}"
       end
     end
   end


### PR DESCRIPTION
Makes it a lot easier to figure out what's going on.
