### PR TITLE
Simplify watcher using newer listen features

### DIFF
--- a/middleman-core/lib/middleman-core/application.rb
+++ b/middleman-core/lib/middleman-core/application.rb
@@ -523,7 +523,7 @@ module Middleman
     #
     # @return [Class]
     def server(&block)
-      @@servercounter ||= 1
+      @@servercounter ||= 0
       @@servercounter += 1
       const_set("MiddlemanApplication#{@@servercounter}", Class.new(Middleman::Application))
     end

--- a/middleman-core/lib/middleman-core/watcher.rb
+++ b/middleman-core/lib/middleman-core/watcher.rb
@@ -1,12 +1,6 @@
 # File changes are forwarded to the currently running app via HTTP
 require "net/http"
 
-module Middleman
-  WINDOWS = !!(RUBY_PLATFORM =~ /(mingw|bccwin|wince|mswin32)/i) unless const_defined?(:WINDOWS)
-end
-
-require "win32/process" if ::Middleman::WINDOWS
-
 require "fileutils"
 
 module Middleman
@@ -17,6 +11,7 @@ module Middleman
       def start(options)
         self.singleton = new(options)
         self.singleton.watch! unless options[:"disable-watcher"]
+        self.singleton.start
       end
       
       def ignore_list
@@ -35,15 +30,7 @@ module Middleman
     
     def initialize(options)
       @options = options
-      
       register_signal_handlers
-      start
-    end
-    
-    # What command is sent to kill instances
-    # @return [Symbol, Fixnum]
-    def kill_command
-      ::Middleman::WINDOWS ? 1 : "TERM"
     end
     
     def watch!
@@ -52,7 +39,8 @@ module Middleman
       # Watcher Library
       require "listen"
       
-      Listen.to(Dir.pwd, :relative_paths => true) do |modified, added, removed|
+      listener = Listen.to(Dir.pwd, :relative_paths => true)
+      listener.change do |modified, added, removed|
         added_and_modified = modified + added
 
         if added_and_modified.length > 0
@@ -63,46 +51,13 @@ module Middleman
           local.run_on_deletion(removed)
         end
       end
-    end
-    
-    def pid_name
-      ".mm-pid-#{@options[:port]||4567}"
-    end
-    
-    def kill_pid!
-      if File.exists?(pid_name)
-        current_pid = File.open(pid_name, 'rb') { |f| f.read }
-        begin
-          Process.kill(kill_command, current_pid.to_i)
-        rescue
-        ensure
-          FileUtils.rm(pid_name) if File.exists?(pid_name)
-        end
-      end
-    end
-    
-    # Start Middleman in a fork
-    # @return [void]
-    def start
-      if @options[:"disable-watcher"]
-        bootup
-      else
-        kill_pid!
-        
-        @server_job = fork {
-          # trap("INT")  { exit(0) }
-          # trap("TERM") { exit(0) }
-          # trap("QUIT") { exit(0) }
-          bootup
-        }
-        
-        File.open(pid_name, "w+") { |f| f.write(@server_job) }
-      end
+      # Don't block this thread
+      listener.start(false)
     end
     
     # Start an instance of Middleman::Application
     # @return [void]
-    def bootup
+    def start
       env = (@options[:environment] || "development").to_sym
       is_logging = @options.has_key?(:debug) && @options[:debug]
       
@@ -124,12 +79,8 @@ module Middleman
     # @return [void]
     def stop
       puts "== The Middleman is shutting down"
-      if !@options[:"disable-watcher"]
-        kill_pid!
-        # Process.kill(::Middleman::WINDOWS ? :KILL : :TERM, @server_job)
-        # Process.wait @server_job
-        # @server_job = nil
-      end
+      # TODO: Figure out some way to actually unload the whole thing
+      #       or maybe just re-exec this same thing
     end
     
     # Simply stop, then start
@@ -172,7 +123,7 @@ module Middleman
       trap("TERM") { stop }
       trap("QUIT") { stop; exit(0) }
     end
-  
+
     # Whether the passed files are config.rb, lib/*.rb or helpers
     # @param [Array<String>] paths Array of paths to check
     # @return [Boolean] Whether the server needs to reload


### PR DESCRIPTION
I noticed we were working around two things that `listen` supports directly. One was the relative-path-izing stuff, which can be done by just passing `:relative_paths => true` to `Listen.to`. The other is to run the watcher in non-blocking mode, which I think means we don't need to do that whole fork/pidfile dance. I've run it this way and things still work - Ctrl-C kills the server, file updates are noticed, the preview server works fine.

This should fix #224 since we no longer fork.
