### PR TITLE
Append to I18n.load_path instead of replacing it

### DIFF
--- a/middleman-core/lib/middleman-core/core_extensions/i18n.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/i18n.rb
@@ -12,7 +12,7 @@ module Middleman::CoreExtensions::I18n
       
       # Needed for helpers as well
       app.after_configuration do
-        ::I18n.load_path = [Dir[File.join(root, locales_dir, "*.yml")]]
+        ::I18n.load_path += [Dir[File.join(root, locales_dir, "*.yml")]]
         ::I18n.reload!
       end
     end


### PR DESCRIPTION
This was causing ActiveSupport stuff to fail like `to_sentence`.
