### PR TITLE
Properly handle pages with no frontmatter

### DIFF
--- a/middleman-core/lib/middleman-core/core_extensions/front_matter.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/front_matter.rb
@@ -184,7 +184,7 @@ module Middleman::CoreExtensions::FrontMatter
       if @local_data.has_key?(path.to_s)
         @local_data[path.to_s]
       else
-        {}.freeze
+        [ ::Middleman::Util.recursively_enhance({}).freeze, nil ]
       end
     end
     


### PR DESCRIPTION
This way, even if there's no frontmatter you can do `current_page.data.whatever` and get nil instead of an error. It's what I had intended in the first place, but I guess I screwed it up :-(
