### PR TITLE
Prevent Sprockets from generating different hashes based on Sprockets version number

### DIFF
--- a/middleman-more/features/asset_hash.feature
+++ b/middleman-more/features/asset_hash.feature
@@ -7,8 +7,8 @@ Feature: Assets get a file hash appended to their and references to them are upd
       | images/100px-1242c368.png |
       | images/100px-5fd6fb90.jpg |
       | images/100px-5fd6fb90.gif |
-      | javascripts/application-570e5d45.js |
-      | stylesheets/site-d9d84711.css |
+      | javascripts/application-df677242.js |
+      | stylesheets/site-ed8c2d12.css |
       | index.html |
       | subdir/index.html |
       | other/index.html |
@@ -19,50 +19,50 @@ Feature: Assets get a file hash appended to their and references to them are upd
       | javascripts/application.js |
       | stylesheets/site.css |
       
-    And the file "javascripts/application-570e5d45.js" should contain "img.src = '/images/100px-5fd6fb90.jpg'"
-    And the file "stylesheets/site-d9d84711.css" should contain "background-image: url('../images/100px-5fd6fb90.jpg')"
-    And the file "index.html" should contain 'href="stylesheets/site-d9d84711.css"'
-    And the file "index.html" should contain 'src="javascripts/application-570e5d45.js"'
+    And the file "javascripts/application-df677242.js" should contain "img.src = '/images/100px-5fd6fb90.jpg'"
+    And the file "stylesheets/site-ed8c2d12.css" should contain "background-image: url('../images/100px-5fd6fb90.jpg')"
+    And the file "index.html" should contain 'href="stylesheets/site-ed8c2d12.css"'
+    And the file "index.html" should contain 'src="javascripts/application-df677242.js"'
     And the file "index.html" should contain 'src="images/100px-5fd6fb90.jpg"'
-    And the file "subdir/index.html" should contain 'href="../stylesheets/site-d9d84711.css"'
-    And the file "subdir/index.html" should contain 'src="../javascripts/application-570e5d45.js"'
+    And the file "subdir/index.html" should contain 'href="../stylesheets/site-ed8c2d12.css"'
+    And the file "subdir/index.html" should contain 'src="../javascripts/application-df677242.js"'
     And the file "subdir/index.html" should contain 'src="../images/100px-5fd6fb90.jpg"'
-    And the file "other/index.html" should contain 'href="../stylesheets/site-d9d84711.css"'
-    And the file "other/index.html" should contain 'src="../javascripts/application-570e5d45.js"'
+    And the file "other/index.html" should contain 'href="../stylesheets/site-ed8c2d12.css"'
+    And the file "other/index.html" should contain 'src="../javascripts/application-df677242.js"'
     And the file "other/index.html" should contain 'src="../images/100px-5fd6fb90.jpg"'
     
   Scenario: Hashed assets work in preview server
     Given the Server is running at "asset-hash-app"
     When I go to "/"
-    Then I should see 'href="stylesheets/site-d9d84711.css"'
-    And I should see 'src="javascripts/application-570e5d45.js"'
+    Then I should see 'href="stylesheets/site-ed8c2d12.css"'
+    And I should see 'src="javascripts/application-df677242.js"'
     And I should see 'src="images/100px-5fd6fb90.jpg"'
     When I go to "/subdir/"
-    Then I should see 'href="../stylesheets/site-d9d84711.css"'
-    And I should see 'src="../javascripts/application-570e5d45.js"'
+    Then I should see 'href="../stylesheets/site-ed8c2d12.css"'
+    And I should see 'src="../javascripts/application-df677242.js"'
     And I should see 'src="../images/100px-5fd6fb90.jpg"'
     When I go to "/other/"
-    Then I should see 'href="../stylesheets/site-d9d84711.css"'
-    And I should see 'src="../javascripts/application-570e5d45.js"'
+    Then I should see 'href="../stylesheets/site-ed8c2d12.css"'
+    And I should see 'src="../javascripts/application-df677242.js"'
     And I should see 'src="../images/100px-5fd6fb90.jpg"'
-    When I go to "/javascripts/application-570e5d45.js"
+    When I go to "/javascripts/application-df677242.js"
     Then I should see "img.src = '/images/100px-5fd6fb90.jpg'"
-    When I go to "/stylesheets/site-d9d84711.css"
+    When I go to "/stylesheets/site-ed8c2d12.css"
     Then I should see "background-image: url('../images/100px-5fd6fb90.jpg')"
 
   Scenario: Enabling an asset host still produces hashed files and references  
     Given the Server is running at "asset-hash-host-app"
     When I go to "/"
-    Then I should see 'href="http://middlemanapp.com/stylesheets/site-0ac82771.css"'
+    Then I should see 'href="http://middlemanapp.com/stylesheets/site-e5a31a3e.css"'
     And I should see 'src="http://middlemanapp.com/images/100px-5fd6fb90.jpg"'
     When I go to "/subdir/"
-    Then I should see 'href="http://middlemanapp.com/stylesheets/site-0ac82771.css"'
+    Then I should see 'href="http://middlemanapp.com/stylesheets/site-e5a31a3e.css"'
     And I should see 'src="http://middlemanapp.com/images/100px-5fd6fb90.jpg"'
     When I go to "/other/"
-    Then I should see 'href="http://middlemanapp.com/stylesheets/site-0ac82771.css"'
+    Then I should see 'href="http://middlemanapp.com/stylesheets/site-e5a31a3e.css"'
     And I should see 'src="http://middlemanapp.com/images/100px-5fd6fb90.jpg"'
     # Asset helpers don't appear to work from Compass right now
-    # When I go to "/stylesheets/site-0ac82771.css"
+    # When I go to "/stylesheets/site-e5a31a3e.css"
     # Then I should see "background-image: url('http://middlemanapp.com/images/100px-5fd6fb90.jpg')"
 
   Scenario: The asset hash should change when a SASS or Sprockets partial changes
@@ -73,12 +73,12 @@ Feature: Assets get a file hash appended to their and references to them are upd
         font-size: 14px
       """
     When I go to "/partials/"
-    Then I should see 'href="../stylesheets/uses_partials-e81dd9b4.css'
+    Then I should see 'href="../stylesheets/uses_partials-8b948098.css'
     And the file "source/stylesheets/_partial.sass" has the contents
       """
       body
         font-size: 18px !important
       """
     When I go to "/partials/"
-    Then I should see 'href="../stylesheets/uses_partials-ba3ef309.css'
+    Then I should see 'href="../stylesheets/uses_partials-1f9f0ed2.css'
     

--- a/middleman-more/lib/middleman-more/core_extensions/sprockets.rb
+++ b/middleman-more/lib/middleman-more/core_extensions/sprockets.rb
@@ -52,8 +52,6 @@ module Middleman::CoreExtensions::Sprockets
       @app = app
       super app.source_dir
 
-      digest = Digest::SHA1
-
       # Make the app context available to Sprockets
       context_class.send(:define_method, :app) { app }
       context_class.class_eval do
@@ -73,6 +71,16 @@ module Middleman::CoreExtensions::Sprockets
       # configure search paths
       append_path app.js_dir
       append_path app.css_dir
+    end
+
+    # Override Sprockets' default digest function to *not*
+    # change depending on the exact Sprockets version. It still takes
+    # into account "version" which is a user-suppliable version
+    # number that can be used to force assets to have a new
+    # hash.
+    def digest
+      @digest ||= Digest::SHA1.new.update(version.to_s)
+      @digest.dup
     end
 
     # During development, don't use the asset cache


### PR DESCRIPTION
This should fix our tests which started failing when Sprockets 2.4.1 got released.
