### PR TITLE
link_to is page-aware

### DIFF
--- a/middleman-core/features/directory_index.feature
+++ b/middleman-core/features/directory_index.feature
@@ -36,3 +36,20 @@ Feature: Directory Index
     Given the Server is running at "indexable-app"
     When I go to "/leave_me_alone/"
     Then I should see "File Not Found"
+
+  Scenario: Link_to knows about directory indexes
+    Given a fixture app "indexable-app"
+    And a file named "source/link_to.html.erb" with:
+    """
+    link_to: <%= link_to "Needs Index", "/needs_index.html" %>
+    explicit_link_to: <%= link_to "Explicit", "/needs_index/index.html" %>
+    unknown_link_to: <%= link_to "Unknown", "/unknown.html" %>
+    relative_link_to: <%= link_to "Relative", "needs_index.html" %>
+    """
+    And the Server is running at "indexable-app"
+    When I go to "/link_to/"
+    Then I should see 'link_to: <a href="/needs_index/">Needs Index</a>'
+    Then I should see 'explicit_link_to: <a href="/needs_index/index.html">Explicit</a>'
+    Then I should see 'unknown_link_to: <a href="/unknown.html">Unknown</a>'
+    # Relative links aren't touched
+    Then I should see 'relative_link_to: <a href="needs_index.html">Relative</a>'

--- a/middleman-core/lib/middleman-core/core_extensions/default_helpers.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/default_helpers.rb
@@ -88,19 +88,31 @@ module Middleman::CoreExtensions::DefaultHelpers
     # @param [String] source The path to the file
     # @return [String]
     def asset_path(kind, source)
-       return source if source =~ /^http/
-       asset_folder  = case kind
-         when :css    then css_dir
-         when :js     then js_dir
-         when :images then images_dir
-         else kind.to_s
-       end
-       source = source.to_s.gsub(/\s/, '')
-       ignore_extension = (kind == :images) # don't append extension
-       source << ".#{kind}" unless ignore_extension or source =~ /\.#{kind}/
-       result_path   = source if source =~ %r{^/} # absolute path
-       result_path ||= asset_url(source, asset_folder)
-       "#{result_path}"
-     end
+      return source if source =~ /^http/
+      asset_folder  = case kind
+        when :css    then css_dir
+        when :js     then js_dir
+        when :images then images_dir
+        else kind.to_s
+      end
+      source = source.to_s.gsub(/\s/, '')
+      ignore_extension = (kind == :images) # don't append extension
+      source << ".#{kind}" unless ignore_extension or source =~ /\.#{kind}/
+      result_path   = source if source =~ %r{^/} # absolute path
+      result_path ||= asset_url(source, asset_folder)
+      "#{result_path}"
+    end
+
+    def link_to(*args, &block)
+      url_arg_index = block_given? ? 0 : 1
+      if url = args[url_arg_index]
+        # Only try to work with absolute URLs
+        if url.start_with? '/'
+          resource = sitemap.find_resource_by_path(url)
+          args[url_arg_index] = resource.url if resource
+        end
+      end
+      super(*args, &block)
+    end
   end
 end


### PR DESCRIPTION
`link_to` with an absolute path that corresponds to a page path will get rewritten to the page's output URL

This is meant as a fix for #388.

I avoided relative URLs explicitly because they can be tricky.
