### PR TITLE
Synchronize gzipped file mtimes with their source file's mtime

### DIFF
--- a/middleman-more/lib/middleman-more/extensions/gzip.rb
+++ b/middleman-more/lib/middleman-more/extensions/gzip.rb
@@ -39,11 +39,25 @@ module Middleman::Extensions
       def gzip_file(path, builder)
         input_file = File.open(path, 'r').read
         output_filename = path + '.gz'
+        input_file_time = File.mtime(path)
+
+        # Check if the right file's already there
+        if File.exist?(output_filename) && File.mtime(output_filename) == input_file_time
+          return
+        end
+
         File.open(output_filename, 'w') do |f|
           gz = Zlib::GzipWriter.new(f, Zlib::BEST_COMPRESSION)
+          gz.mtime = input_file_time.to_i
           gz.write input_file
           gz.close
         end
+
+        # Make the file times match, both for Nginx's gzip_static extension
+        # and so we can ID existing files. Also, so even if the GZ files are
+        # wiped out by build --clean and recreated, we won't rsync them over
+        # again because they'll end up with the same mtime.
+        File.utime(File.atime(output_filename), input_file_time, output_filename)
 
         old_size = File.size(path)
         new_size = File.size(output_filename)


### PR DESCRIPTION
This addresses #380. It also skips re-gzipping when the right file is already there. By setting the mtime of the gzipped file to be the same as the original file (and setting the same mtime in the gzip header too) we maximize compatibility with Nginx's `gzip_static` extension, and we make sure unchanged gzip files don't need to be re-rsynced, even if (like me) you always use `build --clean` and end up having to re-generate your gzip files during build (since the gzip files aren't in the sitemap, so they get cleaned out).
