### PR TITLE
Don't install signal handlers on Windows

### DIFF
--- a/middleman-core/lib/middleman-core/watcher.rb
+++ b/middleman-core/lib/middleman-core/watcher.rb
@@ -1,7 +1,10 @@
 # File changes are forwarded to the currently running app via HTTP
 require "net/http"
-
 require "fileutils"
+
+module Middleman
+  WINDOWS = !!(RUBY_PLATFORM =~ /(mingw|bccwin|wince|mswin32)/i) unless const_defined?(:WINDOWS)
+end
 
 module Middleman
   class Watcher
@@ -31,7 +34,7 @@ module Middleman
     
     def initialize(options)
       @options = options
-      register_signal_handlers
+      register_signal_handlers unless ::Middleman::WINDOWS
     end
     
     def watch!


### PR DESCRIPTION
I'm not 100% sure these signal handlers are needed anywhere, but they certainly don't work on Windows. This helps Windows along, but it still doesn't work right (see #401).
