### PR TITLE
Add Resource#add_metadata for attaching metadata directly to a resource

### DIFF
--- a/middleman-core/lib/middleman-core/sitemap/store.rb
+++ b/middleman-core/lib/middleman-core/sitemap/store.rb
@@ -101,6 +101,12 @@ module Middleman::Sitemap
         next result if !matcher.nil? && !source_file.match(matcher)
         
         metadata = callback.call(source_file)
+
+        if metadata.has_key?(:blocks)
+          result[:blocks] << metadata[:blocks]
+          metadata.delete(:blocks)
+        end
+
         result.deep_merge(metadata)
       end
     end


### PR DESCRIPTION
This is for use in middleman/middleman-blog#45, to make attaching metadata to the tag and calendar pages much more efficient.
