### PR TITLE
Make Middleman somewhat more threadsafe and switch back to webrick

### DIFF
--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -36,9 +36,6 @@ Gem::Specification.new do |s|
   # Watcher
   s.add_dependency("listen", ["~> 0.4.1"])
   
-  # Web Server
-  s.add_dependency("thin", ["~> 1.3.1"])
-
   # i18n
   s.add_dependency("i18n", ["~> 0.6.0"])
 end

--- a/middleman-more/lib/middleman-more/extensions/relative_assets.rb
+++ b/middleman-more/lib/middleman-more/extensions/relative_assets.rb
@@ -42,7 +42,7 @@ module Middleman
           else
             path = File.join(prefix, path) if prefix.length > 0
             
-            request_path = @request_path.dup
+            request_path = current_path.dup
             request_path << index_file if path.match(%r{/$})
 
             parts = request_path.gsub(%r{^/}, '').split('/')


### PR DESCRIPTION
I switched to using thread locals instead of shared instance variables for state like the current path, request, and response. I also moved to a parameter-passing style for most of that stuff, making it more explicit what's used by what. The end result is that I no longer get the mixed-up-responses problem, and I can use Webrick again, letting us drop our Thin dependency entirely.
