### PR TITLE
Switch back to maruku

### DIFF
--- a/middleman-more/features/markdown.feature
+++ b/middleman-more/features/markdown.feature
@@ -9,19 +9,23 @@ Feature: Markdown support
   Scenario: Redcarpet 2 extensions
     Given the Server is running at "markdown-app"
     When I go to "/smarty_pants.html"
-    Then I should see "&ldquo;"
+    Then I should see "&#8220;"
     When I go to "/no_intra_emphasis.html"
     Then I should not see "<em>"
     When I go to "/tables.html"
     Then I should see "<table>"
-    When I go to "/fenced_code_blocks.html"
-    Then I should see "<code>"
-    When I go to "/autolink.html"
-    Then I should see "<a href"
-    When I go to "/strikethrough.html"
-    Then I should see "<del>"
+    # Maruku doesn't support fenced code blocks :-(
+    #When I go to "/fenced_code_blocks.html"
+    #Then I should see "<code>"
+    # or autolink
+    #When I go to "/autolink.html"
+    #Then I should see "<a href"
+    # or del
+    #When I go to "/strikethrough.html"
+    #Then I should see "<del>"
     When I go to "/space_after_headers.html"
     Then I should not see "<h1>"
-    When I go to "/superscript.html"
-    Then I should see "<sup>"
+    # or superscript
+    #When I go to "/superscript.html"
+    #Then I should see "<sup>"
     

--- a/middleman-more/lib/middleman-more/renderers/markdown.rb
+++ b/middleman-more/lib/middleman-more/renderers/markdown.rb
@@ -11,7 +11,7 @@ module Middleman
         def registered(app)
           # Set our preference for a markdown engine
           # TODO: Find a JRuby-compatible version
-          app.set :markdown_engine, :redcarpet
+          app.set :markdown_engine, :maruku
           app.set :markdown_engine_prefix, ::Tilt
       
           app.before_configuration do

--- a/middleman-more/middleman-more.gemspec
+++ b/middleman-more/middleman-more.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |s|
   s.add_dependency("execjs", ["~> 1.2"])
   s.add_dependency("sprockets", ["~> 2.1"])
   s.add_dependency("sprockets-sass", ["~> 0.8.0"])
-  s.add_dependency("redcarpet", ["~> 2.1.0"])
+  s.add_dependency("maruku", ["~> 0.6.0"])
 end
 


### PR DESCRIPTION
Switch back to maruku from Redcarpet :'-(

Tests pass, mod the markdown one that I had to change since Maruku doesn't support all the features. Middleman-blog tests pass too.

I guess it all comes down to how much you want this to work with JRuby.
