### PR TITLE
Remove duplicate server methods and solve webrick logging in a platform-independent way

### DIFF
--- a/middleman-core/lib/middleman-core/application.rb
+++ b/middleman-core/lib/middleman-core/application.rb
@@ -262,41 +262,4 @@ module Middleman
     end
   
   end
-  
-  class << self
-    # Create a new Class which is based on Middleman::Application
-    # Used to create a safe sandbox into which extensions and
-    # configuration can be included later without impacting
-    # other classes and instances.
-    #
-    # @return [Class]
-    def server(&block)
-      @@servercounter ||= 0
-      @@servercounter += 1
-      const_set("MiddlemanApplication#{@@servercounter}", Class.new(Middleman::Application))
-    end
-
-    # Creates a new Rack::Server
-    #
-    # @param [Hash] options to pass to Rack::Server.new
-    # @return [Rack::Server]
-    def start_server(options={})
-      opts = {
-        :Port      => options[:port] || 4567,
-        :Host      => options[:host] || "0.0.0.0",
-        :AccessLog => []
-      }
-
-      app_class = options[:app] ||= ::Middleman.server.inst
-      opts[:app] = app_class
-
-      require "webrick"
-      opts[:Logger] = WEBrick::Log::new("/dev/null", 7) if !options[:logging]
-      opts[:server] = 'webrick'
-
-      server = ::Rack::Server.new(opts)
-      server.start
-      server
-    end
-  end
 end

--- a/middleman-core/lib/middleman-core/cli/build.rb
+++ b/middleman-core/lib/middleman-core/cli/build.rb
@@ -61,7 +61,7 @@ module Middleman::Cli
       #
       # @return [Middleman::Application]
       def shared_instance(verbose=false)
-        @_shared_instance ||= ::Middleman.server.inst do
+        @_shared_instance ||= ::Middleman::Application.server.inst do
           set :environment, :build
           set :logging,     verbose
         end

--- a/middleman-core/lib/middleman-core/core_extensions/request.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/request.rb
@@ -149,7 +149,7 @@ module Middleman
           opts[:app] = app_class
 
           require "webrick"
-          opts[:Logger] = WEBrick::Log::new(RUBY_PLATFORM =~ /(mingw|bccwin|wince|mswin32)/i ? 'NUL:' : '/dev/null', 7) if !options[:logging]
+          opts[:Logger] = WEBrick::Log::new(nil, 0) if !options[:logging]
           opts[:server] = 'webrick'
 
           server = ::Rack::Server.new(opts)

--- a/middleman-core/lib/middleman-core/step_definitions/server_steps.rb
+++ b/middleman-core/lib/middleman-core/step_definitions/server_steps.rb
@@ -47,7 +47,7 @@ Given /^the Server is running$/ do
     set :show_exceptions, false
   }
   
-  @server_inst = Middleman.server.inst do
+  @server_inst = Middleman::Application.server.inst do
     initialize_commands.each do |p|
       instance_exec(&p)
     end

--- a/middleman-core/lib/middleman-core/watcher.rb
+++ b/middleman-core/lib/middleman-core/watcher.rb
@@ -65,7 +65,7 @@ module Middleman
       env = (@options[:environment] || "development").to_sym
       is_logging = @options.has_key?(:debug) && @options[:debug]
       
-      app = ::Middleman.server.inst do
+      app = ::Middleman::Application.server.inst do
         set :environment, env
         set :logging, is_logging
       end
@@ -76,7 +76,7 @@ module Middleman
       opts[:app] = app_rack
       opts[:logging] = is_logging
       puts "== The Middleman is standing watch on port #{opts[:port]||4567}"
-      ::Middleman.start_server(opts)
+      ::Middleman::Application.start_server(opts)
     end
     
     # Stop the forked Middleman


### PR DESCRIPTION
I guess I could have just extended `Middleman` from the `Request` extension rather than moving the server methods in to `Middleman::Application` but they feel more at home there.

`WEBrick::Log::new(nil, 0)` basically says "log to STDERR, but at a log level above FATAL" so nothing ever gets logged.
