### PR TITLE
Frontmatter fixes

### DIFF
--- a/middleman-core/features/frontmatter_page_settings.feature
+++ b/middleman-core/features/frontmatter_page_settings.feature
@@ -25,3 +25,18 @@ Feature: Setting page settings through frontmatter
     Then I should see "File Not Found"
     When I go to "/no_index/index.html"
     Then I should see "File Not Found"
+
+  Scenario: Changing frontmatter in preview server
+    Given the Server is running at "frontmatter-settings-app"
+    When I go to "/ignored/index.html"
+    Then I should see "File Not Found"
+    And the file "source/ignored.html.erb" has the contents
+      """
+      ---
+      ignored: false
+      ---
+
+      This file is no longer ignored.
+      """
+    When I go to "/ignored/index.html"
+    Then I should see "This file is no longer ignored."

--- a/middleman-core/lib/middleman-core/application.rb
+++ b/middleman-core/lib/middleman-core/application.rb
@@ -140,6 +140,10 @@ module Middleman
     # Setup custom rendering
     register Middleman::CoreExtensions::Rendering
   
+    # Parse YAML from templates. Must be before sitemap so sitemap
+    # extensions see updated frontmatter!
+    register Middleman::CoreExtensions::FrontMatter
+
     # Sitemap
     register Middleman::Sitemap
   
@@ -157,9 +161,6 @@ module Middleman
   
     # i18n
     register Middleman::CoreExtensions::I18n
-  
-    # Parse YAML from templates
-    register Middleman::CoreExtensions::FrontMatter
   
     # Built-in Extensions
     

--- a/middleman-core/lib/middleman-core/core_extensions/front_matter.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/front_matter.rb
@@ -15,14 +15,16 @@ module Middleman::CoreExtensions
         # Parsing JSON frontmatter
         require "active_support/json"
       
-        app.after_configuration do
-          ::Middleman::Sitemap::Resource.send :include, ResourceInstanceMethods
-      
-          app.send :include, InstanceMethods
+        app.send :include, InstanceMethods
         
+        app.before_configuration do
           files.changed { |file| frontmatter_manager.clear_data(file) }
           files.deleted { |file| frontmatter_manager.clear_data(file) }
-        
+        end
+
+        app.after_configuration do
+          ::Middleman::Sitemap::Resource.send :include, ResourceInstanceMethods
+
           sitemap.register_resource_list_manipulator(
             :frontmatter,
             frontmatter_manager
@@ -54,9 +56,15 @@ module Middleman::CoreExtensions
         @cache[p] ||= frontmatter_and_content(p)
       end
       
-      def clear_data(path)
-        p = normalize_path(File.expand_path(path, @app.root))
-        @cache.delete(p)
+      def clear_data(file)
+        # Copied from Sitemap::Store#file_to_path, but without
+        # removing the file extension
+        file = File.expand_path(file, @app.root)
+        prefix = @app.source_dir.sub(/\/$/, "") + "/"
+        return unless file.include?(prefix)
+        path = file.sub(prefix, "")
+
+        @cache.delete(path)
       end
       
       # Parse YAML frontmatter out of a string


### PR DESCRIPTION
- Return a `HashWithIndifferentAccess` from frontmatter even if there's no data
- Fix noticing changes of frontmatter when files change
- Fix ordering of frontmatter stuff such that `resource_list_manipulator`s can see updated frontmatter.
