### PR TITLE
Make link_to magical

### DIFF
--- a/middleman-core/features/directory_index.feature
+++ b/middleman-core/features/directory_index.feature
@@ -46,10 +46,21 @@ Feature: Directory Index
     unknown_link_to: <%= link_to "Unknown", "/unknown.html" %>
     relative_link_to: <%= link_to "Relative", "needs_index.html" %>
     """
+    And a file named "source/link_to/sub.html.erb" with:
+    """
+    link_to: <%= link_to "Needs Index", "/needs_index.html" %>
+    explicit_link_to: <%= link_to "Explicit", "/needs_index/index.html" %>
+    unknown_link_to: <%= link_to "Unknown", "/unknown.html" %>
+    relative_link_to: <%= link_to "Relative", "../needs_index.html" %>
+    """
     And the Server is running at "indexable-app"
     When I go to "/link_to/"
     Then I should see 'link_to: <a href="/needs_index/">Needs Index</a>'
     Then I should see 'explicit_link_to: <a href="/needs_index/index.html">Explicit</a>'
     Then I should see 'unknown_link_to: <a href="/unknown.html">Unknown</a>'
-    # Relative links aren't touched
-    Then I should see 'relative_link_to: <a href="needs_index.html">Relative</a>'
+    Then I should see 'relative_link_to: <a href="/needs_index/">Relative</a>'
+    When I go to "/link_to/sub/"
+    Then I should see 'link_to: <a href="/needs_index/">Needs Index</a>'
+    Then I should see 'explicit_link_to: <a href="/needs_index/index.html">Explicit</a>'
+    Then I should see 'unknown_link_to: <a href="/unknown.html">Unknown</a>'
+    Then I should see 'relative_link_to: <a href="/needs_index/">Relative</a>'

--- a/middleman-core/features/helpers_relative_link_to.feature
+++ b/middleman-core/features/helpers_relative_link_to.feature
@@ -1,0 +1,68 @@
+Feature: relative_link_to helper
+
+  Scenario: relative_link_to produces relative links
+    Given a fixture app "indexable-app"
+    And an empty file named "config.rb"
+    And a file named "source/link_to.html.erb" with:
+    """
+    absolute: <%= link_to "Needs Index", "/needs_index.html", :relative => true %>
+    relative: <%= link_to "Relative", "needs_index.html", :relative => true %>
+    """
+    And a file named "source/link_to/sub.html.erb" with:
+    """
+    absolute: <%= link_to "Needs Index", "/needs_index.html", :relative => true %>
+    relative: <%= link_to "Relative", "../needs_index.html", :relative => true %>
+    """
+    And the Server is running at "indexable-app"
+    When I go to "/link_to.html"
+    Then I should see 'absolute: <a href="needs_index.html">Needs Index</a>'
+    Then I should see 'relative: <a href="needs_index.html">Relative</a>'
+    When I go to "/link_to/sub.html"
+    Then I should see 'absolute: <a href="../needs_index.html">Needs Index</a>'
+    Then I should see 'relative: <a href="../needs_index.html">Relative</a>'
+
+  Scenario: relative_link_to produces relative links when :relative_links is set to true
+    Given a fixture app "indexable-app"
+    And a file named "config.rb" with:
+    """
+    set :relative_links, true
+    """
+    And a file named "source/link_to.html.erb" with:
+    """
+    absolute: <%= link_to "Needs Index", "/needs_index.html" %>
+    relative: <%= link_to "Relative", "needs_index.html", :relative => false %>
+    unknown: <%= link_to "Unknown", "foo.html" %>
+    """
+    And a file named "source/link_to/sub.html.erb" with:
+    """
+    absolute: <%= link_to "Needs Index", "/needs_index.html" %>
+    relative: <%= link_to "Relative", "../needs_index.html" %>
+    """
+    And the Server is running at "indexable-app"
+    When I go to "/link_to.html"
+    Then I should see 'absolute: <a href="needs_index.html">Needs Index</a>'
+    Then I should see 'relative: <a href="/needs_index.html">Relative</a>'
+    Then I should see 'unknown: <a href="foo.html">Unknown</a>'
+    When I go to "/link_to/sub.html"
+    Then I should see 'absolute: <a href="../needs_index.html">Needs Index</a>'
+    Then I should see 'relative: <a href="../needs_index.html">Relative</a>'
+
+  Scenario: relative_link_to knows about directory indexes
+    Given a fixture app "indexable-app"
+    And a file named "source/link_to.html.erb" with:
+    """
+    absolute: <%= link_to "Needs Index", "/needs_index.html", :relative => true %>
+    relative: <%= link_to "Relative", "needs_index.html", :relative => true %>
+    """
+    And a file named "source/link_to/sub.html.erb" with:
+    """
+    absolute: <%= link_to "Needs Index", "/needs_index.html", :relative => true %>
+    relative: <%= link_to "Relative", "../needs_index.html", :relative => true %>
+    """
+    And the Server is running at "indexable-app"
+    When I go to "/link_to/"
+    Then I should see 'absolute: <a href="needs_index/">Needs Index</a>'
+    Then I should see 'relative: <a href="needs_index/">Relative</a>'
+    When I go to "/link_to/sub/"
+    Then I should see 'absolute: <a href="../needs_index/">Needs Index</a>'
+    Then I should see 'relative: <a href="../needs_index/">Relative</a>'

--- a/middleman-core/lib/middleman-core/sitemap/resource.rb
+++ b/middleman-core/lib/middleman-core/sitemap/resource.rb
@@ -140,7 +140,7 @@ module Middleman
       # just foo. Best for linking.
       # @return [String]
       def url
-        '/' + destination_path.sub(/#{Regexp.escape(app.index_file)}$/, '')
+        ('/' + destination_path).sub(/\/#{Regexp.escape(app.index_file)}$/, '/')
       end
     end
   end


### PR DESCRIPTION
A few changes to `link_to`:
- You can now reference sitemap paths relative to the current sitemap resource, and `link_to` will do the right thing.
- You can pass `:relative => true` to `link_to` to make it generate a relative URL for sitemap paths instead of an absolute path.
- Or, add `set :relative_links, true` to `config.rb` to default to relative links from `link_to`. You can still turn relative links _off_ for a single `link_to` by adding `:relative => false`.

This should fully resolve #368 and #388.
