### PR TITLE
Fix front-matter parsing

### DIFF
--- a/middleman-core/lib/middleman-core/core_extensions/front_matter.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/front_matter.rb
@@ -71,7 +71,7 @@ module Middleman::CoreExtensions
       # @param [String] content
       # @return [Array<Hash, String>]
       def parse_yaml_front_matter(content)
-        yaml_regex = /^(---\s*\n.*?\n?)^(---\s*$\n?)/m
+        yaml_regex = /\A(---\s*\n.*?\n?)^(---\s*$\n?)/m
         if content =~ yaml_regex
           content = content.sub(yaml_regex, "")
 


### PR DESCRIPTION
Match for start of string instead of start of line. This regexp would
incorrectly try to parse a file that has two "---" somewhere in the file.

For example
http://ajax.googleapis.com/ajax/libs/mootools/1.4.5/mootools.js
would incorreclty trigger the front-matter parsing.
