### PR TITLE
Use pathname consistently in file watcher

### DIFF
--- a/middleman-core/bin/middleman
+++ b/middleman-core/bin/middleman
@@ -12,7 +12,7 @@ require "pathname"
 
 # Recursive method to find config.rb
 def locate_root(cwd = Pathname.new(Dir.pwd))
-  return cwd.to_s if File.exists?(File.join(cwd, 'config.rb'))
+  return cwd.to_s if (cwd + 'config.rb').exists?
   return false if cwd.root?
   locate_root(cwd.parent)
 end

--- a/middleman-core/lib/middleman-core/application.rb
+++ b/middleman-core/lib/middleman-core/application.rb
@@ -72,6 +72,11 @@ module Middleman
     # @return [String]
     set :root,        ENV["MM_ROOT"] || Dir.pwd
   
+    # Pathname-addressed root
+    def root_path
+      @_root_path ||= Pathname.new(root)
+    end
+  
     # Name of the source directory
     # @return [String]
     set :source,      "source"

--- a/middleman-core/lib/middleman-core/cli/build.rb
+++ b/middleman-core/lib/middleman-core/cli/build.rb
@@ -210,7 +210,7 @@ module Middleman::Cli
       puts "== Checking for Compass sprites" if @app.logging?
 
       # Double-check for compass sprites
-      @app.files.find_new_files(File.join(@app.source_dir, @app.images_dir))
+      @app.files.find_new_files(Pathname.new(@app.source_dir) + @app.images_dir)
 
       # Sort paths to be built by the above order. This is primarily so Compass can
       # find files in the build folder when it needs to generate sprites for the

--- a/middleman-core/lib/middleman-core/preview_server.rb
+++ b/middleman-core/lib/middleman-core/preview_server.rb
@@ -83,7 +83,7 @@ module Middleman
 
             # Otherwise forward to Middleman
             added_and_modified.each do |path|
-              @app.files.did_change(path)
+              @app.files.did_change(@app.root_path + path)
             end
           end
       
@@ -93,7 +93,7 @@ module Middleman
 
             # Otherwise forward to Middleman
             removed.each do |path|
-              @app.files.did_delete(path)
+              @app.files.did_delete(@app.root_path + path)
             end
           end
         end

--- a/middleman-core/lib/middleman-core/step_definitions/middleman_steps.rb
+++ b/middleman-core/lib/middleman-core/step_definitions/middleman_steps.rb
@@ -9,9 +9,9 @@ Then /^the file "([^\"]*)" is removed$/ do |path|
 end
 
 Then /^the file "([^\"]*)" did change$/ do |path|
-  @server_inst.files.did_change(path)
+  @server_inst.files.did_change(@server_inst.root_path + path)
 end
 
 Then /^the file "([^\"]*)" did delete$/ do |path|
-  @server_inst.files.did_delete(path)
+  @server_inst.files.did_delete(@server_inst.root_path + path)
 end

--- a/middleman-core/lib/middleman-core/util.rb
+++ b/middleman-core/lib/middleman-core/util.rb
@@ -1,8 +1,12 @@
 # Using Thor's indifferent hash access
 require "thor"
 
+# Core Pathname library used for traversal
+require "pathname"
+
 module Middleman
   module Util
+    
     # Recursively convert a normal Hash into a HashWithIndifferentAccess
     #
     # @private


### PR DESCRIPTION
Starting from the bottom, hoping to use `Pathname` for all paths internally to make *nix/Windows stuff saner.

Would there be any downsides to this?
