### PR TITLE
Update nested_layout tests to show that Haml still doesn't work right

### DIFF
--- a/middleman-core/fixtures/nested-layout-app/source/another.html.markdown
+++ b/middleman-core/fixtures/nested-layout-app/source/another.html.markdown
@@ -1,7 +1,0 @@
---- 
-title: "New Article Title"
-date: 2011-01-01
-layout: inner
----
-
-The Article Content

--- a/middleman-core/fixtures/nested-layout-app/source/haml-test.html.markdown
+++ b/middleman-core/fixtures/nested-layout-app/source/haml-test.html.markdown
@@ -1,7 +1,0 @@
---- 
-title: "New Article Title"
-date: 2011-01-01
-layout: inner_haml
----
-
-The Article Content

--- a/middleman-core/fixtures/nested-layout-app/source/layouts/inner_haml.haml
+++ b/middleman-core/fixtures/nested-layout-app/source/layouts/inner_haml.haml
@@ -1,3 +1,0 @@
-- wrap_layout :outer_haml do
-  Inner
-  = yield

--- a/middleman-core/fixtures/nested-layout-app/source/layouts/master_haml.haml
+++ b/middleman-core/fixtures/nested-layout-app/source/layouts/master_haml.haml
@@ -1,3 +1,0 @@
-Master
-= data.page.title
-= yield

--- a/middleman-core/fixtures/nested-layout-app/source/layouts/outer_haml.haml
+++ b/middleman-core/fixtures/nested-layout-app/source/layouts/outer_haml.haml
@@ -1,3 +1,0 @@
-- wrap_layout :master_haml do
-  Outer
-  = yield

--- a/middleman-more/features/nested_layouts.feature
+++ b/middleman-more/features/nested_layouts.feature
@@ -3,34 +3,45 @@ Feature: Allow nesting of layouts
   Scenario: A page uses an inner layout when uses an outer layout
     Given the Server is running at "nested-layout-app"
     When I go to "/index.html"
-    Then I should see "Template"
-    And I should see "Inner"
-    And I should see "Outer"
-    And I should see "Master"
+    Then I should see:
+    """
+    Master
+      Outer
+        Inner
+      Template
+    
+    """
     When I go to "/another.html"
-    And I should see "New Article Title"
-    And I should see "The Article Content"
-    And I should see "Inner"
-    And I should see "Outer"
-    And I should see "Master"
+    Then I should see:
+    """
+    Master
+    New Article Title
+      Outer
+        Inner
+      <p>The Article Content</p>
+    """
     
   Scenario: A page uses an inner layout when uses an outer layout (slim)
     Given the Server is running at "nested-layout-app"
     When I go to "/slim-test.html"
-    And I should see "New Article Title"
-    And I should see "The Article Content"
-    And I should see "Inner"
-    And I should see "Outer"
-    And I should see "Master"
+    Then I should see:
+    """
+    <h1>Master</h1><p>New Article Title</p><div><h2>Outer</h2><h3>Inner</h3><p>The Article Content</p>
+    </div>
+    """
     
   Scenario: A page uses an inner layout when uses an outer layout (haml)
     Given the Server is running at "nested-layout-app"
     When I go to "/haml-test.html"
-    And I should see "New Article Title"
-    And I should see "The Article Content"
-    And I should see "Inner"
-    And I should see "Outer"
-    And I should see "Master"
+    Then I should see:
+    """
+    Master
+    New Article Title
+    Outer
+    Inner
+
+    <p>The Article Content</p>
+    """
 
   Scenario: YAML Front Matter isn't clobbered with nested layouts
     Given the Server is running at "nested-layout-app"

--- a/middleman-more/fixtures/nested-layout-app/source/layouts/inner_slim.slim
+++ b/middleman-more/fixtures/nested-layout-app/source/layouts/inner_slim.slim
@@ -1,3 +1,3 @@
 - wrap_layout :outer_slim do
-  Inner
-  = yield
+  h3 Inner
+  == yield

--- a/middleman-more/fixtures/nested-layout-app/source/layouts/master_slim.slim
+++ b/middleman-more/fixtures/nested-layout-app/source/layouts/master_slim.slim
@@ -1,3 +1,3 @@
-Master
-= data.page.title
-= yield
+h1 Master
+p== data.page.title
+div== yield

--- a/middleman-more/fixtures/nested-layout-app/source/layouts/outer_slim.slim
+++ b/middleman-more/fixtures/nested-layout-app/source/layouts/outer_slim.slim
@@ -1,3 +1,3 @@
 - wrap_layout :master_slim do
-  Outer
-  = yield
+  h2 Outer
+  == yield


### PR DESCRIPTION
The `nested_layout` tests didn't assert that the output was ordered correctly, and that's one of the problems that had plagued me with Haml and `wrap_layout`. You can see that instead of outputting the correct sequence, it produces a mixed up result, rendering the innermost content _first_, then the wrapped layouts:

``` html
Inner
<p>The Article Content</p>
Master
New Article Title
Outer
```

I think this is due to the different way `concat` works for Haml.

I also updated Slim and ERb tests to verify ordering of output for them too. One of the ERb cases now fails but it's debateable whether or not that's a problem - it' because it's missing a newline where it seems like it should have one, but if you're outputting real HTML it won't care that things are on the same line. It's up to you whether you want to modify the test to accept that, or do something to add in a newline.

(the deleted files were just leftover from when the test fixture was in middleman-core)
