### PR TITLE
Cannot access I18n from helpers anymore 

### DIFF
--- a/middleman-more/lib/middleman-more.rb
+++ b/middleman-more/lib/middleman-more.rb
@@ -37,7 +37,7 @@ module Middleman
       
         Middleman::Extensions.register(:i18n) do
           require "middleman-more/core_extensions/i18n"
-          Middleman::CoreExtensions::I18n
+          Middleman::CoreExtensions::Internationalization
         end
       
         # Compass framework

--- a/middleman-more/lib/middleman-more/core_extensions/i18n.rb
+++ b/middleman-more/lib/middleman-more/core_extensions/i18n.rb
@@ -2,7 +2,7 @@ module Middleman
   module CoreExtensions
     
     # i18n Namespace
-    module I18n
+    module Internationalization
 
       # Setup extension
       class << self


### PR DESCRIPTION
When I tryed to port this helper to MiddleMan 3:

```
def localized_path(path, extension = 'html')
  path = I18n.t("paths.#{path}")
  "#{path}.#{extension}"
end
```

I got this error:

```
undefined method `t' for #<Middleman::CoreExtensions::I18n::Localizer:0x007fac4a552af0>
```

so it seems that is not possible to access I18n from outsides templates anymore.

I don't know if this is by design, but I found useful in the previous version to access I18n in the helpers functions.

Is there any way to do something similar?
