### PR TITLE
Change the default character encoding to 'utf-8', with a dash

### DIFF
--- a/middleman-core/lib/middleman-core/core_extensions/request.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/request.rb
@@ -17,8 +17,8 @@ module Middleman
           ::Rack::Mime::MIME_TYPES['.htc'] = 'text/x-component'
 
           # Let's serve all HTML as UTF-8
-          ::Rack::Mime::MIME_TYPES['.html'] = 'text/html;charset=utf8'
-          ::Rack::Mime::MIME_TYPES['.htm'] = 'text/html;charset=utf8'
+          ::Rack::Mime::MIME_TYPES['.html'] = 'text/html; charset=utf-8'
+          ::Rack::Mime::MIME_TYPES['.htm'] = 'text/html; charset=utf-8'
           
           app.extend ClassMethods
           app.extend ServerMethods


### PR DESCRIPTION
According to IANA the character encoding should be 'utf-8', not 'utf8'. This change fixes the character encoding and makes sure that the character encoding is correctly interpreted by more browsers, including old versions of IE (6, 7, ...?). 
