### PR TITLE
Use method should accept a block when adding Rack middleware.

### DIFF
--- a/middleman-core/lib/middleman-core/core_extensions/request.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/request.rb
@@ -170,7 +170,7 @@ module Middleman
           })
         end
         
-        def use(*args, &block); self.class.use(*args); end
+        def use(*args, &block); self.class.use(*args, &block); end
         def map(*args, &block); self.class.map(*args, &block); end
         
         # Rack env


### PR DESCRIPTION
When using Rack middleware, the `use` method should accept a block. This allows certain middleware that uses blocks to be configured properly. An example of such middleware is `rack-rewrite` (https://github.com/jtrupiano/rack-rewrite). E.g.:

```
use Rack::Rewrite do
  rewrite '/wiki/John_Trupiano', '/john'
end
```
