### PR TITLE
Implement the :encoding setting which defaults to 'utf-8'

### DIFF
--- a/middleman-core/lib/middleman-core/application.rb
+++ b/middleman-core/lib/middleman-core/application.rb
@@ -117,6 +117,10 @@ module Middleman
     # @return [String]
     set :http_prefix, "/"
 
+    # Default string encoding for templates and output.
+    # @return [String]
+    set :encoding,    "utf-8"
+
     # Whether to catch and display exceptions
     # @return [Boolean]
     set :show_exceptions, true
@@ -127,6 +131,9 @@ module Middleman
 
     # Activate custom features and extensions
     include Middleman::CoreExtensions::Extensions
+
+    # Manage Ruby string encodings
+    include Middleman::CoreExtensions::RubyEncoding
 
     # Basic Rack Request Handling
     include Middleman::CoreExtensions::Request

--- a/middleman-core/lib/middleman-core/core_extensions.rb
+++ b/middleman-core/lib/middleman-core/core_extensions.rb
@@ -28,3 +28,6 @@ require "middleman-core/core_extensions/routing"
 
 # Catch and show exceptions at the Rack level
 require "middleman-core/core_extensions/show_exceptions"
+
+# Manage Ruby string encodings
+require "middleman-core/core_extensions/ruby_encoding"

--- a/middleman-core/lib/middleman-core/core_extensions/ruby_encoding.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/ruby_encoding.rb
@@ -1,0 +1,24 @@
+# Simple extension to manage Ruby encodings
+module Middleman::CoreExtensions::RubyEncoding
+
+  # Setup extension
+  class << self
+    
+    # Once registerd
+    def registered(app)
+      app.send :include, InstanceMethods
+    end
+
+  end
+
+  module InstanceMethods
+    def initialize
+      if Object.const_defined?(:Encoding)
+        Encoding.default_internal = encoding
+        Encoding.default_external = encoding
+      end
+
+      super
+    end
+  end
+end


### PR DESCRIPTION
This is my naive attempt to implement the idea discussed in #483. This implements the `:encoding` setting. As this defaults to `utf-8`, this should fix encoding-related errors that may plague certain setups such as Sprockets::EncodingError.
