### PR TITLE
Fix the listener/watcher

### DIFF
--- a/middleman-core/lib/middleman-core/preview_server.rb
+++ b/middleman-core/lib/middleman-core/preview_server.rb
@@ -32,6 +32,8 @@ module Middleman
         )
         
         mount_instance(app)
+
+        start_file_watcher unless options[:"disable-watcher"]
         
         @initialized ||= false
         unless @initialized
@@ -39,8 +41,6 @@ module Middleman
           
           register_signal_handlers unless ::Middleman::WINDOWS
           
-          start_file_watcher unless options[:"disable-watcher"]
-
           # Save the last-used options so it may be re-used when
           # reloading later on.
           @last_options = options
@@ -83,7 +83,10 @@ module Middleman
 
           if added_and_modified.length > 0
             # See if the changed file is config.rb or lib/*.rb
-            return reload if needs_to_reload?(added_and_modified)
+            if needs_to_reload?(added_and_modified)
+              reload
+              return listener.stop
+            end
 
             # Otherwise forward to Middleman
             added_and_modified.each do |path|
@@ -93,7 +96,10 @@ module Middleman
       
           if removed.length > 0
             # See if the changed file is config.rb or lib/*.rb
-            return reload if needs_to_reload?(removed)
+            if needs_to_reload?(removed)
+              reload
+              return listener.stop
+            end
 
             # Otherwise forward to Middleman
             removed.each do |path|


### PR DESCRIPTION
Fix #464.

Old behavior:

```
$ middleman -p 5060
== The Middleman is loading
== The Middleman is standing watch on port 5060
/* did a `touch config.rb` at this point */
== The Middleman is shutting down
== The Middleman is standing watch on port 4567
/* did a `touch config.rb` at this point again... nothing happened */
```

Now:

```
$ middleman -p 5060
== The Middleman is loading
== The Middleman is standing watch on port 5060
/* did a `touch config.rb` at this point */
== The Middleman is shutting down
== The Middleman is standing watch on port 5060
/* did a `touch config.rb` again */
== The Middleman is shutting down
== The Middleman is standing watch on port 5060
/* and so on */
```
