### PR TITLE
Add a Middleman::Util.path_match function and use it

### DIFF
--- a/middleman-core/lib/middleman-core/util.rb
+++ b/middleman-core/lib/middleman-core/util.rb
@@ -56,6 +56,25 @@ module Middleman
       end
     end
     
+    # Takes a matcher, which can be a literal string
+    # or a string containing glob expressions, or a
+    # regexp, or a proc, or anything else that responds
+    # to #match or #call, and returns whether or not the
+    # given path matches that matcher.
+    #
+    # @param matcher A matcher string/regexp/proc/etc
+    # @param path A path as a string
+    # @return [Boolean] Whether the path matches the matcher
+    def self.path_match(matcher, path)
+      if matcher.respond_to? :match
+        matcher.match path
+      elsif matcher.respond_to? :call
+        matcher.call path
+      else
+        File.fnmatch(matcher.to_s, path)
+      end
+    end
+
     # Simple shared cache implementation
     class Cache
       # Initialize

--- a/middleman-more/lib/middleman-more/extensions/asset_hash.rb
+++ b/middleman-more/lib/middleman-more/extensions/asset_hash.rb
@@ -32,7 +32,7 @@ module Middleman
         def manipulate_resource_list(resources)
           resources.each do |resource|
             next unless @exts.include? resource.ext
-            next if @ignore.any? { |r| resource.destination_path.match(r) }
+            next if @ignore.any? { |ignore| Middleman::Util.path_match(ignore, resource.destination_path) }
               
             if resource.template? # if it's a template, render it out
               digest = Digest::SHA1.hexdigest(resource.render)[0..7]

--- a/middleman-more/lib/middleman-more/extensions/minify_css.rb
+++ b/middleman-more/lib/middleman-more/extensions/minify_css.rb
@@ -66,7 +66,7 @@ module Middleman
 
             headers["Content-Length"] = ::Rack::Utils.bytesize(minified).to_s
             response = [minified]
-          elsif path.end_with?('.css') && @ignore.none? {|ignore| path =~ ignore }
+          elsif path.end_with?('.css') && @ignore.none? {|ignore| Middleman::Util.path_match(ignore, path) }
             uncompressed_source = ::Middleman::Util.extract_response_text(response)
             minified_css = @compressor.compress(uncompressed_source)
 

--- a/middleman-more/lib/middleman-more/extensions/minify_javascript.rb
+++ b/middleman-more/lib/middleman-more/extensions/minify_javascript.rb
@@ -75,7 +75,7 @@ module Middleman
 
               headers["Content-Length"] = ::Rack::Utils.bytesize(minified).to_s
               response = [minified]
-            elsif path.end_with?('.js') && @ignore.none? {|ignore| path =~ ignore }
+            elsif path.end_with?('.js') && @ignore.none? {|ignore| Middleman::Util.path_match(ignore, path) }
               uncompressed_source = ::Middleman::Util.extract_response_text(response)
               minified_js = @compressor.compress(uncompressed_source)
 


### PR DESCRIPTION
Got a `Regexp`? `path_match`'ll match it. Got a string with glob expressions? Oh yeah, `path_match`'ll match it. Heck, all you got is a `Proc`? `path_match` don't care, it's gonna match it.

I applied `path_match` to the `asset_hash`, `minify_javascript`, and `minify_css` extensions, so that whatever type of object people think the `:ignore` options take, they're right.
