### PR TITLE
Use Sprockets in default template

### DIFF
--- a/middleman-core/lib/middleman-core/templates/default/source/layouts/layout.erb
+++ b/middleman-core/lib/middleman-core/templates/default/source/layouts/layout.erb
@@ -9,7 +9,7 @@
     <!-- Use title if it's in the page YAML frontmatter -->
     <title><%= data.page.title || "The Middleman" %></title>
     
-    <%= stylesheet_link_tag "normalize", "all" %>
+    <%= stylesheet_link_tag "all" %>
     <%= javascript_include_tag  "all" %>
   </head>
   

--- a/middleman-core/lib/middleman-core/templates/default/source/stylesheets/all.css
+++ b/middleman-core/lib/middleman-core/templates/default/source/stylesheets/all.css
@@ -1,3 +1,7 @@
+/*
+ *= require normalize
+ */
+
 @charset "utf-8";
 
 body {


### PR DESCRIPTION
Sprockets is awesome (at least more awesome than no dependency
management system at all), so let's demo it in the template.

---

Sprockets is part of the default install, right? Then I'm thinking we might as well demo it.

If you don't like this for whatever reason, just go ahead and close it. :)
