### PR TITLE
Make :http_prefix work in link_to and asset helpers

### DIFF
--- a/middleman-core/lib/middleman-core/sitemap/resource.rb
+++ b/middleman-core/lib/middleman-core/sitemap/resource.rb
@@ -144,7 +144,8 @@ module Middleman
       # just foo. Best for linking.
       # @return [String]
       def url
-        ('/' + destination_path).sub(/\/#{Regexp.escape(app.index_file)}$/, '/')
+        File.join(app.respond_to?(:http_prefix) ? app.http_prefix : '/',
+          destination_path.sub(/\/#{Regexp.escape(app.index_file)}$/, '/'))
       end
     end
   end

--- a/middleman-more/features/former_padrino_helpers.feature
+++ b/middleman-more/features/former_padrino_helpers.feature
@@ -6,7 +6,22 @@ Feature: Built-in macro view helpers
     When I go to "/former_padrino_test.html"
     And I should see 'href="test2.com"'
     And I should see 'src="/images/test2.png"'
+    And I should see 'src="/images/100px.png"'
     And I should see 'src="/javascripts/test1.js"'
     And I should see 'href="/stylesheets/test1.css"'
     And I should see '1 KB'
+
+  Scenario: Setting http_prefix
+    Given a fixture app "padrino-helpers-app"
+    And a file named "config.rb" with:
+    """
+    set :http_prefix, "/foo"
+    """
+    And the Server is running at "padrino-helpers-app"
+    When I go to "/former_padrino_test.html"
+    And I should see 'src="/foo/images/test2.png"'
+    And I should see 'src="/foo/images/100px.png"'
+    And I should see 'src="/foo/javascripts/test1.js"'
+    And I should see 'href="/foo/stylesheets/test1.css"'
+
                 

--- a/middleman-more/features/helpers_link_to.feature
+++ b/middleman-more/features/helpers_link_to.feature
@@ -76,3 +76,18 @@ Feature: link_to helper
     And the Server is running at "indexable-app"
     When I go to "/link_to/"
     Then I should see '<a href="/needs_index/">Needs Index</a>'
+
+  Scenario: Setting http_prefix
+    Given a fixture app "indexable-app"
+    And a file named "config.rb" with:
+    """
+    set :http_prefix, "/foo"
+    """
+    And a file named "source/link_to.html.erb" with:
+    """
+    <%= link_to "Needs Index", "/needs_index.html" %>
+    """
+    And the Server is running at "indexable-app"
+    When I go to "/link_to.html"
+    Then I should see '<a href="/foo/needs_index.html">Needs Index</a>'
+

--- a/middleman-more/fixtures/padrino-helpers-app/source/former_padrino_test.html.erb
+++ b/middleman-more/fixtures/padrino-helpers-app/source/former_padrino_test.html.erb
@@ -1,5 +1,6 @@
 <%= stylesheet_link_tag "test1" %>
 <%= javascript_include_tag "test1" %>
 <%= image_tag "test2.png", :alt => "alt" %>
+<%= image_tag "100px.png", :alt => "alt" %>
 <%= link_to "Has param", "test2.com", :class => "test" %>
 <%= number_to_human_size(1024) %>

--- a/middleman-more/lib/middleman-more/core_extensions/assets.rb
+++ b/middleman-more/lib/middleman-more/core_extensions/assets.rb
@@ -31,10 +31,10 @@ module Middleman
           else # rewrite paths to use their destination path
             path = File.join(prefix, path)
             if resource = sitemap.find_resource_by_path(path)
-              path = resource.destination_path
+              resource.url
+            else
+              File.join(http_prefix, path)
             end
-
-            File.join(http_prefix, path)
           end
         end
       end


### PR DESCRIPTION
... as long as the linked item is a sitemap resource. Fixes #484.
