### PR TITLE
Fix build failure message, option --debug does not exist anymore

### DIFF
--- a/middleman-core/lib/middleman-core/cli/build.rb
+++ b/middleman-core/lib/middleman-core/cli/build.rb
@@ -56,7 +56,7 @@ module Middleman::Cli
       action GlobAction.new(self, opts)
 
       if @had_errors && !@debugging
-        self.shell.say "There were errors during this build, re-run with --debug to see the full exception."
+        self.shell.say "There were errors during this build, re-run with --verbose to see the full exception."
       end
       
       exit(1) if @had_errors


### PR DESCRIPTION
After a build failure a message is printed on the console: 

<pre>There were errors during this build, re-run with --debug to see the full exception.</pre>

But on the current master branch the option _--debug_ does not exist anymore, it should now be _--verbose_.
This commit changes the text accordingly:

<pre>There were errors during this build, re-run with --verbose to see the full exception.</pre>
