### PR TITLE
Syntax errors lock up Middleman

### DIFF
--- a/middleman-core/lib/middleman-core/application.rb
+++ b/middleman-core/lib/middleman-core/application.rb
@@ -217,6 +217,14 @@ module Middleman
       logging
     end
 
+    # Work around this bug: http://bugs.ruby-lang.org/issues/4521
+    # where Ruby will call to_s/inspect while printing exception
+    # messages, which can take a long time (minutes at full CPU)
+    # if the object is huge or has cyclic references, like this.
+    def to_s
+      "the Middleman application context"
+    end
+
     # Expand a path to include the index file if it's a directory
     #
     # @private


### PR DESCRIPTION
I've noticed this in my main website project, which has a lot of pages - I haven't been able to reproduce it with little apps I've created to try and show it in action. Often, when I've messed up and used a method that doesn't exist or something, instead of showing a nice error page, the preview server locks up completely, never returns a response, and consumes 100% CPU. I have no idea why it does this.
