### PR TITLE
Bad error message for extensionless files

### DIFF
--- a/middleman-core/lib/middleman-core/core_extensions/rendering.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/rendering.rb
@@ -115,9 +115,13 @@ module Middleman
           # handles cases like `style.css.sass.erb`
           content = nil
           while ::Tilt[path]
-            opts[:template_body] = content if content
-            content = render_individual_file(path, locs, opts, context)
-            path = File.basename(path, File.extname(path))
+            begin
+              opts[:template_body] = content if content
+              content = render_individual_file(path, locs, opts, context)
+              path = File.basename(path, File.extname(path))
+            rescue LocalJumpError => e
+              raise "Tried to render a layout (calls yield) at #{path} like it was a template. Non-default layouts need to be in #{source}/layouts."
+            end
           end
       
           # Certain output file types don't use layouts


### PR DESCRIPTION
I saw that non-default layouts must now be in a `layouts/` folder, which is fine, but the error message I got when Middleman encountered one of the old layouts (identified by having only a templating extension) that I hadn't moved yet was:

```
no block given (yield)
```

We should probably provide some more instructive error message.
