### PR TITLE
Make :automatic_image_sizes work for absolute image paths

### DIFF
--- a/middleman-more/lib/middleman-more/extensions/automatic_image_sizes.rb
+++ b/middleman-more/lib/middleman-more/extensions/automatic_image_sizes.rb
@@ -32,22 +32,22 @@ module Middleman
         def image_tag(path, params={})
           if !params.has_key?(:width) && !params.has_key?(:height) && !path.include?("://")
             params[:alt] ||= ""
-            http_prefix = http_images_path rescue images_dir
 
-            begin
-              real_path = File.join(source, images_dir, path)
-              full_path = File.expand_path(real_path, root)
-              http_prefix = http_images_path rescue images_dir
-              if File.exists? full_path
-                dimensions = ::FastImage.size(full_path, :raise_on_failure => true)
-                params[:width]  = dimensions[0]
-                params[:height] = dimensions[1]
+            real_path = path
+            real_path = File.join(images_dir, real_path) unless real_path =~ %r{^/}
+            full_path = File.join(source_dir, real_path)
+
+            if File.exists? full_path
+              begin
+                width, height = ::FastImage.size(full_path, :raise_on_failure => true)
+                params[:width]  = width
+                params[:height] = height
+              rescue
+                warn "Couldn't determine dimensions for image #{path}: #{$!.message}"
               end
-            rescue
-              # $stderr.puts params.inspect
             end
           end
-      
+
           super(path, params)
         end
       end


### PR DESCRIPTION
I noticed that I'd get automatic image sizes for files in my `images` folder, but for images outside that folder that I referenced via an absolute path. This fixes that. It also adds a little warning when image sizes can't be calculated.
