### PR TITLE
Use middleman's image_tag and link_to helpers from within Redcarpet markdown

### DIFF
--- a/middleman-core/lib/middleman-core/renderers/markdown.rb
+++ b/middleman-core/lib/middleman-core/renderers/markdown.rb
@@ -10,7 +10,6 @@ module Middleman
         # Once registered
         def registered(app)
           # Set our preference for a markdown engine
-          # TODO: Find a JRuby-compatible version
           app.set :markdown_engine, :maruku
           app.set :markdown_engine_prefix, ::Tilt
       

--- a/middleman-core/lib/middleman-core/renderers/redcarpet.rb
+++ b/middleman-core/lib/middleman-core/renderers/redcarpet.rb
@@ -7,12 +7,12 @@ module Middleman
       
       # Overwrite built-in Tilt version. 
       # Don't overload :renderer option with smartypants
-      # Supper renderer-level options
+      # Support renderer-level options
       def generate_renderer
         return options.delete(:renderer) if options.has_key?(:renderer)
         
         # Pick a renderer
-        renderer = ::Redcarpet::Render::HTML
+        renderer = MiddlemanRedcarpetHTML
         
         # Support SmartyPants
         if options.delete(:smartypants)
@@ -28,8 +28,28 @@ module Middleman
           sum[opt] = options.delete(opt) if options.has_key?(opt)
           sum
         end
-        
+
         renderer.new(render_options)
+      end
+
+      def evaluate(scope, locals, &block)
+        if @engine.renderer.respond_to? :middleman_app=
+          @engine.renderer.middleman_app = scope
+        end
+        super
+      end
+    end
+
+    # Custom Redcarpet renderer that uses our helpers for images and links
+    class MiddlemanRedcarpetHTML < ::Redcarpet::Render::HTML
+      attr_accessor :middleman_app
+
+      def image(link, title, alt_text)
+        middleman_app.image_tag(link, :title => title, :alt => alt_text)
+      end
+
+      def link(link, title, content)
+        middleman_app.link_to(content, link, :title => title)
       end
     end
    


### PR DESCRIPTION
This uses our fancy `image_tag` and `link_to` helpers to do the work of rendering images and links for Redcarpet-powered markdown documents. That means image and link tags in those documents get things like relative assets, sitemap-based links, global relative linking, automatic image sizing, etc.

It's also a bit of a hack, and it's late enough that I'd be fine with this not making 3.0.
