### PR TITLE
Use plain Dir.chdir instead of enclosing middleman in a Dir.chdir-block.

### DIFF
--- a/middleman-core/bin/middleman
+++ b/middleman-core/bin/middleman
@@ -63,9 +63,8 @@ end
 # Start the CLI
 if ENV["MM_ROOT"]
   # Change directory to the root
-  Dir.chdir(ENV["MM_ROOT"]) do
-    Middleman::Cli::Base.start
-  end
+  Dir.chdir(ENV["MM_ROOT"])
+  Middleman::Cli::Base.start
 else
   Middleman::Cli::Base.start
 end


### PR DESCRIPTION
This allows extensions, templates and monkey-patches to chdir
when needed, without triggering this ruby warning:

  warning: conflicting chdir during another chdir block

This patch was created to make the less-fix (Issue #236) work
without littering the console with the aforementioned warning, but there
will likely be more cases in the future that require a chdir in user-code
to accommodate a template-handler or extension.

As a follow-up to this patch I would recommend to make middleman
perform another chdir (back to its ENV["MM_ROOT"]) after every callout
to user-code that could potentially alter CWD and forget to change it back.
This extra-safeguard is not included in this patch because I'm not familiar
enough with the code-base to locate all places where such callouts happen.
