### PR TITLE
Support profiling server startup and build via a --profile flag

### DIFF
--- a/middleman-core/bin/middleman
+++ b/middleman-core/bin/middleman
@@ -7,6 +7,12 @@ $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 moredir = File.expand_path(File.join(File.dirname(File.dirname(libdir)), "middleman-more", "lib", "middleman-more"))
 $LOAD_PATH.unshift(moredir) unless $LOAD_PATH.include?(moredir)
 
+require 'middleman-core/profiling'
+if ARGV.include? '--profile'
+  Middleman::Profiling.profiler = Middleman::Profiling::RubyProfProfiler.new
+end
+Middleman::Profiling.start
+
 require "middleman-core/load_paths"
 Middleman.setup_load_paths
 

--- a/middleman-core/lib/middleman-core/cli.rb
+++ b/middleman-core/lib/middleman-core/cli.rb
@@ -9,7 +9,6 @@ module Middleman
     
     # The base task from which everything else etends
     class Base < Thor
-    
       class << self
         def start(*args)
           # Change flag to a module
@@ -23,7 +22,7 @@ module Middleman
           super
         end
       end
-    
+
       desc "version", "Show version"
       def version
         require 'middleman-core/version'

--- a/middleman-core/lib/middleman-core/cli/build.rb
+++ b/middleman-core/lib/middleman-core/cli/build.rb
@@ -32,6 +32,10 @@ module Middleman::Cli
       :type    => :string, 
       :default => false,
       :desc    => 'Print instrument messages'
+    method_option :profile,
+      :type    => :boolean,
+      :default => false,
+      :desc    => 'Generate profiling report for the build'
     
     # Core build Thor command
     # @return [void]
@@ -257,6 +261,8 @@ module Middleman::Cli
 
         @cleaning_queue.delete(Pathname.new(output_path).realpath) if cleaning?
       end
+
+      ::Middleman::Profiling.report("build")
     end
   end
   

--- a/middleman-core/lib/middleman-core/cli/server.rb
+++ b/middleman-core/lib/middleman-core/cli/server.rb
@@ -33,7 +33,11 @@ module Middleman::Cli
       :type    => :boolean, 
       :default => false,
       :desc    => 'Disable the file change and delete watcher process'
-    
+    method_option :profile,
+      :type    => :boolean,
+      :default => false,
+      :desc    => 'Generate profiling report for server startup'
+
     # Start the server
     def server
       require "middleman-core"

--- a/middleman-core/lib/middleman-core/core_extensions/request.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/request.rb
@@ -204,6 +204,7 @@ module Middleman
             process_request(env, req, res)
 
             res.status = 404
+
             res.finish
           end
         end

--- a/middleman-core/lib/middleman-core/preview_server.rb
+++ b/middleman-core/lib/middleman-core/preview_server.rb
@@ -46,7 +46,8 @@ module Middleman
           # Save the last-used options so it may be re-used when
           # reloading later on.
           @last_options = options
-          
+          ::Middleman::Profiling.report("server_start")
+
           @webrick.start
         end
       end

--- a/middleman-core/lib/middleman-core/profiling.rb
+++ b/middleman-core/lib/middleman-core/profiling.rb
@@ -1,0 +1,58 @@
+module Middleman
+  module Profiling
+    
+    # The profiler instance. There can only be one!
+    def self.profiler=(prof)
+      @profiler = prof
+    end
+    def self.profiler
+      @profiler ||= NullProfiler.new
+    end
+
+    # Start the profiler
+    def self.start
+      profiler.start
+    end
+
+    # Stop the profiler and generate a report. Make sure to call start first
+    def self.report(report_name)
+      profiler.report(report_name)
+    end
+
+    # A profiler that does nothing. The default.
+    class NullProfiler
+      def start
+      end
+
+      def report
+      end
+    end
+
+    # A profiler that uses ruby-prof
+    class RubyProfProfiler
+      def initialize
+        begin
+          require 'ruby-prof'
+        rescue LoadError
+          raise "To use the --profile option, you must 'gem install ruby-prof' (and include it in your Gemfile if running under bundle exec)"
+        end
+      end
+
+      def start
+        RubyProf.start
+      end
+
+      def report(report_name)
+        result = RubyProf.stop
+
+        printer = RubyProf::GraphHtmlPrinter.new(result)
+        outfile = File.join("profile", report_name)
+        outfile = (outfile + '.html') unless outfile.end_with? '.html'
+        FileUtils.mkdir_p(File.dirname(outfile))
+        File.open(outfile, 'w') do |f|
+          printer.print(f, :min_percent=> 1)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This should make it a bit easier to start figuring out performance issues. I'd like to also add profiling to individual requests but I haven't quite gotten the rack middleware for that working yet. In the meantime, you can get `ruby-prof` graphs of server startup or build in the `profile` directory by adding `--profile` to CLI invocations. This doesn't add `ruby-prof` as a hard dependency, it only requires it if you invoke profiling.

Note that unfortunately due to tanoku/redcarpet#144 you can't profile a project that uses Redcarpet.
