### PR TITLE
Reduce work converting paths from relative to absolute and back again

### DIFF
--- a/middleman-core/lib/middleman-core/cli/build.rb
+++ b/middleman-core/lib/middleman-core/cli/build.rb
@@ -237,7 +237,7 @@ module Middleman::Cli
       logger.debug "== Checking for Compass sprites"
 
       # Double-check for compass sprites
-      @app.files.find_new_files(Pathname.new(@app.source_dir) + @app.images_dir)
+      @app.files.find_new_files((Pathname(@app.source_dir) + @app.images_dir).relative_path_from(@app.root_path))
 
       # Sort paths to be built by the above order. This is primarily so Compass can
       # find files in the build folder when it needs to generate sprites for the
@@ -245,11 +245,8 @@ module Middleman::Cli
 
       logger.debug "== Building files"
 
-      resources = @app.sitemap.resources.sort do |a, b|
-        a_idx = sort_order.index(a.ext) || 100
-        b_idx = sort_order.index(b.ext) || 100
-
-        a_idx <=> b_idx
+      resources = @app.sitemap.resources.sort_by do |r|
+        sort_order.index(r.ext) || 100
       end
 
       # Loop over all the paths and build them.

--- a/middleman-core/lib/middleman-core/preview_server.rb
+++ b/middleman-core/lib/middleman-core/preview_server.rb
@@ -98,7 +98,7 @@ module Middleman
 
             # Otherwise forward to Middleman
             added_and_modified.each do |path|
-              @app.files.did_change(@app.root_path + path)
+              @app.files.did_change(path)
             end
           end
       
@@ -111,7 +111,7 @@ module Middleman
 
             # Otherwise forward to Middleman
             removed.each do |path|
-              @app.files.did_delete(@app.root_path + path)
+              @app.files.did_delete(path)
             end
           end
         end

--- a/middleman-core/lib/middleman-core/sitemap.rb
+++ b/middleman-core/lib/middleman-core/sitemap.rb
@@ -25,22 +25,19 @@ module Middleman
         # Setup callbacks which can exclude paths from the sitemap
         app.set :ignored_sitemap_matchers, {
           # dotfiles and folders in the root
-          :root_dotfiles => proc { |file, path| file.match(/^\./) },
+          :root_dotfiles => proc { |file| file.match(%r{^\.}) },
         
           # Files starting with an dot, but not .htaccess
-          :source_dotfiles => proc { |file, path| 
-            (file.match(/\/\./) && !file.match(/\/\.htaccess/)) 
+          :source_dotfiles => proc { |file| 
+            file.match(%r{/\.}) && !file.match(%r{/\.htaccess})
           },
         
           # Files starting with an underscore, but not a double-underscore
-          :partials => proc { |file, path| (file.match(/\/_/) && !file.match(/\/__/)) },
+          :partials => proc { |file| file.match(%r{/_}) && !file.match(%r{/__}) },
         
-          :layout => proc { |file, path| 
-            file.match(/^source\/layout\./) || file.match(/^source\/layouts\//)
-          },
-        
-          # Files without any output extension (layouts, partials)
-          # :extensionless => proc { |file, path| !path.match(/\./) },
+          :layout => proc { |file| 
+            file.match(%r{^source/layout\.}) || file.match(%r{^source/layouts/})
+          }
         }
       
         # Include instance methods

--- a/middleman-core/lib/middleman-core/sitemap/extensions/on_disk.rb
+++ b/middleman-core/lib/middleman-core/sitemap/extensions/on_disk.rb
@@ -40,13 +40,13 @@ module Middleman
         # @param [String] file
         # @return [Boolean]
         def touch_file(file, rebuild=true)
-          return false if file == @app.source_dir || File.directory?(file)
+          return false if File.directory?(file)
 
           path = @sitemap.file_to_path(file)
           return false unless path
 
           ignored = @app.ignored_sitemap_matchers.any? do |name, callback|
-            callback.call(file, path)
+            callback.call(file)
           end
 
           @file_paths_on_disk << file unless ignored

--- a/middleman-core/lib/middleman-core/sitemap/store.rb
+++ b/middleman-core/lib/middleman-core/sitemap/store.rb
@@ -173,7 +173,7 @@ module Middleman
         file = File.expand_path(file, @app.root)
   
         prefix = @app.source_dir.sub(/\/$/, "") + "/"
-        return false unless file.include?(prefix)
+        return false unless file.start_with?(prefix)
   
         path = file.sub(prefix, "")
         

--- a/middleman-core/lib/middleman-core/step_definitions/middleman_steps.rb
+++ b/middleman-core/lib/middleman-core/step_definitions/middleman_steps.rb
@@ -9,9 +9,9 @@ Then /^the file "([^\"]*)" is removed$/ do |path|
 end
 
 Then /^the file "([^\"]*)" did change$/ do |path|
-  @server_inst.files.did_change(@server_inst.root_path + path)
+  @server_inst.files.did_change(path)
 end
 
 Then /^the file "([^\"]*)" did delete$/ do |path|
-  @server_inst.files.did_delete(@server_inst.root_path + path)
+  @server_inst.files.did_delete(path)
 end


### PR DESCRIPTION
In starting to profile, I noticed that we were making a ton of calls to Pathname#+ and Pathname#relative_path_from. Looking at the code, it seemed a shame that we were taking relative paths, making them absolute, then making them relative again (often multiple times). I reorganized the code so they stay relative. All tests pass.

I am sorta sad about having to do the `Dir.chdir` in `reload_path`, but one big downside of relative paths is that Pathname works relative to the current directory, so I needed to switch directories in there mainly to get the tests working.

I also killed a stray request to the old `__middleman__` URL... I thought that had been removed before.
