### PR TITLE
Update middleman-core/lib/middleman-core/templates/extension/Rakefile

### DIFF
--- a/middleman-core/lib/middleman-core/templates/extension/Rakefile
+++ b/middleman-core/lib/middleman-core/templates/extension/Rakefile
@@ -10,3 +10,5 @@ end
 require 'rake/clean'
 
 task :test => ["cucumber"]
+
+task :default => :test


### PR DESCRIPTION
A default target is required by http://travis-ci.org. Another option is to provide a `.travis.yml` that looks like:

```
script: "bundle exec rake test"
```
