### PR TITLE
Add test for asset_hashing rack-filtered items.

### DIFF
--- a/middleman-more/features/asset_hash.feature
+++ b/middleman-more/features/asset_hash.feature
@@ -85,3 +85,16 @@ Feature: Assets get a file hash appended to their and references to them are upd
       """
     When I go to "/partials/"
     Then I should see 'href="../stylesheets/uses_partials-e8c3d4eb.css'
+
+  Scenario: The asset hash should change when a Rack-based filter changes
+    Given the Server is running at "asset-hash-app"
+    And the file "config.rb" has the contents
+      """
+      activate :asset_hash
+      activate :relative_assets
+      activate :directory_indexes
+      require 'lib/middleware.rb'
+      use Middleware
+      """
+    When I go to "/"
+    Then I should see 'href="stylesheets/site-d7d72dc2.css'

--- a/middleman-more/fixtures/asset-hash-app/lib/middleware.rb
+++ b/middleman-more/fixtures/asset-hash-app/lib/middleware.rb
@@ -1,0 +1,16 @@
+class Middleware
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    status, headers, response = @app.call(env)
+    body = ''
+    response.each {|part| body += part }
+    if (env["PATH_INFO"] =~ /css$/)
+      body += "\n/* Added by Rack filter */"
+      status, headers, response = Rack::Response.new(body, status, headers).finish
+    end
+    [status, headers, response]
+  end
+end


### PR DESCRIPTION
I know bhollis is assigned to #558, but thought I'd get the ball rolling (and finally contribute something more significant than a typo-fix) with a failing test for asset_hashing rack-filtered output.

FWIW, the sprockets-specific tests bhollis was looking for still exist, they just live in the middleman-sprockets repo now. As expected, they're currently failing.

I don't mean to step on bhollis's toes, so no worries if you don't want to merge.
