### PR TITLE
Can not start the server when i use Compass (0.12.2) and Sass (3.2.0)

### DIFF
--- a/middleman-core/lib/middleman-core/renderers/sass.rb
+++ b/middleman-core/lib/middleman-core/renderers/sass.rb
@@ -14,6 +14,11 @@ module Middleman
           # Default sass options
           app.set :sass, {}
 
+          # Location of SASS/SCSS files external to source directory.
+          # @return [Array]
+          #   set :sass_assets_paths, ["#{root}/assets/sass/", "/path/2/external/sass/repository/"]
+          app.set :sass_assets_paths, []
+
           # Location of SASS .sass_cache directory.
           # @return [String]
           #   set :sass_cache_path, "/tmp/middleman-app-name/sass_cache"
@@ -41,12 +46,12 @@ module Middleman
 
         def initialize(*args, &block)
           super
-          
+
           if @options.has_key?(:context)
             @context = @options[:context]
           end
         end
-        
+
         # Define the expected syntax for the template
         # @return [Symbol]
         def syntax
@@ -74,15 +79,15 @@ module Middleman
         # @return [Hash]
         def sass_options
           more_opts = { :filename => eval_file, :line => line, :syntax => syntax }
-          
+
           if @context.is_a?(::Middleman::Application) && file
             location_of_sass_file = File.expand_path(@context.source, @context.root)
-          
+
             parts = basename.split('.')
             parts.pop
             more_opts[:css_filename] = File.join(location_of_sass_file, @context.css_dir, parts.join("."))
           end
-          
+
           options.merge(more_opts)
         end
       end

--- a/middleman-more/lib/middleman-more/core_extensions/compass.rb
+++ b/middleman-more/lib/middleman-more/core_extensions/compass.rb
@@ -17,11 +17,6 @@ module Middleman
           # done with it
           app.define_hook :compass_config
 
-          # Location of SASS/SCSS files external to source directory.
-          # @return [Array]
-          #   set :sass_assets_paths, ["#{root}/assets/sass/", "/path/2/external/sass/repository/"]
-          app.set :sass_assets_paths, []
-
           app.after_configuration do
             ::Compass.configuration do |config|
               config.project_path    = source_dir


### PR DESCRIPTION
When i use Compass (0.12.2) and Sass (3.2.0), i can not start the server.

Gemfile: 

``` ruby
group :development do
  gem 'middleman', '3.0.2'
  gem 'compass', '0.12.2'
  gem 'susy', '1.0'
end
```

I got the error:

```
$ middleman
== The Middleman is loading
/Users/Daniel/.rvm/gems/ruby-1.9.3-p194/gems/middleman-more-3.0.2/lib/middleman-more/core_extensions/compass.rb:31:in `block (2 levels) in registered': undefined local variable or method `sass_assets_paths' for #<Middleman::Application> (NameError)
    from /Users/Daniel/.rvm/gems/ruby-1.9.3-p194/gems/compass-0.12.2/lib/compass/configuration/helpers.rb:9:in `configuration'
    from /Users/Daniel/.rvm/gems/ruby-1.9.3-p194/gems/middleman-more-3.0.2/lib/middleman-more/core_extensions/compass.rb:26:in `block in registered'
    from /Users/Daniel/.rvm/gems/ruby-1.9.3-p194/gems/middleman-core-3.0.2/lib/middleman-core/vendor/hooks-0.2.0/lib/hooks.rb:53:in `instance_exec'
    from /Users/Daniel/.rvm/gems/ruby-1.9.3-p194/gems/middleman-core-3.0.2/lib/middleman-core/vendor/hooks-0.2.0/lib/hooks.rb:53:in `block in run_hook_for'
    from /Users/Daniel/.rvm/gems/ruby-1.9.3-p194/gems/middleman-core-3.0.2/lib/middleman-core/vendor/hooks-0.2.0/lib/hooks.rb:49:in `each'
    from /Users/Daniel/.rvm/gems/ruby-1.9.3-p194/gems/middleman-core-3.0.2/lib/middleman-core/vendor/hooks-0.2.0/lib/hooks.rb:49:in `run_hook_for'
    from /Users/Daniel/.rvm/gems/ruby-1.9.3-p194/gems/middleman-core-3.0.2/lib/middleman-core/vendor/hooks-0.2.0/lib/hooks.rb:107:in `run_hook'
    from /Users/Daniel/.rvm/gems/ruby-1.9.3-p194/gems/middleman-core-3.0.2/lib/middleman-core/core_extensions/extensions.rb:151:in `initialize'
    from /Users/Daniel/.rvm/gems/ruby-1.9.3-p194/gems/middleman-core-3.0.2/lib/middleman-core/core_extensions/data.rb:35:in `initialize'
    from /Users/Daniel/.rvm/gems/ruby-1.9.3-p194/gems/middleman-core-3.0.2/lib/middleman-core/application.rb:192:in `initialize'
    from /Users/Daniel/.rvm/gems/ruby-1.9.3-p194/gems/middleman-core-3.0.2/lib/middleman-core/core_extensions/request.rb:57:in `new'
    from /Users/Daniel/.rvm/gems/ruby-1.9.3-p194/gems/middleman-core-3.0.2/lib/middleman-core/core_extensions/request.rb:57:in `inst'
    from /Users/Daniel/.rvm/gems/ruby-1.9.3-p194/gems/middleman-core-3.0.2/lib/middleman-core/preview_server.rb:18:in `start'
    from /Users/Daniel/.rvm/gems/ruby-1.9.3-p194/gems/middleman-core-3.0.2/lib/middleman-core/cli/server.rb:63:in `server'
    from /Users/Daniel/.rvm/gems/ruby-1.9.3-p194/gems/thor-0.15.4/lib/thor/task.rb:27:in `run'
    from /Users/Daniel/.rvm/gems/ruby-1.9.3-p194/gems/thor-0.15.4/lib/thor/invocation.rb:120:in `invoke_task'
    from /Users/Daniel/.rvm/gems/ruby-1.9.3-p194/gems/thor-0.15.4/lib/thor.rb:275:in `dispatch'
    from /Users/Daniel/.rvm/gems/ruby-1.9.3-p194/gems/thor-0.15.4/lib/thor/base.rb:425:in `start'
    from /Users/Daniel/.rvm/gems/ruby-1.9.3-p194/gems/middleman-core-3.0.2/lib/middleman-core/cli.rb:77:in `method_missing'
    from /Users/Daniel/.rvm/gems/ruby-1.9.3-p194/gems/thor-0.15.4/lib/thor/task.rb:29:in `run'
    from /Users/Daniel/.rvm/gems/ruby-1.9.3-p194/gems/thor-0.15.4/lib/thor/task.rb:126:in `run'
    from /Users/Daniel/.rvm/gems/ruby-1.9.3-p194/gems/thor-0.15.4/lib/thor/invocation.rb:120:in `invoke_task'
    from /Users/Daniel/.rvm/gems/ruby-1.9.3-p194/gems/thor-0.15.4/lib/thor.rb:275:in `dispatch'
    from /Users/Daniel/.rvm/gems/ruby-1.9.3-p194/gems/thor-0.15.4/lib/thor/base.rb:425:in `start'
    from /Users/Daniel/.rvm/gems/ruby-1.9.3-p194/gems/middleman-core-3.0.2/lib/middleman-core/cli.rb:22:in `start'
    from /Users/Daniel/.rvm/gems/ruby-1.9.3-p194/gems/middleman-core-3.0.2/bin/middleman:25:in `<top (required)>'
    from /Users/Daniel/.rvm/gems/ruby-1.9.3-p194/bin/middleman:19:in `load'
    from /Users/Daniel/.rvm/gems/ruby-1.9.3-p194/bin/middleman:19:in `<main>'
    from /Users/Daniel/.rvm/gems/ruby-1.9.3-p194/bin/ruby_noexec_wrapper:14:in `eval'
    from /Users/Daniel/.rvm/gems/ruby-1.9.3-p194/bin/ruby_noexec_wrapper:14:in `<main>'
```
