### PR TITLE
Please create a "--skip-bundle" flag for middleman init

### DIFF
--- a/middleman-core/lib/middleman-core/cli/init.rb
+++ b/middleman-core/lib/middleman-core/cli/init.rb
@@ -28,10 +28,18 @@ module Middleman::Cli
       :type    => :boolean,
       :default => false,
       :desc    => 'Include a config.ru file'
-    method_option "bundler",
+    method_option "skip-gemfile",
       :type    => :boolean,
       :default => false,
-      :desc    => 'Create a Gemfile and use Bundler to manage gems'
+      :desc    => "Don't create a Gemfile"
+    method_option "skip-bundle",
+      :type    => :boolean,
+      :default => false,
+      :desc    => "Don't run bundle install"
+    method_option "skip-git",
+      :type    => :boolean,
+      :default => false,
+      :desc    => 'Skip Git ignores and keeps'
     # The init task
     # @param [String] name
     def init(name)

--- a/middleman-core/lib/middleman-core/templates.rb
+++ b/middleman-core/lib/middleman-core/templates.rb
@@ -50,23 +50,28 @@ module Middleman::Templates
       template "shared/config.ru", File.join(location, "config.ru")
     end
 
+    class_option :'skip-bundle', :type => :boolean, :default => false
+    class_option :'skip-gemfile', :type => :boolean, :default => false
+
     # Write a Bundler Gemfile file for project
     # @return [void]
     def generate_bundler!
+      return if options[:'skip-gemfile']
       template "shared/Gemfile.tt", File.join(location, "Gemfile")
 
+      return if options[:'skip-bundle']
       inside(location) do
         ::Middleman::Cli::Bundle.new.invoke(:bundle)
       end unless ENV["TEST"]
     end
 
     # Output a .gitignore file
-    class_option :git, :type => :boolean, :default => true
+    class_option :'skip-git', :type => :boolean, :default => false
 
     # Write a .gitignore file for project
     # @return [void]
     def generate_gitignore!
-      return unless options[:git]
+      return if options[:'skip-git']
       copy_file "shared/gitignore", File.join(location, ".gitignore")
     end
   end


### PR DESCRIPTION
Hello. Thank you for the continuing excellent work on Middleman.

Ruby on Rails' 'rails new PATH' command allows for a flag "--skip-bundle" which prevents bundler from being run automatically after the creation of a new site skeleton. There are some circumstances where a person might want to manage the installation of gems himself whether or not with the use of bundler. Personally, I like to run 'middleman init' as a regular system user and to have Ruby and RubyGems installed globally. On my system I need to run 'bundle install' as a super user in order to do that. Allowing a flag like "--skip-bundle" could allow for the creation of the site skeleton while preserving the installation of gems for the user in a second, modified step. I do not think this should be default, just that there should be an optional flag.

Thanks for your consideration.
