### PR TITLE
Print a helpful message when encountering an unknown command

### DIFF
--- a/middleman-core/lib/middleman-core/cli.rb
+++ b/middleman-core/lib/middleman-core/cli.rb
@@ -71,7 +71,7 @@ module Middleman
         end
 
         if klass.nil?
-          super
+          raise Thor::Error.new "There's no '#{meth}' command for Middleman. Try 'middleman help' for a list of commands."
         else
           args.unshift(task) if task
           klass.start(args, :shell => self.shell)


### PR DESCRIPTION
Instead of a nasty stack trace. Prevents issues like #563.
