### PR TITLE
Upgrade proxy to be able to take :locals and understand :ignore

### DIFF
--- a/middleman-core/features/proxy_pages.feature
+++ b/middleman-core/features/proxy_pages.feature
@@ -1,0 +1,94 @@
+Feature: Proxy Pages (using proxy rather than page)
+  In order to use a single view to generate multiple output files
+
+  Scenario: Checking built folder for content
+    Given a successfully built app at "proxy-pages-app"
+    When I cd to "build"
+    Then the following files should exist:
+      | fake.html                                     |
+      | fake2.html                                    |
+      | fake3.html                                    |
+      | fake4.html                                    |
+      | fake/one.html                                 |
+      | fake/two.html                                 |
+      | fake2/one.html                                |
+      | fake2/two.html                                |
+      | fake3/one.html                                |
+      | fake3/two.html                                |
+      | fake4/one.html                                |
+      | fake4/two.html                                |
+      | target_ignore.html                            |
+      | target_ignore2.html                           |
+      | target_ignore3.html                           |
+      | target_ignore4.html                           |
+      | 明日がある.html                               |
+    Then the following files should not exist:
+      | should_be_ignored6.html                       |
+      | should_be_ignored7.html                       |
+      | should_be_ignored8.html                       |
+    
+  Scenario: Preview basic proxy
+    Given the Server is running at "proxy-pages-app"
+    When I go to "/fake.html"
+    Then I should see "I am real"
+    When I go to "/fake2.html"
+    Then I should see "I am real"
+    When I go to "/fake3.html"
+    Then I should see "I am real"
+    When I go to "/fake4.html"
+    Then I should see "I am real"
+    
+  Scenario: Preview proxy with variable one
+    Given the Server is running at "proxy-pages-app"
+    When I go to "/fake/one.html"
+    Then I should see "I am real: one"
+    
+    When I go to "/fake2/one.html"
+    Then I should see "I am real: one"
+    
+    When I go to "/fake3/one.html"
+    Then I should see "I am real: one"
+    
+    When I go to "/fake4/one.html"
+    Then I should see "I am real: one"
+    
+  Scenario: Preview proxy with variable two
+    Given the Server is running at "proxy-pages-app"
+    When I go to "/fake/two.html"
+    Then I should see "I am real: two"
+    
+    When I go to "/fake2/two.html"
+    Then I should see "I am real: two"
+    
+    When I go to "/fake3/two.html"
+    Then I should see "I am real: two"
+    
+    When I go to "/fake4/two.html"
+    Then I should see "I am real: two"
+
+  Scenario: Build proxy with variable one
+    Given a successfully built app at "proxy-pages-app"
+    When I cd to "build"
+    Then the file "fake/one.html" should contain "I am real: one"
+    Then the file "fake2/one.html" should contain "I am real: one"
+    Then the file "fake3/one.html" should contain "I am real: one"
+    
+  Scenario: Target ignore
+    Given the Server is running at "proxy-pages-app"
+    When I go to "/target_ignore.html"
+    Then I should see "Ignore me! 3"
+    When I go to "/target_ignore2.html"
+    Then I should see "Ignore me! 6"
+    When I go to "/target_ignore3.html"
+    Then I should see "Ignore me! 7"
+    When I go to "/target_ignore4.html"
+    Then I should see "Ignore me! 8"
+    
+  Scenario: Preview ignored paths
+    Given the Server is running at "proxy-pages-app"
+    When I go to "/should_be_ignored6.html"
+    Then I should see "File Not Found"
+    When I go to "/should_be_ignored7.html"
+    Then I should see "File Not Found"
+    When I go to "/should_be_ignored8.html"
+    Then I should see "File Not Found"

--- a/middleman-core/fixtures/proxy-pages-app/config.rb
+++ b/middleman-core/fixtures/proxy-pages-app/config.rb
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+proxy "/fake.html", "/real.html", :layout => false
+proxy "fake2.html", "/real.html", :layout => false
+proxy "fake3.html", "real.html", :layout => false
+proxy "/fake4.html", "real.html", :layout => false
+
+proxy "/target_ignore.html", "/should_be_ignored3.html", :ignore => true
+proxy "target_ignore2.html", "/should_be_ignored6.html", :ignore => true
+proxy "target_ignore3.html", "should_be_ignored7.html", :ignore => true
+proxy "/target_ignore4.html", "should_be_ignored8.html", :ignore => true
+
+%w(one two).each do |num|
+  proxy "/fake/#{num}.html", "/real/index.html", :ignore => true, :locals => { :num => num }
+  proxy "fake2/#{num}.html", "/real/index.html", :ignore => true, :locals => { :num => num }
+  proxy "fake3/#{num}.html", "real/index.html", :ignore => true, :locals => { :num => num }
+  proxy "/fake4/#{num}.html", "real/index-ivars.html", :ignore => true do
+    @num = num
+  end
+end
+
+proxy "明日がある.html", "/real.html", :layout => false

--- a/middleman-core/fixtures/proxy-pages-app/source/real.html
+++ b/middleman-core/fixtures/proxy-pages-app/source/real.html
@@ -1,0 +1,1 @@
+I am real

--- a/middleman-core/fixtures/proxy-pages-app/source/real/index-ivars.html.erb
+++ b/middleman-core/fixtures/proxy-pages-app/source/real/index-ivars.html.erb
@@ -1,0 +1,6 @@
+---
+layout: false
+---
+
+I am real: <%= @num %>
+

--- a/middleman-core/fixtures/proxy-pages-app/source/real/index.html.erb
+++ b/middleman-core/fixtures/proxy-pages-app/source/real/index.html.erb
@@ -1,0 +1,5 @@
+---
+layout: false
+---
+
+I am real: <%= num %>

--- a/middleman-core/fixtures/proxy-pages-app/source/should_be_ignored3.html
+++ b/middleman-core/fixtures/proxy-pages-app/source/should_be_ignored3.html
@@ -1,0 +1,1 @@
+<h1>Ignore me! 3</h1>

--- a/middleman-core/fixtures/proxy-pages-app/source/should_be_ignored6.html
+++ b/middleman-core/fixtures/proxy-pages-app/source/should_be_ignored6.html
@@ -1,0 +1,1 @@
+<h1>Ignore me! 6</h1>

--- a/middleman-core/fixtures/proxy-pages-app/source/should_be_ignored7.html
+++ b/middleman-core/fixtures/proxy-pages-app/source/should_be_ignored7.html
@@ -1,0 +1,1 @@
+<h1>Ignore me! 7</h1>

--- a/middleman-core/fixtures/proxy-pages-app/source/should_be_ignored8.html
+++ b/middleman-core/fixtures/proxy-pages-app/source/should_be_ignored8.html
@@ -1,0 +1,1 @@
+<h1>Ignore me! 8</h1>

--- a/middleman-core/lib/middleman-core/core_extensions/routing.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/routing.rb
@@ -45,9 +45,7 @@ module Middleman
         # @param [Hash] opts
         # @return [void]
         def page(url, opts={}, &block)
-
-          blocks = []
-          blocks << block if block_given?
+          blocks = Array(block)
 
           # Default layout
           opts[:layout] = layout if opts[:layout].nil?
@@ -70,20 +68,12 @@ module Middleman
           end
 
           # Setup proxy
-          if opts.has_key?(:proxy)
-            proxy(url, opts[:proxy])
-
-            if opts.has_key?(:ignore) && opts[:ignore]
-              ignore(opts[:proxy])
-              opts.delete(:ignore)
-            end
-
-            opts.delete(:proxy)
-          else
-            if opts.has_key?(:ignore) && opts[:ignore]
-              ignore(url)
-              opts.delete(:ignore)
-            end
+          if target = opts.delete(:proxy)
+            # TODO: deprecate proxy through page?
+            proxy(url, target, opts, &block) and return
+          elsif opts.delete(:ignore)
+            # TODO: deprecate ignore through page?
+            ignore(url)
           end
 
           # Setup a metadata matcher for rendering those options

--- a/middleman-core/lib/middleman-core/sitemap/extensions/ignores.rb
+++ b/middleman-core/lib/middleman-core/sitemap/extensions/ignores.rb
@@ -60,8 +60,6 @@ module Middleman
           # @param [String, Regexp] path Path glob expression, or path regex
           # @return [void]
           def ignore(path=nil, &block)
-            original_callback_size = @ignored_callbacks.size
-
             if path.is_a? Regexp
               @ignored_callbacks << Proc.new {|p| p =~ path }
             elsif path.is_a? String

--- a/middleman-core/lib/middleman-core/sitemap/store.rb
+++ b/middleman-core/lib/middleman-core/sitemap/store.rb
@@ -115,19 +115,10 @@ module Middleman
       # @param [Symbol] origin an indicator of where this metadata came from - only one
       #                        block per [matcher, origin] pair may exist.
       # @return [Array<Array<Proc, Regexp>>]
-      def provides_metadata_for_path(matcher=nil, origin=nil, &block)
+      def provides_metadata_for_path(matcher=nil, &block)
         @_provides_metadata_for_path ||= []
         if block_given?
-          if origin
-            existing_provider = @_provides_metadata_for_path.find {|b,m,o| o == origin && m == matcher}
-          end
-
-          if existing_provider
-            existing_provider[0] = block
-          else
-            @_provides_metadata_for_path << [block, matcher, origin]
-          end
-
+          @_provides_metadata_for_path << [block, matcher]
           @_cached_metadata = {}
         end
         @_provides_metadata_for_path
@@ -151,10 +142,7 @@ module Middleman
 
           metadata = callback.call(request_path)
 
-          if metadata.has_key?(:blocks)
-            result[:blocks] << metadata[:blocks]
-            metadata.delete(:blocks)
-          end
+          result[:blocks] += Array(metadata.delete(:blocks))
 
           result.deep_merge(metadata)
         end


### PR DESCRIPTION
And store proxy options and metadata with the proxy list.

This allows users to use `proxy` directly instead of `page` to create dynamic pages, and improves performance of dynamic pages for sites that create many proxies. It also allows people to use locals instead of instance variables, which are better for partials and reduce the risk of overwriting Middleman settings.

Once this is in, I'll update the documentation to recommend `proxy` with `:locals` instead of `page` with a block for creating dynamic pages. I think we should probably emit a deprecation warning for using page to set up proxy and ignore at some point. 

I tried this out with a Middleman project that generates 70,000 pages via proxies (courtesy of @metadata) and this change speeds it up by quite a bit - pages fly by in build instead of taking around a second per page. Note that users of `page` get these benefits as well, since `page` now just reroutes to `proxy` for proxies.
