### PR TITLE
Fix asset hash generation in combination with sprockets.

### DIFF
--- a/middleman-more/features/asset_hash.feature
+++ b/middleman-more/features/asset_hash.feature
@@ -9,7 +9,7 @@ Feature: Assets get a file hash appended to their and references to them are upd
       | images/100px-1242c368.png |
       | images/100px-5fd6fb90.jpg |
       | images/100px-5fd6fb90.gif |
-      | javascripts/application-1d8d5276.js |
+      | javascripts/application-9b3adada.js |
       | stylesheets/site-50eaa978.css |
       | index.html |
       | subdir/index.html |
@@ -20,41 +20,41 @@ Feature: Assets get a file hash appended to their and references to them are upd
       | images/100px.gif |
       | javascripts/application.js |
       | stylesheets/site.css |
-      
-    And the file "javascripts/application-1d8d5276.js" should contain "img.src = '/images/100px-5fd6fb90.jpg'"
+
+    And the file "javascripts/application-9b3adada.js" should contain "img.src = '/images/100px-5fd6fb90.jpg'"
     And the file "stylesheets/site-50eaa978.css" should contain "background-image: url('../images/100px-5fd6fb90.jpg')"
     And the file "index.html" should contain 'href="apple-touch-icon.png"'
     And the file "index.html" should contain 'href="stylesheets/site-50eaa978.css"'
-    And the file "index.html" should contain 'src="javascripts/application-1d8d5276.js"'
+    And the file "index.html" should contain 'src="javascripts/application-9b3adada.js"'
     And the file "index.html" should contain 'src="images/100px-5fd6fb90.jpg"'
     And the file "subdir/index.html" should contain 'href="../stylesheets/site-50eaa978.css"'
-    And the file "subdir/index.html" should contain 'src="../javascripts/application-1d8d5276.js"'
+    And the file "subdir/index.html" should contain 'src="../javascripts/application-9b3adada.js"'
     And the file "subdir/index.html" should contain 'src="../images/100px-5fd6fb90.jpg"'
     And the file "other/index.html" should contain 'href="../stylesheets/site-50eaa978.css"'
-    And the file "other/index.html" should contain 'src="../javascripts/application-1d8d5276.js"'
+    And the file "other/index.html" should contain 'src="../javascripts/application-9b3adada.js"'
     And the file "other/index.html" should contain 'src="../images/100px-5fd6fb90.jpg"'
-    
+
   Scenario: Hashed assets work in preview server
     Given the Server is running at "asset-hash-app"
     When I go to "/"
     Then I should see 'href="apple-touch-icon.png"'
     And I should see 'href="stylesheets/site-50eaa978.css"'
-    And I should see 'src="javascripts/application-1d8d5276.js"'
+    And I should see 'src="javascripts/application-9b3adada.js"'
     And I should see 'src="images/100px-5fd6fb90.jpg"'
     When I go to "/subdir/"
     Then I should see 'href="../stylesheets/site-50eaa978.css"'
-    And I should see 'src="../javascripts/application-1d8d5276.js"'
+    And I should see 'src="../javascripts/application-9b3adada.js"'
     And I should see 'src="../images/100px-5fd6fb90.jpg"'
     When I go to "/other/"
     Then I should see 'href="../stylesheets/site-50eaa978.css"'
-    And I should see 'src="../javascripts/application-1d8d5276.js"'
+    And I should see 'src="../javascripts/application-9b3adada.js"'
     And I should see 'src="../images/100px-5fd6fb90.jpg"'
-    When I go to "/javascripts/application-1d8d5276.js"
+    When I go to "/javascripts/application-9b3adada.js"
     Then I should see "img.src = '/images/100px-5fd6fb90.jpg'"
     When I go to "/stylesheets/site-50eaa978.css"
     Then I should see "background-image: url('../images/100px-5fd6fb90.jpg')"
 
-  Scenario: Enabling an asset host still produces hashed files and references  
+  Scenario: Enabling an asset host still produces hashed files and references
     Given the Server is running at "asset-hash-host-app"
     When I go to "/"
     Then I should see 'href="http://middlemanapp.com/stylesheets/site-171eb3c0.css"'
@@ -104,3 +104,21 @@ Feature: Assets get a file hash appended to their and references to them are upd
     Then I should see 'Added by Rack filter'
     When I go to "stylesheets/site-50eaa978.css"
     Then I should see 'Not Found'
+
+  Scenario: The asset hash should change when a JavaScript dependency changes
+    Given the Server is running at "asset-hash-app"
+    And the file "source/javascripts/library.js" has the contents
+      """
+      /* Example JS library */
+      document.documentElement.className = "js";
+      """
+    When I go to "/"
+    Then I should see 'src="javascripts/application-9b3adada.js"'
+    Given the Server is running at "asset-hash-app"
+    And the file "source/javascripts/library.js" has the contents
+      """
+      /* Example JS library v2 */
+      document.documentElement.className = "javascript";
+      """
+    When I go to "/"
+    Then I should see 'src="javascripts/application-496e97c8.js"'

--- a/middleman-more/fixtures/asset-hash-app/config.rb
+++ b/middleman-more/fixtures/asset-hash-app/config.rb
@@ -1,8 +1,11 @@
+require "middleman-sprockets"
 
 activate :asset_hash
 
 activate :relative_assets
 
 activate :directory_indexes
+
+activate :sprockets
 
 #page '/foo.html', :directory_index => false

--- a/middleman-more/fixtures/asset-hash-app/source/javascripts/application.js
+++ b/middleman-more/fixtures/asset-hash-app/source/javascripts/application.js
@@ -1,3 +1,7 @@
+/*
+ *= require "./library"
+ */
+
 function foo() {
   var img = document.createElement('img');
   img.src = '/images/100px.jpg';

--- a/middleman-more/fixtures/asset-hash-app/source/javascripts/library.js
+++ b/middleman-more/fixtures/asset-hash-app/source/javascripts/library.js
@@ -1,0 +1,2 @@
+/* Example JS library */
+document.documentElement.className = "js";

--- a/middleman-more/lib/middleman-more/extensions/asset_hash.rb
+++ b/middleman-more/lib/middleman-more/extensions/asset_hash.rb
@@ -39,16 +39,12 @@ module Middleman
             next unless @exts.include? resource.ext
             next if @ignore.any? { |ignore| Middleman::Util.path_match(ignore, resource.destination_path) }
 
-            if resource.template? # if it's a template, render it out
-              # Render through the Rack interface so middleware and mounted apps get a shot
-              rack_client = ::Rack::Test::Session.new(@app.class)
-              response = rack_client.get(URI.escape(resource.destination_path), {}, { "bypass_asset_hash" => true })
-              raise "#{resource.path} should be in the sitemap!" unless response.status == 200
+            # Render through the Rack interface so middleware and mounted apps get a shot
+            rack_client = ::Rack::Test::Session.new(@app.class)
+            response = rack_client.get(URI.escape(resource.destination_path), {}, { "bypass_asset_hash" => true })
+            raise "#{resource.path} should be in the sitemap!" unless response.status == 200
 
-              digest = Digest::SHA1.hexdigest(response.body)[0..7]
-            else # if it's a static file, just hash it
-              digest = Digest::SHA1.file(resource.source_file).hexdigest[0..7]
-            end
+            digest = Digest::SHA1.hexdigest(response.body)[0..7]
 
             resource.destination_path = resource.destination_path.sub(/\.(\w+)$/) { |ext| "-#{digest}#{ext}" }
           end


### PR DESCRIPTION
Hi!

I was having some problems where the asset hash generated by middleman was not updated when my assets changed.

I'm using `middleman-sprockets` and include a couple of Javascript file from `javascript/site.js`. Whenever a dependency is updated but the main Javascript file remains the same the asset hash does _not_ change. This causes problems for visitors whenever something is updated.

Apparently Middleman only looks at the entire result if the file is a template. In my case it's not a template, it's processed by Sprockets.

This PR fixes the problem by simply using a digest of the output in all cases, whether it's a template or not. A test for this scenario is included as well.
