### PR TITLE
Fix asset hash generation in combination with sprockets.

### DIFF
--- a/middleman-more/lib/middleman-more/extensions/asset_hash.rb
+++ b/middleman-more/lib/middleman-more/extensions/asset_hash.rb
@@ -39,16 +39,12 @@ module Middleman
             next unless @exts.include? resource.ext
             next if @ignore.any? { |ignore| Middleman::Util.path_match(ignore, resource.destination_path) }
 
-            if resource.template? # if it's a template, render it out
-              # Render through the Rack interface so middleware and mounted apps get a shot
-              rack_client = ::Rack::Test::Session.new(@app.class)
-              response = rack_client.get(URI.escape(resource.destination_path), {}, { "bypass_asset_hash" => true })
-              raise "#{resource.path} should be in the sitemap!" unless response.status == 200
+            # Render through the Rack interface so middleware and mounted apps get a shot
+            rack_client = ::Rack::Test::Session.new(@app.class)
+            response = rack_client.get(URI.escape(resource.destination_path), {}, { "bypass_asset_hash" => true })
+            raise "#{resource.path} should be in the sitemap!" unless response.status == 200
 
-              digest = Digest::SHA1.hexdigest(response.body)[0..7]
-            else # if it's a static file, just hash it
-              digest = Digest::SHA1.file(resource.source_file).hexdigest[0..7]
-            end
+            digest = Digest::SHA1.hexdigest(response.body)[0..7]
 
             resource.destination_path = resource.destination_path.sub(/\.(\w+)$/) { |ext| "-#{digest}#{ext}" }
           end


### PR DESCRIPTION
This is a duplicate of #640, but targeted to `3.0-stable`.

---

I was having some problems where the asset hash generated by middleman was not updated when my assets changed.

I'm using middleman-sprockets and include a couple of Javascript file from javascript/site.js. Whenever a dependency is updated but the main Javascript file remains the same the asset hash does not change. This causes problems for visitors whenever something is updated.

Apparently Middleman only looks at the entire result if the file is a template. In my case it's not a template, it's processed by Sprockets.

This PR fixes the problem by simply using a digest of the output in all cases, whether it's a template or not. A test for this scenario is included as well.
