### PR TITLE
Fixing automatic_image_sizes to eliminate warnings on vector images

### DIFF
--- a/middleman-more/lib/middleman-more/extensions/automatic_image_sizes.rb
+++ b/middleman-more/lib/middleman-more/extensions/automatic_image_sizes.rb
@@ -30,7 +30,11 @@ module Middleman
         # @param [Hash] params
         # @return [String]
         def image_tag(path, params={})
-          if !params.has_key?(:width) && !params.has_key?(:height) && !path.include?("://")
+          params[:supported_extensions] ||= %w(.png .jpg .jpeg .bmp .gif)
+          
+          if !params.has_key?(:width) && !params.has_key?(:height) && !path.include?("://") &&
+            params[:supported_extensions].include?(File.extname(path).downcase)
+            
             params[:alt] ||= ""
 
             real_path = path


### PR DESCRIPTION
Hi,

Vector images are sometimes used (particularly SVGs). In my current project, I have SVG images inside img tags. The automatic_image_sizes helper is great for my PNGs, but for my SVGs, it's constantly throwing out the following exceptions on the CLI: `Couldn't determine dimensions for image gap.svg:`

This code is very simple: it just checks the path in the image_helper and looks for a supported image type. The list of extensions was generated by the FastImage documentation, which states: "FastImage does this minimal fetch for image types GIF, JPEG, PNG and BMP."

You can override this behavior, however, by passing param :supported_extensions into the image_tag helper, which takes an array of image extensions you'd like the helper to process through FastImage.

I'm open to another suggested approach, but these exceptions are quite annoying to have as part of my build process, and sometimes SVGs are nice to use. Especially in the current web world where retina displays, and all sorts of adaptive sized layouts are becoming increasingly popular, it's nice not to have to scale your images to generate tons of sizes.

Let me know what you think, and if you'd like to take another approach. I'm all for it :)

Regards,
Daniel
