### PR TITLE
Changed log message when middleman starts.

### DIFF
--- a/middleman-core/lib/middleman-core/preview_server.rb
+++ b/middleman-core/lib/middleman-core/preview_server.rb
@@ -3,7 +3,6 @@ require "webrick"
 module Middleman
   module PreviewServer
 
-    DEFAULT_HOST = '0.0.0.0'
     DEFAULT_PORT = 4567
 
     class << self
@@ -14,7 +13,7 @@ module Middleman
       # @return [void]
       def start(opts={})
         @options = opts
-        @host = @options[:host] || DEFAULT_HOST
+        @host = @options[:host] || Socket.gethostname
         @port = @options[:port] || DEFAULT_PORT
 
         mount_instance


### PR DESCRIPTION
Old message: 

```
== The Middleman is standing watch on port 4567
```

New message: 

```
The Middleman is standing watch at http://0.0.0.0:4567
```

The URL in the message makes it clickable if the terminal supports it.
