### PR TITLE
turn html5 boilerplate into a layout

### DIFF
--- a/middleman-core/lib/middleman-core/templates/html5/source/index.html.erb
+++ b/middleman-core/lib/middleman-core/templates/html5/source/index.html.erb
@@ -1,0 +1,6 @@
+---
+title: HTML5 Boilerplate Middleman
+---
+
+<!-- Add your site or application content here -->
+<p>Hello world! This is HTML5 Boilerplate.</p>

--- a/middleman-core/lib/middleman-core/templates/html5/source/layouts/layout.erb
+++ b/middleman-core/lib/middleman-core/templates/html5/source/layouts/layout.erb
@@ -6,7 +6,8 @@
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-        <title></title>
+        <!-- Use title if it's in the page YAML frontmatter -->
+        <title><%= data.page.title || "HTML5 Boilerplate" %></title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
 
@@ -21,8 +22,7 @@
             <p class="chromeframe">You are using an outdated browser. <a href="http://browsehappy.com/">Upgrade your browser today</a> or <a href="http://www.google.com/chromeframe/?redirect=true">install Google Chrome Frame</a> to better experience this site.</p>
         <![endif]-->
 
-        <!-- Add your site or application content here -->
-        <p>Hello world! This is HTML5 Boilerplate.</p>
+        <%= yield %>
 
         <script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.0/jquery.min.js"></script>
         <script>window.jQuery || document.write('<script src="js/vendor/jquery-1.8.0.min.js"><\/script>')</script>


### PR DESCRIPTION
This is a very lightweight change to them html5 template, to use h5bp as a default layout for the template, instead of a default page. This is a really really subtle change when compared to #561
