### PR TITLE
adds libv8 to the Gemfile, fixes #680

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ group :test do
 
   platforms :ruby do
     gem "therubyracer", :require => 'v8'
-    gem "libv8", "~> 3.11.8"
+    gem "libv8", "3.11.8.3"
     
     gem "redcarpet", "~> 2.1.1"
   end


### PR DESCRIPTION
I'm a little bit worried that adding libv8 might make the travis build go over the timeout limit, as mentioned in [StackOverflow](http://stackoverflow.com/a/13714292/207119)

> Just note that `libv8` can take a significant amount of time to install and I've noticed that it may end up being the cause of going over [Travis CI's timeout limits](http://about.travis-ci.org/docs/user/build-configuration/#Build-Timeouts), causing your build to fail.

Let's see how Travis handles this. If it fails, we can always lock therubyracer to 0.10
