### PR TITLE
Adding ejs as a dependency in middleman-more

### DIFF
--- a/middleman-more/middleman-more.gemspec
+++ b/middleman-more/middleman-more.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency("compass", [">= 0.12.2"])
   s.add_dependency("coffee-script", ["~> 2.2.0"])
   s.add_dependency("coffee-script-source", ["~> 1.3.3"])
+  s.add_dependency("ejs", ["~> 1.1.1"])
   s.add_dependency("execjs", ["~> 1.4.0"])
   s.add_dependency("maruku", ["~> 0.6.0"])
   s.add_dependency("i18n", ["~> 0.6.0"])


### PR DESCRIPTION
When trying to run the `bundle exec middleman`, an error is thrown saying that ejs can not be loaded. Adding `gem 'ejs'` to the Gemfile fixes the issue. I'm pretty sure there aren't any ejs files in our app, so I'm not sure why it is getting loaded at all. If it is needed for middleman, then it should be added as a dependency in middleman-more.

```
== The Middleman is loading
/Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/tilt-1.3.3/lib/tilt/template.rb:108:in `require': cannot load such file -- ejs (LoadError)
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/tilt-1.3.3/lib/tilt/template.rb:108:in `require_template_library'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/sprockets-2.4.5/lib/sprockets/ejs_template.rb:20:in `initialize_engine'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/tilt-1.3.3/lib/tilt/template.rb:55:in `initialize'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/tilt-1.3.3/lib/tilt.rb:98:in `new'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/tilt-1.3.3/lib/tilt.rb:98:in `block in []'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/tilt-1.3.3/lib/tilt.rb:96:in `each'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/tilt-1.3.3/lib/tilt.rb:96:in `[]'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/middleman-core-3.0.7/lib/middleman-core/sitemap/store.rb:189:in `extensionless_path'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/middleman-core-3.0.7/lib/middleman-core/sitemap/store.rb:178:in `file_to_path'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/middleman-core-3.0.7/lib/middleman-core/sitemap/extensions/on_disk.rb:45:in `touch_file'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/middleman-core-3.0.7/lib/middleman-core/sitemap/extensions/on_disk.rb:24:in `block in initialize'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/middleman-core-3.0.7/lib/middleman-core/core_extensions/file_watcher.rb:158:in `instance_exec'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/middleman-core-3.0.7/lib/middleman-core/core_extensions/file_watcher.rb:158:in `block in run_callbacks'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/middleman-core-3.0.7/lib/middleman-core/core_extensions/file_watcher.rb:156:in `each'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/middleman-core-3.0.7/lib/middleman-core/core_extensions/file_watcher.rb:156:in `run_callbacks'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/middleman-core-3.0.7/lib/middleman-core/core_extensions/file_watcher.rb:94:in `did_change'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/middleman-core-3.0.7/lib/middleman-core/core_extensions/file_watcher.rb:126:in `block (2 levels) in reload_path'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/middleman-core-3.0.7/lib/middleman-core/core_extensions/file_watcher.rb:122:in `each'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/middleman-core-3.0.7/lib/middleman-core/core_extensions/file_watcher.rb:122:in `block in reload_path'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/middleman-core-3.0.7/lib/middleman-core/core_extensions/file_watcher.rb:115:in `chdir'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/middleman-core-3.0.7/lib/middleman-core/core_extensions/file_watcher.rb:115:in `reload_path'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/middleman-core-3.0.7/lib/middleman-core/core_extensions/file_watcher.rb:37:in `block in registered'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/middleman-core-3.0.7/lib/middleman-core/vendor/hooks-0.2.0/lib/hooks.rb:53:in `instance_exec'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/middleman-core-3.0.7/lib/middleman-core/vendor/hooks-0.2.0/lib/hooks.rb:53:in `block in run_hook_for'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/middleman-core-3.0.7/lib/middleman-core/vendor/hooks-0.2.0/lib/hooks.rb:49:in `each'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/middleman-core-3.0.7/lib/middleman-core/vendor/hooks-0.2.0/lib/hooks.rb:49:in `run_hook_for'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/middleman-core-3.0.7/lib/middleman-core/vendor/hooks-0.2.0/lib/hooks.rb:107:in `run_hook'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/middleman-core-3.0.7/lib/middleman-core/core_extensions/request.rb:57:in `inst'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/middleman-core-3.0.7/lib/middleman-core/preview_server.rb:73:in `new_app'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/middleman-core-3.0.7/lib/middleman-core/preview_server.rb:154:in `mount_instance'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/middleman-core-3.0.7/lib/middleman-core/preview_server.rb:19:in `start'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/middleman-core-3.0.7/lib/middleman-core/cli/server.rb:68:in `server'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/thor-0.15.4/lib/thor/task.rb:27:in `run'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/thor-0.15.4/lib/thor/invocation.rb:120:in `invoke_task'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/thor-0.15.4/lib/thor.rb:275:in `dispatch'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/thor-0.15.4/lib/thor/base.rb:425:in `start'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/middleman-core-3.0.7/lib/middleman-core/cli.rb:77:in `method_missing'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/thor-0.15.4/lib/thor/task.rb:29:in `run'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/thor-0.15.4/lib/thor/task.rb:126:in `run'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/thor-0.15.4/lib/thor/invocation.rb:120:in `invoke_task'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/thor-0.15.4/lib/thor.rb:275:in `dispatch'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/thor-0.15.4/lib/thor/base.rb:425:in `start'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/middleman-core-3.0.7/lib/middleman-core/cli.rb:22:in `start'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/middleman-core-3.0.7/bin/middleman:18:in `<top (required)>'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/bin/middleman:23:in `load'
    from /Users/joeytrapp/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/bin/middleman:23:in `<main>'
```
