### PR TITLE
Querystring option for link_to helper 

### DIFF
--- a/middleman-more/lib/middleman-more/core_extensions/default_helpers.rb
+++ b/middleman-more/lib/middleman-more/core_extensions/default_helpers.rb
@@ -158,8 +158,9 @@ module Middleman
                 else
                   new_url = resource.url
                 end
+                qs  = "?#{options.delete(:querystring).to_s}" if options[:querystring]
 
-                args[url_arg_index] = new_url
+                args[url_arg_index] = new_url + qs.to_s
               else
                 raise "No resource exists at #{url}" if relative
               end


### PR DESCRIPTION
New option for link_to helper (:querystring), which appends URL querystring data after MM looks up the URL path
