### PR TITLE
URL not being parsed when using a link with a hash with link_to helper

### DIFF
--- a/middleman-more/features/helpers_link_to.feature
+++ b/middleman-more/features/helpers_link_to.feature
@@ -104,3 +104,15 @@ Feature: link_to helper
     Then I should see '<a href="/needs_index/#foo">Needs Index Anchor</a>'
     Then I should see '<a href="/needs_index/?foo">Needs Index Query</a>'
     Then I should see '<a href="/needs_index/?foo#foo">Needs Index Query and Anchor</a>'
+
+  Scenario: link_to accepts a :query option that appends a query string
+    Given a fixture app "indexable-app"
+    And a file named "source/link_to.html.erb" with:
+    """
+    <%= link_to "Needs Index String", "/needs_index.html", :query => "foo" %>
+    <%= link_to "Needs Index Hash", "/needs_index.html", :query => { :foo => :bar } %>
+    """
+    And the Server is running at "indexable-app"
+    When I go to "/link_to/"
+    Then I should see '<a href="/needs_index/?foo">Needs Index String</a>'
+    Then I should see '<a href="/needs_index/?foo=bar">Needs Index Hash</a>'

--- a/middleman-more/lib/middleman-more/core_extensions/default_helpers.rb
+++ b/middleman-more/lib/middleman-more/core_extensions/default_helpers.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/object/to_query'
+
 module Middleman
   module CoreExtensions
     # Built-in helpers
@@ -113,6 +115,10 @@ module Middleman
         # config[:relative_links] = true
         #
         # to config.rb to have all links default to relative.
+        # 
+        # There is also a :query option that can be used to append a
+        # query string, which can be expressed as either a String,
+        # or a Hash which will be turned into URL parameters.
         def link_to(*args, &block)
           url_arg_index = block_given? ? 0 : 1
           options_index = block_given? ? 1 : 2
@@ -172,6 +178,14 @@ module Middleman
             end
           end
 
+          # Support a :query option that can be a string or hash
+          query = options.delete(:query)
+          if query
+            uri = URI(args[url_arg_index])
+            uri.query = query.respond_to?(:to_param) ? query.to_param : query.to_s
+            args[url_arg_index] = uri.to_s
+          end
+            
           super(*args, &block)
         end
       end


### PR DESCRIPTION
I need to use a link with a hash like that `path/file.html#hash`

the link_to helper should parse the url `path/file.html` and return a link like this `path/file/#hash` when using `active :directory_indexes`

but it is not working the url is not being modified.
