### PR TITLE
supported_extensions attribute was added to the img tag when using image_tag

### DIFF
--- a/middleman-more/lib/middleman-more/extensions/automatic_image_sizes.rb
+++ b/middleman-more/lib/middleman-more/extensions/automatic_image_sizes.rb
@@ -53,6 +53,8 @@ module Middleman
               end
             end
           end
+          
+          params = params.delete_if {|key| key == :supported_extensions }
 
           super(path, params)
         end


### PR DESCRIPTION
Corrected code so that
supported_extensions="[&quot;.png&quot;, &quot;.jpg&quot;, &quot;.jpeg&quot;, &quot;.bmp&quot;, &quot;.gif&quot;]"
would not appear in the img that when using the image_tag helper.
