### PR TITLE
3.0.8/3.0.9 breaks middleman-blog's `tag_path` method

### DIFF
--- a/middleman-more/lib/middleman-more/core_extensions/default_helpers.rb
+++ b/middleman-more/lib/middleman-more/core_extensions/default_helpers.rb
@@ -176,14 +176,13 @@ module Middleman
                 end
               end
             end
-          end
 
-          # Support a :query option that can be a string or hash
-          query = options.delete(:query)
-          if query
-            uri = URI(args[url_arg_index])
-            uri.query = query.respond_to?(:to_param) ? query.to_param : query.to_s
-            args[url_arg_index] = uri.to_s
+            # Support a :query option that can be a string or hash
+            if query = options.delete(:query)
+              uri = URI(args[url_arg_index])
+              uri.query = query.respond_to?(:to_param) ? query.to_param : query.to_s
+              args[url_arg_index] = uri.to_s
+            end
           end
             
           super(*args, &block)


### PR DESCRIPTION
The method `tag_path` returns `nil` for all strings (that I tested it with, at least) for versions after `3.0.7`. With middleman Gemfile-locked to 3.0.7, all is well.

Perhaps something to do with 49ad35b2c8?
