### PR TITLE
Fix Middleman::Util.extract_response_text to follow the Rack spec (and thus work with rack 1.4.3)

### DIFF
--- a/middleman-core/lib/middleman-core/util.rb
+++ b/middleman-core/lib/middleman-core/util.rb
@@ -66,18 +66,12 @@ module Middleman
     # @param response The response from #call
     # @return [String] The whole response as a string.
     def self.extract_response_text(response)
-      case(response)
-      when String
-        response
-      when Array
-        response.join
-      when Rack::Response
-        response.body.join
-      when Rack::File
-        File.read(response.path)
-      else
-        response.to_s
+      # The rack spec states all response bodies must respond to each
+      result = ''
+      response.each do |part, s|
+        result << part
       end
+      result
     end
 
     # Takes a matcher, which can be a literal string


### PR DESCRIPTION
Rack specifies only that response bodies must respond to `each` with some strings, so this changes us to handle that correctly (and it's nicer code too).
