### PR TITLE
More file types for asset hashes

### DIFF
--- a/middleman-more/lib/middleman-more/extensions/asset_hash.rb
+++ b/middleman-more/lib/middleman-more/extensions/asset_hash.rb
@@ -7,7 +7,7 @@ module Middleman
           require 'rack/test'
           require 'uri'
 
-          exts = options[:exts] || %w(.jpg .jpeg .png .gif .js .css .otf .woff .eot .ttf)
+          exts = options[:exts] || %w(.jpg .jpeg .png .gif .js .css .otf .woff .eot .ttf .svg)
 
           # Allow specifying regexes to ignore, plus always ignore apple touch icons
           ignore = Array(options[:ignore]) << /^apple-touch-icon/


### PR DESCRIPTION
- Font files (.otf .woff .eot .ttf)
- SVG images (.svg)

There may be use cases where SVG should not get an asset hash, but it’s still possible to deactivate it for those cases manually.
