### PR TITLE
Update installation command for susy-gem.

### DIFF
--- a/middleman-core/lib/middleman-core/templates/shared/config.tt
+++ b/middleman-core/lib/middleman-core/templates/shared/config.tt
@@ -3,7 +3,7 @@
 ###
 
 # Susy grids in Compass
-# First: gem install susy --pre
+# First: gem install susy
 # require 'susy'
 
 # Change Compass configuration


### PR DESCRIPTION
Use a stable version of Susy. `--pre` is no longer necessary. 
