### PR TITLE
also "build" .htpasswd files

### DIFF
--- a/middleman-core/features/builder.feature
+++ b/middleman-core/features/builder.feature
@@ -14,6 +14,7 @@ Feature: Builder
       | images/Read me (example).txt                  |
       | images/Child folder/regular_file(example).txt |
       | .htaccess                                     |
+      | .htpasswd                                     |
       | feed.xml                                      |
     Then the following files should not exist:
       | _partial                                      |

--- a/middleman-core/fixtures/large-build-app/source/.htpasswd
+++ b/middleman-core/fixtures/large-build-app/source/.htpasswd
@@ -1,0 +1,1 @@
+# .htpasswd

--- a/middleman-core/lib/middleman-core/cli/build.rb
+++ b/middleman-core/lib/middleman-core/cli/build.rb
@@ -220,7 +220,7 @@ module Middleman::Cli
 
       paths = ::Middleman::Util.all_files_under(@destination)
       @cleaning_queue += paths.select do |path|
-        !path.to_s.match(/\/\./) || path.to_s.match(/\.htaccess/)
+        !path.to_s.match(/\/\./) || path.to_s.match(/\.htaccess|\.htpasswd/)
       end
     end
 

--- a/middleman-core/lib/middleman-core/sitemap.rb
+++ b/middleman-core/lib/middleman-core/sitemap.rb
@@ -29,7 +29,7 @@ module Middleman
 
           # Files starting with an dot, but not .htaccess
           :source_dotfiles => proc { |file|
-            file.match(%r{/\.}) && !file.match(%r{/\.htaccess})
+            file.match(%r{/\.}) && !file.match(%r{/\.htaccess|\.htpasswd})
           },
 
           # Files starting with an underscore, but not a double-underscore

--- a/middleman-more/features/directory_index.feature
+++ b/middleman-more/features/directory_index.feature
@@ -11,6 +11,7 @@ Feature: Directory Index
       | wildcard_leave_me_alone.html                  |
       | regular/index.html                            |
       | .htaccess                                     |
+      | .htpasswd                                     |
     Then the following files should not exist:
       | egular/index/index.html                       |
       | needs_index.html                              |

--- a/middleman-more/fixtures/indexable-app/source/.htpasswd
+++ b/middleman-more/fixtures/indexable-app/source/.htpasswd
@@ -1,0 +1,1 @@
+# .htpasswd


### PR DESCRIPTION
Realized after doing this that you could just keep track of the .htpasswd in the build directory and it wouldn't get overwritten ... but maybe worth adding. No worries if you feel like closing this PR

cheers,
steven
