### PR TITLE
Fixes the Pledgie donate badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The best way to get quick responses to your issues and swift fixes to your bugs 
 
 # Donate
 
-[![Click here to lend your support to Middleman](https://www.pledgie.com/campaigns/15807.png)](http://www.pledgie.com/campaigns/15807)
+[![Click here to lend your support to Middleman](http://www.pledgie.com/campaigns/15807.png)](http://www.pledgie.com/campaigns/15807)
 
 # License
 


### PR DESCRIPTION
The badge was broken due to the pledgie image server not supporting https:

![](https://f.cloud.github.com/assets/43314/117587/837edc84-6c47-11e2-879b-e0e5770be0b6.png)
