### PR TITLE
Revert the more-flexible Thor dependency since it breaks bundle install

### DIFF
--- a/middleman-core/middleman-core-x86-mingw32.gemspec
+++ b/middleman-core/middleman-core-x86-mingw32.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency("rack-test", ["~> 0.6.1"])
   
   # CLI
-  s.add_dependency("thor", [">= 0.15.4", "~> 0.15"])
+  s.add_dependency("thor", [">~ 0.15.4"])
   
   # Helpers
   s.add_dependency("activesupport", ["~> 3.2.6"])

--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency("rack-test", ["~> 0.6.1"])
   
   # CLI
-  s.add_dependency("thor", [">= 0.15.4", "~> 0.15"])
+  s.add_dependency("thor", [">~ 0.15.4"])
   
   # Helpers
   s.add_dependency("activesupport", ["~> 3.2.6"])


### PR DESCRIPTION
...for JRuby and we will need to update Padrino when it gets upgraded anyway (because we have Padrino locked to a specific minor version and they haven't released the version that uses Thor 0.17 yet)
