### PR TITLE
Change the behavior of before_render and after_render hooks from #761.

### DIFF
--- a/middleman-core/lib/middleman-core/core_extensions/rendering.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/rendering.rb
@@ -246,15 +246,26 @@ module Middleman
           options = opts.merge(options_for_ext(extension))
           options[:outvar] ||= '@_out_buf'
 
+          template_class = Tilt[path]
+          # Allow hooks to manipulate the template before render
+          self.class.callbacks_for_hook(:before_render).each do |callback|
+            newbody = callback.call(body, path, locs, template_class)
+            body = newbody if newbody # Allow the callback to return nil to skip it
+          end
+
           # Read compiled template from disk or cache
           template = cache.fetch(:compiled_template, options, body) do
             ::Tilt.new(path, 1, options) { body }
           end
 
           # Render using Tilt
-          run_hook :before_render, template.data, template
-          content = template.render(context, locs, &block)
-          run_hook :after_render, content, template
+          content = template.render(context, path, locs, &block)
+
+          # Allow hooks to manipulate the result after render
+          self.class.callbacks_for_hook(:after_render).each do |callback|
+            content = callback.call(content, locs, template_class)
+          end
+
           return content
         ensure
           # Reset stored buffer


### PR DESCRIPTION
This changes the before_render and after_render hooks so that the callbacks 
given to them each get to modify the template source / the rendered output in
turn, instead of having to modify them in-place. It also changes the
arguments provided to the callbacks - now, they are given the source/output,
the locals hash, and the Tilt template _class_, wheras previously they were
given the source/output and the Tilt template _instance_. The locals hash is
there in case pron case hooks want to pay attention to the locals in some
way. The before_render hook is also run before compiling the template and
caching it, which should prevent weird data mismatches and save some template
compilation effort.
