### PR TITLE
Add a metadata page for inspecting configuration.

### DIFF
--- a/middleman-core/lib/middleman-core/application.rb
+++ b/middleman-core/lib/middleman-core/application.rb
@@ -142,7 +142,7 @@ module Middleman
       cache.clear
 
       # Setup the default values from calls to set before initialization
-      self.class.superclass.config.to_h.each { |k,v| self.class.config.define_setting(k,v) }
+      self.class.config.load_settings(self.class.superclass.config.all_settings)
 
       # Evaluate a passed block if given
       instance_exec(&block) if block_given?

--- a/middleman-core/lib/middleman-core/configuration.rb
+++ b/middleman-core/lib/middleman-core/configuration.rb
@@ -171,10 +171,18 @@ module Middleman
       def dup
         copy = ConfigurationManager.new
         @settings.each do |key, setting|
-          copy_setting = copy.define_setting setting.key, setting.default, setting.description
+          copy_setting = copy.define_setting(setting.key, setting.default, setting.description)
           copy_setting.value = setting.value if setting.value_set?
         end
         copy
+      end
+
+      # Load in a list of settings
+      def load_settings(other_settings)
+        other_settings.each do |setting|
+          new_setting = define_setting(setting.key, setting.default, setting.description)
+          new_setting.value = setting.value if setting.value_set?
+        end
       end
 
       def to_h

--- a/middleman-core/lib/middleman-core/meta_pages.rb
+++ b/middleman-core/lib/middleman-core/meta_pages.rb
@@ -27,13 +27,17 @@ module Middleman
           map '/sitemap' do
             run meta_pages.method(:sitemap)
           end
+
+          map '/config' do
+            run meta_pages.method(:config)
+          end
         end
       end
 
       def call(*args)
         @rack_app.call(*args)
       end
-      
+
       # The index page
       def index(env)
         template('index.html.erb')
@@ -50,6 +54,11 @@ module Middleman
         end
 
         template('sitemap.html.erb', :sitemap_tree => sitemap_tree)
+      end
+
+      # Inspect configuration
+      def config(env)
+        template('config.html.erb', :config => @middleman.config)
       end
 
       private

--- a/middleman-core/lib/middleman-core/meta_pages/templates/config.html.erb
+++ b/middleman-core/lib/middleman-core/meta_pages/templates/config.html.erb
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+        
+    <title>Middleman Config</title>
+  </head>
+  
+  <body>
+    <h1>Middleman Config</h1>
+    <a href="../">More meta pages</a>
+
+    <ul>
+    <% config.all_settings.each do |setting| %>
+      <li>
+        <b><%= setting.key %></b>: 
+        <%= setting.value.inspect %>
+        <% if setting.value_set? %>
+          <br>
+          Default: <%= setting.default.inspect %>
+        <% else %>
+          (Default)
+        <% end %>
+        <br>
+        <i><%= setting.description %></i>
+      </li>
+    <% end %>
+    </ul>
+  </body>
+</html>
+
+

--- a/middleman-core/lib/middleman-core/meta_pages/templates/index.html.erb
+++ b/middleman-core/lib/middleman-core/meta_pages/templates/index.html.erb
@@ -13,6 +13,7 @@
 
     <ul>
       <li><a href="sitemap/">Sitemap</a></li>
+      <li><a href="config/">Configuration</a></li>
     </ul>
   </body>
 </html>


### PR DESCRIPTION
This is another metadata page that uses the new configuration system to
show all the available options, their current values, and their defaults.
This is still unstyled, but the info is there. I still need to add on a
method for extensions to register their configuration with the global
config so they show up (stuff like blog) but this is a start.
