### PR TITLE
Redcarpet and Pygments

### DIFF
--- a/middleman-core/lib/middleman-core/renderers/redcarpet.rb
+++ b/middleman-core/lib/middleman-core/renderers/redcarpet.rb
@@ -1,4 +1,5 @@
 require "redcarpet"
+require "pygments"
 
 module Middleman
   module Renderers
@@ -7,7 +8,7 @@ module Middleman
 
       def initialize(*args, &block)
         super
-        
+
         if @options.has_key?(:context)
           @context = @options[:context]
         end
@@ -18,6 +19,8 @@ module Middleman
       # Support renderer-level options
       def generate_renderer
         return options.delete(:renderer) if options.has_key?(:renderer)
+
+        options.merge!(:fenced_code_blocks => true)
 
         # Pick a renderer
         renderer = MiddlemanRedcarpetHTML
@@ -60,6 +63,13 @@ module Middleman
 
       def link(link, title, content)
         middleman_app.link_to(content, link, :title => title)
+      end
+
+      def block_code(code, language)
+        syntax_highlighted_html = Pygments.highlight code, :lexer => language,
+          :options => {:encoding => 'utf-8'}
+
+        syntax_highlighted_html.gsub('class="highlight"',"class=\"highlight sh_#{language}\"")
       end
     end
 


### PR DESCRIPTION
### Feature

I wanted to use Middleman to display code samples when used with the `middleman-blog`. This pull-request adds:
- Redcarpet will handle code fences
- Code fences support colorization based on language through pygments

This works if the project adds the following gems:

``` ruby
gem "redcarpet"
gem "pygments.rb"
```

And then you specify in the configuration to use `redcarpet` as the renderer.

``` ruby
set :markdown_engine, :redcarpet
```
### Discussion

This is not how it should be done, but how it can be done. I wanted to open up the pull-request to discuss if this was a desired feature and the best way to proceed with integration.
- Should the user specify a different markdown_engine?
- Should the user specify redcarpet but then have an additional way to specify pygments?
