### PR TITLE
Bundler advises not to use a source symbol anymore

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 # Build and doc tools
 gem "rake",     "~> 10.0.3"


### PR DESCRIPTION
Just updated to latest [Bundler](http://gembundler.com/) and now [see this](https://github.com/carlhuda/bundler/commit/d30026e9c8fc6c98478120866a47ca5b619251b8) everywhere.

```
The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
```
