### PR TITLE
Parallel building

### DIFF
--- a/middleman-core/features/parallel_build.feature
+++ b/middleman-core/features/parallel_build.feature
@@ -1,0 +1,58 @@
+Feature: Parallel
+  In order to speed up large builds we should build in parallel
+
+  Scenario: Build an app
+    Given a successfully built app at "large-build-app" with flags "--parallel"
+    When I cd to "build"
+    Then the following files should exist:
+      | index.html                                    |
+      | static.html                                   |
+      | services/index.html                           |
+      | stylesheets/static.css                        |
+      | spaces in file.html                           |
+      | images/blank.gif                              |
+      | images/Read me (example).txt                  |
+      | images/Child folder/regular_file(example).txt |
+      | .htaccess                                     |
+      | .htpasswd                                     |
+      | feed.xml                                      |
+    Then the following files should not exist:
+      | _partial                                      |
+      | layout                                        |
+      | layouts/custom                                |
+      | layouts/content_for                           |
+      
+    And the file "index.html" should contain "Comment in layout"
+    And the file "index.html" should contain "<h1>Welcome</h1>"
+    And the file "static.html" should contain "Static, no code!"
+    And the file "services/index.html" should contain "Services"
+    And the file "stylesheets/static.css" should contain "body"
+    And the file "spaces in file.html" should contain "spaces"
+
+    Scenario: Build and Clean an app ( in parallel )
+      Given a fixture app "clean-app"
+      And app "clean-app" is using config "empty"
+      And a successfully built app at "clean-app" with flags "--parallel"
+      Then the following files should exist:
+        | build/index.html              |
+        | build/should_be_ignored.html  |
+        | build/should_be_ignored2.html |
+        | build/should_be_ignored3.html |
+      And app "clean-app" is using config "complications"
+      Given a successfully built app at "clean-app" with flags "--clean --parallel"
+      Then the following files should not exist:
+        | build/should_be_ignored.html  |
+        | build/should_be_ignored2.html |
+        | build/should_be_ignored3.html |
+      And the file "build/index.html" should contain "Comment in layout"
+
+    Scenario: Clean build an app with newly ignored files and a nested output directory
+      Given a built app at "clean-nested-app" with flags "--parallel"
+      Then a directory named "sub/dir" should exist
+      Then the following files should exist:
+        | sub/dir/about.html        |
+      When I append to "config.rb" with "ignore 'about.html'"
+      Given a built app at "clean-nested-app" with flags "--clean --parallel"
+      Then the following files should not exist:
+        | sub/dir/about.html        |
+        

--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   
   # Builder
   s.add_dependency("rack-test", ["~> 0.6.1"])
+  s.add_dependency("parallel", ["~> 0.6.2"])
   
   # CLI
   s.add_dependency("thor", ["~> 0.15.4"])


### PR DESCRIPTION
**pull request more for a discussion then a 'ready to be merged'...**

Quite experimental, however.

Whilst putting together a rebuild of [middleman-sync](https://github.com/karlfreeman/middleman-sync/issues/16) I've had quite a bit of success with [parallel](https://github.com/grosser/parallel). At first I thought I'd see just how much of speed difference it would make if it were utilised in `middleman build` whilst building my small site.

```
middleman build 13.15s user 2.17s system 255% cpu 5.354 total - with
middleman build 7.59s user 0.90s system 99% cpu 8.531 total - without
```

A small gain, however watching the build log it appears to have quite a noticeable effect.  Of course some proper benchmarking tests should be done ( pictures below illustrate it 'working' ).
### Problems
- `--clean`ing in parallel ( processes ) is out of the question as we need to keep track of dirty files. However cleaning in parallel ( threads ) could be possible but defeats the purpose of parallel building as we would have to guess or allow the user to specify how many threads to spawn on build ( could be a CLI option `--threads` though )
- Logging goes a little crazy, something we could solve for sure.
### Questions
- Could you try this out on one of your own ( more complex ) middleman apps?
- The tests pass however the order in which the build processes files in parallel would essentially be random. Do other extensions / etc rely on the build to be built in a specific order?
- Would it be worth continuing the idea of executing build in parallel or is it too fraught with possible problems that it should be delayed?
### Pictures
##### 2 threads ( bundle exec and middleman )

![without-parallel-activity](https://f.cloud.github.com/assets/139095/192874/d3afc5fc-7f6f-11e2-8045-b6c9b26e0aeb.jpg)
##### 10 threads ( bundle exec, middleman and 8 build's )

![with-parallel-activity](https://f.cloud.github.com/assets/139095/192872/cea4a97e-7f6f-11e2-8165-28c724f1207f.jpg)
##### Using one core

![without-parallel](https://f.cloud.github.com/assets/139095/192918/a76c88b2-7f70-11e2-8c9d-03058e985969.jpg)
##### Using all the cores

![with-parallel](https://f.cloud.github.com/assets/139095/192919/ae7a32b2-7f70-11e2-8cc8-9861914bdd6b.jpg)
