### PR TITLE
Fix dynamic multi-byte utf-8 files rebuilding.

### DIFF
--- a/middleman-core/features/unicode_filecontents.feature
+++ b/middleman-core/features/unicode_filecontents.feature
@@ -1,0 +1,13 @@
+Feature: Unicode filecontents
+  In order to support non-ASCII characters in file contents
+
+  Scenario: Rebuild with files containing unicode characters in their name
+    Given a fixture app "clean-app"
+    And a file named "source/index.html.erb" with:
+      """
+      你好
+      """
+    And a successfully built app at "clean-app"
+    And a modification time for a file named "build/index.html"
+    And a successfully built app at "clean-app"
+    Then the file "build/index.html" should not have been updated

--- a/middleman-core/lib/middleman-core/cli/build.rb
+++ b/middleman-core/lib/middleman-core/cli/build.rb
@@ -137,7 +137,7 @@ module Middleman::Cli
             response = self.class.shared_rack.get(URI.escape(resource.destination_path))
 
             if response.status == 200
-              create_file(output_file, response.body)
+              create_file(output_file, binary_encode(response.body))
             else
               handle_error(output_file, response.body)
             end
@@ -159,6 +159,13 @@ module Middleman::Cli
         elsif options["verbose"]
           self.shell.error(response)
         end
+      end
+
+      def binary_encode(string)
+        if string.respond_to?(:force_encoding)
+          string.force_encoding("ascii-8bit")
+        end
+        string
       end
     }
   end

--- a/middleman-core/lib/middleman-core/step_definitions/builder_steps.rb
+++ b/middleman-core/lib/middleman-core/step_definitions/builder_steps.rb
@@ -1,5 +1,9 @@
 require 'fileutils'
 
+Before do
+  @modification_times = Hash.new
+end
+
 Given /^app "([^\"]*)" is using config "([^\"]*)"$/ do |path, config_name|
   target = File.join(PROJECT_ROOT_PATH, "fixtures", path)
   config_path = File.join(current_dir, "config-#{config_name}.rb")
@@ -48,6 +52,16 @@ end
 Given /^a successfully built app at "([^\"]*)" with flags "([^\"]*)"$/ do |path, flags|
   step %Q{a built app at "#{path}" with flags "#{flags}"}
   step %Q{was successfully built}
+end
+
+Given /^a modification time for a file named "([^\"]*)"$/ do |file|
+  target = File.join(current_dir, file)
+  @modification_times[target] = File.mtime(target)
+end
+
+Then /^the file "([^\"]*)" should not have been updated$/ do |file|
+  target = File.join(current_dir, file)
+  File.mtime(target).should == @modification_times[target]
 end
 
 # Provide this Aruba overload in case we're matching something with quotes in it


### PR DESCRIPTION
Thor compares the new contents with the existing file by using
File.binread(destination) == new_content.
File.binread returns a string with ASCII_8BIT encoding, which will not
match the new_content if new_content contains multi-byte utf-8.

This patch simply encodes the new_content to ASCII_8BIT before passing
it to Thor.
