### PR TITLE
Changed 'default' and 'html5' templates to use 'current_page.data.title' instead of 'data.page.title'

### DIFF
--- a/middleman-core/lib/middleman-core/templates/default/source/layouts/layout.erb
+++ b/middleman-core/lib/middleman-core/templates/default/source/layouts/layout.erb
@@ -7,7 +7,7 @@
     <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">
     
     <!-- Use title if it's in the page YAML frontmatter -->
-    <title><%= data.page.title || "The Middleman" %></title>
+    <title><%= current_page.data.title || "The Middleman" %></title>
     
     <%= stylesheet_link_tag "normalize", "all" %>
     <%= javascript_include_tag  "all" %>

--- a/middleman-core/lib/middleman-core/templates/html5/source/layouts/layout.erb
+++ b/middleman-core/lib/middleman-core/templates/html5/source/layouts/layout.erb
@@ -7,7 +7,7 @@
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <!-- Use title if it's in the page YAML frontmatter -->
-        <title><%= data.page.title || "HTML5 Boilerplate" %></title>
+        <title><%= current_page.data.title || "HTML5 Boilerplate" %></title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
 


### PR DESCRIPTION
Since `data.page.title` seems broken (according to https://github.com/middleman/middleman-blog/issues/107#issuecomment-14944013), this PR changes the 'default' and 'html5' templates to use `current_page.data.title` instead.

Since the number of failing tests is the same before and after this modification, I guess the build not passing the tests is not related to this very PR (furthermore, the templates does not seem to be tested at all).
