### PR TITLE
Support directory name as a data key

### DIFF
--- a/middleman-core/features/data.feature
+++ b/middleman-core/features/data.feature
@@ -5,18 +5,23 @@ Feature: Local Data API
     Given the Server is running at "basic-data-app"
     When I go to "/data.html"
     Then I should see "One:Two"
-  
+
   Scenario: Rendering json
     Given the Server is running at "basic-data-app"
     When I go to "/data3.html"
     Then I should see "One:Two"
-    
+
   Scenario: Using data in config.rb
     Given the Server is running at "data-app"
     When I go to "/test1.html"
     Then I should see "Welcome"
-    
+
   Scenario: Using data2 in config.rb
     Given the Server is running at "data-app"
     When I go to "/test2.html"
     Then I should see "Welcome"
+
+  Scenario: Using nested data
+    Given the Server is running at "nested-data-app"
+    When I go to "/test.html"
+    Then I should see "test:Hello"

--- a/middleman-core/fixtures/nested-data-app/config.rb
+++ b/middleman-core/fixtures/nested-data-app/config.rb
@@ -1,0 +1,1 @@
+set :layout, false

--- a/middleman-core/fixtures/nested-data-app/data/examples/test.yml
+++ b/middleman-core/fixtures/nested-data-app/data/examples/test.yml
@@ -1,0 +1,1 @@
+title: "Hello"

--- a/middleman-core/fixtures/nested-data-app/source/test.html.erb
+++ b/middleman-core/fixtures/nested-data-app/source/test.html.erb
@@ -1,0 +1,1 @@
+<%= data.examples.map { |k, r| [k, r.title].join(":") }.join %>


### PR DESCRIPTION
I want to use directory to group some data.

For example:

```
$ tree
.
└─ data
     └── example
           ├── test1.yml
           └── test2.yml
```

At this time, I want to access example data through `data.example`.

Currently, this case could be made by using `example.yml` with keys [test1, test2].
But when each data is too large, it is difficult to treat as one file.
