### PR TITLE
Document livereload usage in config file

### DIFF
--- a/middleman-core/lib/middleman-core/templates/shared/config.tt
+++ b/middleman-core/lib/middleman-core/templates/shared/config.tt
@@ -41,8 +41,7 @@
 # activate :automatic_image_sizes
 
 # Enable middleman-livereload
-# First: gem install middleman-livereload
-# Or add it to your Gemfile and run bundle install (preferred)
+# First: add it to your Gemfile and run bundle install
 # activate :livereload
 
 # Methods defined in the helpers block are available in templates


### PR DESCRIPTION
Trying to make it easier for users to livereload their middleman projects.

Two questions, though:
1. Should config.rb `require "middleman-livereload"` the way middleman-smusher does?
2. Should I suggest `gem install middleman-livereload"` or adding it to the Gemfile and running `bundle install`?
