### PR TITLE
Compass sprites don't work great

### DIFF
--- a/middleman-core/lib/middleman-core/step_definitions/server_steps.rb
+++ b/middleman-core/lib/middleman-core/step_definitions/server_steps.rb
@@ -67,6 +67,10 @@ When /^I go to "([^\"]*)"$/ do |url|
   @browser.get(URI.escape(url))
 end
 
+When /^the response code should be "([^\"]*)"$/ do |code|
+  @browser.last_response.status.should == code.to_i
+end
+
 Then /^going to "([^\"]*)" should not raise an exception$/ do |url|
   lambda { @browser.get(URI.escape(url)) }.should_not raise_exception
 end

--- a/middleman-more/features/compass-sprites.feature
+++ b/middleman-more/features/compass-sprites.feature
@@ -1,6 +1,20 @@
 Feature: Compass sprites should be generated on build and copied
+  Scenario: Compass sprites in preview server
+    Given the Server is running at "compass-sprites-app"
+    When I go to "/stylesheets/site.css"
+    Then I should see "/images/icon-s1a8aa64128.png"
+    And I should see ".icon-sprite, .icon-arrow_down, .icon-arrow_left, .icon-arrow_right, .icon-arrow_up"
+    When I go to "/images/icon-s1a8aa64128.png"
+    Then the response code should be "200"
+    Then the following files should not exist:
+      | source/images/icon-s1a8aa64128.png |
+
   Scenario: Building a clean site with sprites
-    Given a successfully built app at "compass-sprites-app"
+    Given a successfully built app at "compass-sprites-app" with flags "--clean"
+    Then the following files should not exist:
+      | source/images/icon-s1a8aa64128.png |
     When I cd to "build"
     Then the following files should exist:
       | images/icon-s1a8aa64128.png |
+    And the file "stylesheets/site.css" should contain "icon-s1a8aa64128.png"
+    

--- a/middleman-more/lib/middleman-more/core_extensions/compass.rb
+++ b/middleman-more/lib/middleman-more/core_extensions/compass.rb
@@ -33,6 +33,9 @@ module Middleman
               compass_config.fonts_dir       = config[:fonts_dir]
               compass_config.images_dir      = config[:images_dir]
               compass_config.http_path       = config[:http_prefix]
+              if build?
+                compass_config.generated_images_path = root_path.join(config[:build_dir]).join(config[:images_dir])
+              end
 
               config[:sass_assets_paths].each do |path|
                 compass_config.add_import_path path


### PR DESCRIPTION
I'm trying to use Compass' [sprite support](http://compass-style.org/help/tutorials/spriting/) in one of my Middleman projects. For example, I have a directory `source/images/icon` which contains some images, and then a Sass file with:

``` sass
@import "icon/*.png"
@include all-icon-sprites
```

When I run `middleman build`, the icon sprite (named something like `icon-s4f7554543b.png`) is produced in the source directory (`source/images/icon/icon-s4f7554543b.png`) instead of the build directory. I can sort of work around this by building twice - the first time puts the sprite in source, and the second time copies the sprite into the build directory.

I suspect that the Compass defaults could be tweaked to get the sprites to appear in the build directory instead of the source, though I haven't yet been able to figure out exactly what to change. One complication is that the sprite image would need to also have a sitemap entry so that `build --clean` won't just remove it on the next build.

I haven't put together a test case or test project because the problem is pretty straightforward to reproduce, but I could do so if you wanted.
