### PR TITLE
Switch default markdown engine to Kramdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 master
 ===
 
+* Switched default Markdown engine to Kramdown. #852
 * Overhaul content-type handling, and add a `:content_type` parameter for `page`, `proxy`, and frontmatter that allows for overriding the default content type. #851
 * Fixes for upcoming Sass versions.
 * Fix markdown filters in Haml 4 so that they don't throw errors when generating links/images and so they use our magic image_tag/link_to methods. #662

--- a/middleman-core/lib/middleman-core/renderers/markdown.rb
+++ b/middleman-core/lib/middleman-core/renderers/markdown.rb
@@ -10,7 +10,7 @@ module Middleman
         # Once registered
         def registered(app)
           # Set our preference for a markdown engine
-          app.config.define_setting :markdown_engine, :maruku, 'Preferred markdown engine'
+          app.config.define_setting :markdown_engine, :kramdown, 'Preferred markdown engine'
           app.config.define_setting :markdown_engine_prefix, ::Tilt, 'The parent module for markdown template engines'
 
           app.before_configuration do

--- a/middleman-more/features/markdown.feature
+++ b/middleman-more/features/markdown.feature
@@ -9,4 +9,4 @@ Feature: Markdown support
   Scenario: Markdown extensions (Maruku)
     Given the Server is running at "markdown-app"
     When I go to "/smarty_pants.html"
-    Then I should see "&"
+    Then I should see "“Hello”"

--- a/middleman-more/fixtures/markdown-app/config.rb
+++ b/middleman-more/fixtures/markdown-app/config.rb
@@ -1,0 +1,1 @@
+set :markdown, :smartypants => true

--- a/middleman-more/middleman-more.gemspec
+++ b/middleman-more/middleman-more.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency("compass", [">= 0.12.2"])
   s.add_dependency("coffee-script", ["~> 2.2.0"])
   s.add_dependency("execjs", ["~> 1.4.0"])
-  s.add_dependency("maruku", ["~> 0.6.0"])
+  s.add_dependency("kramdown", ["~> 1.0.0"])
   s.add_dependency("i18n", ["~> 0.6.4"])
   s.add_dependency("padrino-helpers", ["0.10.7"])
 end


### PR DESCRIPTION
Kramdown is faster, less buggy, better written, and as of version 1.0.0, MIT licensed. It's also pure-Ruby so it works with JRuby. We should ship Kramdown as the default instead of old and busted Maruku.

(I realize that this is ironic given that I own Maruku, but it's not as good as Kramdown.)
