### PR TITLE
Include I18n::Fallbacks and set the default I18n locale to our default locale.

### DIFF
--- a/middleman-more/features/i18n_preview.feature
+++ b/middleman-more/features/i18n_preview.feature
@@ -203,3 +203,16 @@ Feature: i18n Preview
     Then I should see '"../stylesheets/site.css"'
     When I go to "/es/hola.html"
     Then I should see '"../stylesheets/site.css"'
+
+  Scenario: Missing translations fall back to the default locale
+    Given a fixture app "i18n-default-app"
+    And a file named "config.rb" with:
+      """
+      activate :i18n, :mount_at_root => :es
+      """
+    Given the Server is running at "i18n-default-app"
+    When I go to "/en/"
+    Then I should see "Default locale: es"
+    Then I should see "Current locale: en"
+    Then I should see "Buenos días"
+    Then I should see "Howdy"

--- a/middleman-more/fixtures/i18n-default-app/locales/en.yml
+++ b/middleman-more/fixtures/i18n-default-app/locales/en.yml
@@ -1,0 +1,4 @@
+---
+en:
+  greetings: "Howdy"
+  hi: "Hello"

--- a/middleman-more/fixtures/i18n-default-app/locales/es.yml
+++ b/middleman-more/fixtures/i18n-default-app/locales/es.yml
@@ -1,0 +1,8 @@
+---
+es:
+  paths:
+    hello: "hola"
+  
+  greetings: "Como Esta?"
+  hi: "Hola"
+  untranslated: "Buenos días"

--- a/middleman-more/fixtures/i18n-default-app/source/localizable/index.html.erb
+++ b/middleman-more/fixtures/i18n-default-app/source/localizable/index.html.erb
@@ -1,0 +1,5 @@
+Default locale: <%= I18n.default_locale %>
+Current locale: <%= I18n.locale %>
+Fallbacks: <%= I18n.fallbacks[:en] %>
+<%= t(:untranslated) %>
+<%= t(:greetings) %>


### PR DESCRIPTION
Thus, when a translation is missing in the current locale, fall back to the
default locale. See https://github.com/svenfuchs/i18n/wiki/Fallbacks for more
info and configuration settings available to users.

Also, this change adds a "t" helper that proxies to I18n.t, just like Rails,
for more concise translating.
