### PR TITLE
Add try() to DataStore.

### DIFF
--- a/middleman-core/lib/middleman-core/core_extensions/data.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/data.rb
@@ -181,6 +181,14 @@ module Middleman
         def respond_to?(method, include_private = false)
           super || @local_data.has_key?(method.to_s) || !!(data_for_path(method))
         end
+        
+        # Return requested data, or nil if data does not exist
+        #
+        # @param [String, Symbol] path The name of the data namespace
+        # @return [Hash, nil]
+        def try(path)
+          __send__(path) if respond_to?(path)
+        end
 
         # Convert all the data into a static hash
         #


### PR DESCRIPTION
As discussed in #872, this simplifies the code needed to check for the existence of data before trying to access it. Adding `try()` allows for code like this:

``` ruby
s3_sync.aws_access_key_id     = data.try(:secrets).try(:aws_access_key_id)
s3_sync.aws_secret_access_key = data.try(:secrets).try(:aws_secret_access_key)
```

We can probably DRY up the code in method_missing() and try() with something like

``` ruby
def method_missing(path)
   try(path) || super
end
```

But I was afraid to attempt that change without specs. Are there specs for DataStore somewhere (sorry if I'm missing something obvious)?
