### PR TITLE
Add [] operator and has_key? to DataStore to make DataStore act like a hash

### DIFF
--- a/middleman-core/lib/middleman-core/core_extensions/data.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/data.rb
@@ -179,7 +179,20 @@ module Middleman
 
         # Needed so that method_missing makes sense
         def respond_to?(method, include_private = false)
-          super || @local_data.has_key?(method.to_s) || !!(data_for_path(method))
+          super || has_key?(method)
+        end
+        
+        # Make DataStore act like a hash. Return requested data, or
+        # nil if data does not exist
+        #
+        # @param [String, Symbol] key The name of the data namespace
+        # @return [Hash, nil]
+        def [](key)
+          __send__(key) if has_key?(key)
+        end
+
+        def has_key?(key)
+          @local_data.has_key?(key.to_s) || !!(data_for_path(key))
         end
 
         # Convert all the data into a static hash


### PR DESCRIPTION
This is another option to address #872. It simplifies the code needed to check for the existence of data before trying to access it. For example:

``` ruby
s3_sync.aws_access_key_id     = data[:secrets].try(:aws_access_key_id)
s3_sync.aws_secret_access_key = data[:secrets].try(:aws_secret_access_key)
```

This is redundant with pull request #878
