### PR TITLE
Make the list of regexes ignored by FileWatcher configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ master
 
 * DataStore may now be accessed like a hash with #[] and #has_key?. #880
 * The i18n extension now supports providing localized templates as separate files, like index.es.html.haml. #816, #823
+* The list of regular expressions for which files are ignored by the file watcher are now configurable.
 
 3.1.0.beta.2
 ===

--- a/middleman-core/lib/middleman-core/core_extensions/file_watcher.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/file_watcher.rb
@@ -27,6 +27,8 @@ module Middleman
         def registered(app)
           app.send :include, InstanceMethods
 
+          app.config.define_setting :file_watcher_ignore, IGNORE_LIST, 'Regexes for paths that should be ignored when they change.'
+
           # Before parsing config, load the data/ directory
           app.before_configuration do
             files.reload_path(config[:data_dir])
@@ -146,7 +148,7 @@ module Middleman
         # @return [Boolean]
         def ignored?(path)
           path = path.to_s
-          IGNORE_LIST.any? { |r| path =~ r }
+          config[:file_watcher_ignore].any? { |r| path =~ r }
         end
 
         # Notify callbacks for a file given an array of callbacks


### PR DESCRIPTION
I think this is an OK idea. It's mostly for LiveReload's sake, but I was thinking that anything people wanted to exclude from livereload might as well be excluded from all file change events.

Syntax for adding to this will have to leverage the new config module:

``` ruby
config[:file_watcher_ignore] << /foo/
```
