### PR TITLE
Cache the filtered resource list

### DIFF
--- a/middleman-core/lib/middleman-core/sitemap/extensions/ignores.rb
+++ b/middleman-core/lib/middleman-core/sitemap/extensions/ignores.rb
@@ -68,11 +68,14 @@ module Middleman
                 @ignored_callbacks << Proc.new {|p| File.fnmatch(path_clean, p) }
               else
                 # Add a specific-path ignore unless that path is already covered
-                @ignored_callbacks << Proc.new {|p| p == path_clean } unless ignored?(path_clean)
+                return if ignored?(path_clean)
+                @ignored_callbacks << Proc.new {|p| p == path_clean }
               end
             elsif block_given?
               @ignored_callbacks << block
             end
+
+            @app.sitemap.invalidate_resources_not_ignored_cache!
           end
 
           # Whether a path is ignored

--- a/middleman-core/lib/middleman-core/sitemap/store.rb
+++ b/middleman-core/lib/middleman-core/sitemap/store.rb
@@ -90,9 +90,15 @@ module Middleman
           if include_ignored
             @resources
           else
-            @resources.reject(&:ignored?)
+            @resources_not_ignored ||= @resources.reject(&:ignored?)
           end
         end
+      end
+
+      # Invalidate our cached view of resource that are not ingnored. If your extension
+      # adds ways to ignore files, you should call this to make sure #resources works right.
+      def invalidate_resources_not_ignored_cache!
+        @resources_not_ignored = nil
       end
 
       # Register a handler to provide metadata on a file path
@@ -213,6 +219,8 @@ module Middleman
 
             newres
           end
+
+          invalidate_resources_not_ignored_cache!
         end
       end
 


### PR DESCRIPTION
This is a performance improvement inspired by #903 that avoids calling `Resource#ignored?` a ton. In the profiler output from that issue, `Resource#ignored?` was called almost 300,000 times! With this change, my own site's build time drops by about 10s (from 1m15s to 1m04s).

However, I have some reservations about how this is cached - it doesn't get invalidated except when the sitemap gets recomputed. That means that if you add an `ignore` rule and don't rebuild the sitemap, your ignore won't be reflected everywhere. That worries me, though all our tests pass and my site builds correctly. I tried invalidating the sitemap from `ignore`, but middleman-blog calls ignore from within a `resource_list_manipulator` which ends up creating a resource invalidation/recomputation infinite recursion.
