### PR TITLE
Fix #823-2 to allow only one extension on localized views

### DIFF
--- a/middleman-core/features/i18n_builder.feature
+++ b/middleman-core/features/i18n_builder.feature
@@ -13,9 +13,11 @@ Feature: i18n Builder
       | index.html                                    |
       | hello.html                                    |
       | morning.html                                  |
+      | one.html                                      |
       | es/index.html                                 |
       | es/hola.html                                  |
       | es/manana.html                                |
+      | es/una.html                                   |
       | CNAME                                         |
       | password.txt                                  |
     Then the following files should not exist:
@@ -23,9 +25,11 @@ Feature: i18n Builder
     And the file "index.html" should contain "Howdy"  
     And the file "hello.html" should contain "Hello World"
     And the file "morning.html" should contain "Good morning"
+    And the file "one.html" should contain "Only one"
     And the file "es/index.html" should contain "Como Esta?"
     And the file "es/hola.html" should contain "Hola World"
     And the file "es/manana.html" should contain "Buenos días"
+    And the file "es/una.html" should contain "Solamente una"
     And the file "CNAME" should contain "test.github.com"
     And the file "password.txt" should contain "hunter2"
     

--- a/middleman-core/features/i18n_preview.feature
+++ b/middleman-core/features/i18n_preview.feature
@@ -14,6 +14,8 @@ Feature: i18n Preview
     Then I should see "Hello World"
     When I go to "/morning.html"
     Then I should see "Good morning"
+    When I go to "/one.html"
+    Then I should see "Only one"
     When I go to "/en/index.html"
     Then I should see "File Not Found"
     When I go to "/en/morning.html"
@@ -24,6 +26,8 @@ Feature: i18n Preview
     Then I should see "Hola World"
     When I go to "/es/manana.html"
     Then I should see "Buenos días"
+    When I go to "/es/una.html"
+    Then I should see "Solamente una"
 
   Scenario: A template changes i18n during preview
     Given a fixture app "i18n-test-app"

--- a/middleman-core/fixtures/i18n-test-app/locales/es.yml
+++ b/middleman-core/fixtures/i18n-test-app/locales/es.yml
@@ -3,6 +3,7 @@ es:
   paths:
     hello: "hola"
     morning: "manana"
+    one: "una"
   
   greetings: "Como Esta?"
   hi: "Hola"

--- a/middleman-core/fixtures/i18n-test-app/source/one.en.md
+++ b/middleman-core/fixtures/i18n-test-app/source/one.en.md
@@ -1,0 +1,1 @@
+Only one

--- a/middleman-core/fixtures/i18n-test-app/source/one.es.md
+++ b/middleman-core/fixtures/i18n-test-app/source/one.es.md
@@ -1,0 +1,1 @@
+Solamente una

--- a/middleman-core/lib/middleman-core/sitemap/store.rb
+++ b/middleman-core/lib/middleman-core/sitemap/store.rb
@@ -250,7 +250,7 @@ module Middleman
           path_bits = path.split('.')
           lang = path_bits.last
           if app.langs.include?(lang.to_sym)
-            return path_bits[0..-1].join('.')
+            return path_bits[0..-2].join('.')
           end
         end
 


### PR DESCRIPTION
I'm not sure I should have made another PR for this, but I made another PR for this, assuming checking PR's is a better part of your workflow than checking notifications.

(Oh, and I also wanted to see the green Travis icon, guilty ;) )

Fixed!
