### PR TITLE
include '/vendor' in ignored files / folders

### DIFF
--- a/middleman-core/lib/middleman-core/core_extensions/file_watcher.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/file_watcher.rb
@@ -8,6 +8,7 @@ module Middleman
 
       IGNORE_LIST = [
         /^\.bundle\//,
+        /^vendor\//,
         /^\.sass-cache\//,
         /^\.git\//,
         /^\.gitignore$/,


### PR DESCRIPTION
I vendor all my gems and noticed that its folder was being included in the file watcher. I'm wondering though whether excluding files / folders to watch is the right way to go? Surely building a list of files / folders to include would be better? 
