### PR TITLE
content_for is escaping .erb

### DIFF
--- a/middleman-core/features/content_for.feature
+++ b/middleman-core/features/content_for.feature
@@ -3,14 +3,14 @@ Feature: Support content_for and yield_content helpers
   Scenario: content_for works as expected in erb
     Given the Server is running at "content-for-app"
     When I go to "/content_for_erb.html"
-    Then I should see "In Layout: I am the yielded content erb"
+    Then I should see "In Layout: I am the yielded content erb <s>with html tags</s>"
     
   Scenario: content_for works as expected in haml
     Given the Server is running at "content-for-app"
     When I go to "/content_for_haml.html"
-    Then I should see "In Layout: I am the yielded content haml"
+    Then I should see "In Layout: I am the yielded content haml <s>with html tags</s>"
     
   Scenario: content_for works as expected in slim
     Given the Server is running at "content-for-app"
     When I go to "/content_for_slim.html"
-    Then I should see "In Layout: I am the yielded content slim"
+    Then I should see "In Layout: I am the yielded content slim <s>with html tags</s>"

--- a/middleman-core/fixtures/content-for-app/source/content_for_erb.html.erb
+++ b/middleman-core/fixtures/content-for-app/source/content_for_erb.html.erb
@@ -1,5 +1,5 @@
 <% content_for :from_template do %>
-  I am the yielded content erb
+  I am the yielded content erb <s>with html tags</s>
 <% end %>
 
 I am in the template

--- a/middleman-core/fixtures/content-for-app/source/content_for_haml.html.haml
+++ b/middleman-core/fixtures/content-for-app/source/content_for_haml.html.haml
@@ -1,4 +1,4 @@
 - content_for :from_template do
-  = "I am the yielded content haml"
+  = "I am the yielded content haml <s>with html tags</s>"
 
 %p I am in the template

--- a/middleman-core/fixtures/content-for-app/source/content_for_slim.html.slim
+++ b/middleman-core/fixtures/content-for-app/source/content_for_slim.html.slim
@@ -1,4 +1,5 @@
 - content_for :from_template do
-  | I am the yielded content slim
+  | I am the yielded content slim 
+  s with html tags
 
 | I am in the template


### PR DESCRIPTION
It appears by [updating the padrino helpers to v11](https://github.com/middleman/middleman/commit/69c36e691f06d07cad26cc1129abc060d2b7cfd7) there have been some changes to the default behaviour for the `content_for`, `capture_html`, etc.. helper tags.

[In a blog post annoucing the v11](http://www.padrinorb.com/blog/padrino-0-11-0-released-padrino-lives) they mention the change (search for "ActiveSupport::SafeBuffer"). Digging a little deeper [this pull request](https://github.com/padrino/padrino-framework/pull/1031) outlines the change but a TLDR; is that Padrino is assuming unsafe strings by default.

The haml tests pass because they have been [flagged as safe already?](https://github.com/middleman/middleman/blob/69c36e691f06d07cad26cc1129abc060d2b7cfd7/middleman-core/lib/vendored-middleman-deps/padrino-core-0.11.2/lib/padrino-core/application/rendering/extensions/haml.rb#L22), the same is [true for slim?](https://github.com/middleman/middleman/blob/69c36e691f06d07cad26cc1129abc060d2b7cfd7/middleman-core/lib/vendored-middleman-deps/padrino-core-0.11.2/lib/padrino-core/application/rendering/extensions/slim.rb#L10)

However, [erb is different?](https://github.com/middleman/middleman/blob/69c36e691f06d07cad26cc1129abc060d2b7cfd7/middleman-core/lib/vendored-middleman-deps/padrino-core-0.11.2/lib/padrino-core/application/rendering/extensions/erubis.rb#L11)

Haven't gotten deeper then this but at least now the tests are representative of what the [docs state](http://beta.middlemanapp.com/helpers/#toc_2).

Its difficult to grok whats changed / going on straight away due to the multiple layers ( us, padrino-helpers, tilt, template engines )
