### PR TITLE
Prevent relative asset helper from munging data URIs

### DIFF
--- a/middleman-more/features/relative_assets.feature
+++ b/middleman-more/features/relative_assets.feature
@@ -100,3 +100,14 @@ Feature: Relative Assets
     And the Server is running at "relative-assets-app"
     When I go to "/sub/image_tag.html"
     Then I should see '<img src="../img/blank.gif" />'
+
+  Scenario: Relative assets should not break data URIs in image_tag
+    Given a fixture app "relative-assets-app"
+    Given "relative_assets" feature is "enabled"
+    And a file named "source/sub/image_tag.html.erb" with:
+      """
+      <%= image_tag "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" %>
+      """
+    And the Server is running at "relative-assets-app"
+    When I go to "/sub/image_tag.html"
+    Then I should see '<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" />'

--- a/middleman-more/lib/middleman-more/core_extensions/assets.rb
+++ b/middleman-more/lib/middleman-more/core_extensions/assets.rb
@@ -26,7 +26,8 @@ module Middleman
         # @return [String] The fully qualified asset url
         def asset_url(path, prefix="")
           # Don't touch assets which already have a full path
-          if path.include?("//")
+          # or are inline data URIs
+          if path.include?('//') or path.start_with?('data:')
             path
           else # rewrite paths to use their destination path
             path = File.join(prefix, path)

--- a/middleman-more/lib/middleman-more/core_extensions/default_helpers.rb
+++ b/middleman-more/lib/middleman-more/core_extensions/default_helpers.rb
@@ -89,7 +89,7 @@ module Middleman
         # @param [String] source The path to the file
         # @return [String]
         def asset_path(kind, source)
-          return source if source.to_s.include?('//')
+          return source if source.to_s.include?('//') || source.to_s.start_with?('data:')
           asset_folder  = case kind
             when :css    then css_dir
             when :js     then js_dir

--- a/middleman-more/lib/middleman-more/extensions/relative_assets.rb
+++ b/middleman-more/lib/middleman-more/extensions/relative_assets.rb
@@ -32,7 +32,7 @@ module Middleman
         def asset_url(path, prefix="")
           path = super(path, prefix)
 
-          if path.include?("//") || !current_resource
+          if path.include?('//') || path.start_with?('data:') || !current_resource
             path
           else
             current_dir = Pathname('/' + current_resource.destination_path)


### PR DESCRIPTION
Fully qualified URLs are considered to be only those with `//` in them (another issue, as that is valid, but odd in the path) but this excludes URLs that start with `data:`

This fix adds an explicit fix for that common senario.
