### PR TITLE
Fix content_tag helper, only try to mark content as safe if it is not a hash of options

### DIFF
--- a/middleman-core/lib/middleman-more/core_extensions/default_helpers.rb
+++ b/middleman-core/lib/middleman-more/core_extensions/default_helpers.rb
@@ -50,7 +50,8 @@ class Middleman::CoreExtensions::DefaultHelpers < ::Middleman::Extension
 
     # Make all block content html_safe
     def content_tag(name, content = nil, options = nil, &block)
-      mark_safe(super(name, mark_safe(content), options, &block))
+      content = mark_safe(content) unless content.is_a?(Hash)
+      mark_safe(super(name, content, options, &block))
     end
 
     def capture_html(*args, &block)


### PR DESCRIPTION
The Padrino content_tag helper can be used in two ways: http://www.padrinorb.com/api/Padrino/Helpers/TagHelpers.html#content_tag-instance_method
The second one (content given in a block not string) failed after this recent commit: a52effc119cdd29304efbef92b766ab79ea0a1fc
