### PR TITLE
Fixed typo in middleman-core/core-extensions/request.rb.

### DIFF
--- a/middleman-core/lib/middleman-core/core_extensions/request.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/request.rb
@@ -71,7 +71,7 @@ module Middleman
             app.use Rack::Lint
 
             Array(@middleware).each do |klass, options, blockm|
-              app.use(klass, *options, &block)
+              app.use(klass, *options, &blockm)
             end
 
             inner_app = inst(&block)


### PR DESCRIPTION
There is, I believe, a typo in this file which prevents the use of blocks with middleware such as Rack::Rewrite.
