### PR TITLE
Loading an image repeatedly in the server throws a 500 Internal Server Error

### DIFF
--- a/middleman-core/lib/middleman-core/core_extensions/request.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/request.rb
@@ -291,8 +291,13 @@ module Middleman
           file      = ::Rack::File.new nil
           file.path = resource.source_file
           response = file.serving(env)
+          status = response[0]
           response[1]['Content-Encoding'] = 'gzip' if %w(.svgz .gz).include?(resource.ext)
-          response[1]['Content-Type'] = resource.content_type || "application/octet-stream"
+          # Do not set Content-Type if status is 1xx, 204, 205 or 304, otherwise
+          # Rack will throw an error (500)
+          if !(100..199).include?(status) && ![204, 205, 304].include?(status)
+            response[1]['Content-Type'] = resource.content_type || "application/octet-stream"
+          end
           halt response
         end
       end


### PR DESCRIPTION
I had some strange behavior with the server where each time I hit refresh in the browser, some of the images wouldn't load. On the next refresh, these images (that didn't load before) would load and the rest (that loaded before) wouldn't this time. Looking at the console, I saw that the images failed with a 500 Internal Server Error. Requesting an image directly and hitting refresh time after time, it would alternate between successfully showing the image (200) and (304) throwing the following error: "Content-Type header found in 304 response, not allowed" I narrowed this down to Rack's `check_content_type` function in `lib/rack/lint.rb` where it documents this behavior.
