### PR TITLE
kramdown 1.0.x -> 1.1

### DIFF
--- a/middleman/middleman.gemspec
+++ b/middleman/middleman.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |s|
   s.add_dependency("uglifier", ["~> 2.1.0"])
   s.add_dependency("coffee-script", ["~> 2.2.0"])
   s.add_dependency("execjs", ["~> 1.4.0"])
-  s.add_dependency("kramdown", ["~> 1.0.0"])
+  s.add_dependency("kramdown", ["~> 1.1.0"])
 end


### PR DESCRIPTION
Middleman's kramdown dependency was set to pessimistic versioning `~>1.0.0`. I needed some of the features/bugfixes added to kramdown 1.1, which was released a couple of weeks ago. All specs appear to pass on my end.
