### PR TITLE
Default markdown renderer (kramdown) does not use Middleman Sitemap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 master
 ===
 
+* Magic sitemap-aware links and image references now work when your markdown engine is Kramdown (the default for Middleman).
+* Having the build directory be a symlink no longer causes the --clean (default) option to wipe out your build.
+* Fix handling paths and URLs with spaces in them. #961
+* Loosen up Kramdown dependency to allow for using version 1.2.
+
 3.1.5
 ===
 
@@ -253,7 +258,7 @@ master
 3.0.0.rc.2
 ====
 * Doing a build now shows identical files (#475)
-* asset_hash, minify_javascript, and minify_css can now accept regexes, globs, 
+* asset_hash, minify_javascript, and minify_css can now accept regexes, globs,
   and procs (#489, #480)
 * The `link_to` helper can now accept a sitemap Resource as a URL (#474)
 * The preview server now correctly listens for changes (#487, #464)

--- a/middleman-core/features/markdown_kramdown.feature
+++ b/middleman-core/features/markdown_kramdown.feature
@@ -1,0 +1,36 @@
+Feature: Markdown (Kramdown) support
+  In order to test included Kramdown support
+
+  Scenario: Kramdown smartypants extension
+    Given a fixture app "markdown-app"
+    And a file named "config.rb" with:
+      """
+      set :markdown_engine, :kramdown
+      set :markdown, :smartypants => true
+      """
+    Given the Server is running at "markdown-app"
+    When I go to "/smarty_pants.html"
+    Then I should see "“Hello”"
+
+  Scenario: Kramdown uses our link_to and image_tag helpers
+    Given a fixture app "markdown-app"
+    And a file named "config.rb" with:
+      """
+      set :markdown_engine, :kramdown
+      activate :automatic_image_sizes
+      activate :directory_indexes
+      """
+    And a file named "source/link_and_image.html.markdown" with:
+      """
+      [A link](/smarty_pants.html)
+
+      ![image](blank.gif)
+
+      [Mail me](mailto:ben@benhollis.net)
+      """
+    Given the Server is running at "markdown-app"
+    When I go to "/link_and_image/"
+    Then I should see "/smarty_pants/"
+    Then I should see 'width="1"'
+    And I should see 'height="1"'
+    And I should see 'src="/images/blank.gif"'

--- a/middleman-core/features/markdown_kramdown_in_haml.feature
+++ b/middleman-core/features/markdown_kramdown_in_haml.feature
@@ -1,0 +1,41 @@
+Feature: Markdown support in Haml (Kramdown)
+  In order to test support of the Haml markdown filter
+
+  Scenario: Markdown filter in Haml works (with Kramdown)
+    Given a fixture app "markdown-in-haml-app"
+    And a file named "config.rb" with:
+      """
+      set :markdown_engine, :kramdown
+      activate :directory_indexes
+      """
+    And a file named "source/markdown_filter.html.haml" with:
+      """
+      :markdown
+        # H1
+
+        paragraph
+      """
+    Given the Server is running at "markdown-in-haml-app"
+    When I go to "/markdown_filter/"
+    Then I should see "<h1 id="h1">H1</h1>"
+    Then I should see "<p>paragraph</p>"
+
+
+  Scenario: Markdown filter in Haml uses our link_to and image_tag helpers (with Kramdown)
+    Given a fixture app "markdown-in-haml-app"
+    And a file named "config.rb" with:
+      """
+      set :markdown_engine, :kramdown
+      activate :directory_indexes
+      """
+    And a file named "source/link_and_image.html.haml" with:
+      """
+      :markdown
+        [A link](/link_target.html)
+
+        ![image](blank.gif)
+      """
+    Given the Server is running at "markdown-in-haml-app"
+    When I go to "/link_and_image/"
+    Then I should see "/link_target/"
+    Then I should see 'src="/images/blank.gif"'

--- a/middleman-core/features/markdown_redcarpet.feature
+++ b/middleman-core/features/markdown_redcarpet.feature
@@ -1,6 +1,6 @@
 @nojava
-Feature: Markdown support
-  In order to test included Maruku support
+Feature: Markdown (Redcarpet) support
+  In order to test included Redcarpet support
 
   Scenario: Redcarpet 2 extensions
     Given a fixture app "markdown-app"

--- a/middleman-core/lib/middleman-core/renderers/kramdown.rb
+++ b/middleman-core/lib/middleman-core/renderers/kramdown.rb
@@ -1,0 +1,41 @@
+require "kramdown"
+
+module Middleman
+  module Renderers
+
+    # Our own Kramdown Tilt template that simply uses our custom renderer.
+    class KramdownTemplate < ::Tilt::KramdownTemplate
+      def evaluate(scope, locals, &block)
+        @output ||= begin
+          output, warnings = MiddlemanKramdownHTML.convert(@engine.root, @engine.options)
+          @engine.warnings.concat(warnings)
+          output
+        end
+      end
+    end
+
+    # Custom Kramdown renderer that uses our helpers for images and links
+    class MiddlemanKramdownHTML < ::Kramdown::Converter::Html
+      cattr_accessor :middleman_app
+
+      def convert_img(el, indent)
+        attrs = el.attr.dup
+        link = attrs.delete('src')
+        middleman_app.image_tag(link, attrs)
+      end
+
+      def convert_a(el, indent)
+        content = inner(el, indent)
+        attr = el.attr.dup
+        if attr['href'] =~ /\Amailto:/
+          mail_addr = attr['href'].sub(/\Amailto:/, '')
+          attr['href'] = obfuscate('mailto') << ":" << obfuscate(mail_addr)
+          content = obfuscate(content) if content == mail_addr
+        end
+
+        link = attr.delete('href')
+        middleman_app.link_to(content, link, attr)
+      end
+    end
+  end
+end

--- a/middleman-core/lib/middleman-core/renderers/markdown.rb
+++ b/middleman-core/lib/middleman-core/renderers/markdown.rb
@@ -23,13 +23,18 @@ module Middleman
 
           # Once configuration is parsed
           app.after_configuration do
+            markdown_exts = %w(markdown mdown md mkd mkdn)
 
             begin
               # Look for the user's preferred engine
               if config[:markdown_engine] == :redcarpet
                 require "middleman-core/renderers/redcarpet"
-                ::Tilt.prefer(::Middleman::Renderers::RedcarpetTemplate)
+                ::Tilt.prefer(::Middleman::Renderers::RedcarpetTemplate, *markdown_exts)
                 MiddlemanRedcarpetHTML.middleman_app = self
+              elsif config[:markdown_engine] == :kramdown
+                require "middleman-core/renderers/kramdown"
+                ::Tilt.prefer(::Middleman::Renderers::KramdownTemplate, *markdown_exts)
+                MiddlemanKramdownHTML.middleman_app = self
               elsif !config[:markdown_engine].nil?
                 # Map symbols to classes
                 markdown_engine_klass = if config[:markdown_engine].is_a? Symbol
@@ -41,7 +46,7 @@ module Middleman
                 end
 
                 # Tell tilt to use that engine
-                ::Tilt.prefer(markdown_engine_klass)
+                ::Tilt.prefer(markdown_engine_klass, *markdown_exts)
               end
             rescue LoadError
               logger.warn "Requested Markdown engine (#{config[:markdown_engine]}) not found. Maybe the gem needs to be installed and required?"


### PR DESCRIPTION
Kramdown should be overridden to use Middleman's sitemap object, in order to allow relative linking and other features of the link_to and url_for helpers.
