### PR TITLE
Do not cache generated redirect index file.

### DIFF
--- a/middleman-core/lib/middleman-core/sitemap/extensions/redirects.rb
+++ b/middleman-core/lib/middleman-core/sitemap/extensions/redirects.rb
@@ -77,7 +77,7 @@ module Middleman
           def template?
             true
           end
-      
+
           def render(*args, &block)
             url = ::Middleman::Util.url_for(store.app, @request_path, :relative => false, :find_resource => true)
 
@@ -89,6 +89,7 @@ module Middleman
                   <head>
                     <meta http-equiv=refresh content="0; url=#{url}" />
                     <meta name="robots" content="noindex,follow" />
+                    <meta http-equiv="cache-control" content="no-cache" />
                   </head>
                   <body>
                   </body>


### PR DESCRIPTION
Returning visitors to site were being redirected to the old page because their browser was caching the index page which was pointing to the previously URL.
