### PR TITLE
metadata[:blocks] array is growing on every request

### DIFF
--- a/middleman-core/lib/middleman-core/sitemap/resource.rb
+++ b/middleman-core/lib/middleman-core/sitemap/resource.rb
@@ -57,6 +57,7 @@ module Middleman
       # @return [Hash]
       def metadata
         result = store.metadata_for_path(path).dup
+        result[:blocks] = result[:blocks].dup
 
         file_meta = store.metadata_for_file(source_file).dup
         if file_meta.has_key?(:blocks)


### PR DESCRIPTION
Serious bug, when metadata[:blocks] array is growing on every request in a huge amount of times, that cause a memory leaks and callback duplicate problems. Steps to reproduce:
- Call add_metadata{p :hello} at any resource once,
- Render a resource several times,
- :hello will output to a console for a growing number of times!

I'm not sure, how to provide tests for that, sorry...
