### PR TITLE
Documentation: Windows users use a VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ These days, many websites are built with an API in mind. Rather than package the
 
 ## Install
 
-Middleman is built on Ruby and uses the RubyGems package manager for installation. These are usually pre-installed on Mac OS X and Linux. Windows users can install both using [RubyInstaller].
+Middleman is built on Ruby and uses the RubyGems package manager for installation. These are usually pre-installed on Mac OS X and Linux. Windows users can install both using [RubyInstaller]. However since Windows is not a system used by many middleman developers Windows users should consider working inside a Linux virtual machine. 
 
 ```
 gem install middleman


### PR DESCRIPTION
I enjoy working with middleman. However after my first projects I have come to the conclusion that working with middleman on Windows machines is guarantee for constant source of frustration. It seems to me there are so many extra steps to take to get things up and running and so many little pieces that don't quite work as they should (e.g. js compression or additional gems that have never been tested with Windows before) that most Windows users are just better off developing inside a Linux VM. It seems to me Windows is just not very well supported in the Ruby universe since not a lot of people use it. 

If you agree here is a patch.
