### PR TITLE
Upgrade url_for to search for resources relative to their destination path

### DIFF
--- a/middleman-core/features/directory_index.feature
+++ b/middleman-core/features/directory_index.feature
@@ -27,12 +27,12 @@ Feature: Directory Index
     And the file "regular/index.html" should contain "Regular"
     And the file "evil spaces/index.html" should contain "Spaces"
 
-    
+
   Scenario: Preview normal file
     Given the Server is running at "indexable-app"
     When I go to "/needs_index/"
     Then I should see "Indexable"
-    
+
   Scenario: Preview normal file with spaces in filename
     Given the Server is running at "indexable-app"
     When I go to "/evil%20spaces/"
@@ -42,7 +42,7 @@ Feature: Directory Index
     Given the Server is running at "indexable-app"
     When I go to "/a_folder/needs_index/"
     Then I should see "Indexable"
-    
+
   Scenario: Preview ignored file
     Given the Server is running at "indexable-app"
     When I go to "/leave_me_alone/"
@@ -69,14 +69,13 @@ Feature: Directory Index
     And the Server is running at "indexable-app"
     When I go to "/link_to/"
     Then I should see 'link_to: <a href="/needs_index/">Needs Index</a>'
-    Then I should see 'explicit_link_to: <a href="/needs_index/index.html">Explicit</a>'
+    Then I should see 'explicit_link_to: <a href="/needs_index/">Explicit</a>'
     Then I should see 'unknown_link_to: <a href="/unknown.html">Unknown</a>'
     Then I should see 'relative_link_to: <a href="/needs_index/">Relative</a>'
     Then I should see 'link_to_with_spaces: <a href="/evil%20spaces/">Spaces</a>'
     When I go to "/link_to/sub/"
     Then I should see 'link_to: <a href="/needs_index/">Needs Index</a>'
-    Then I should see 'explicit_link_to: <a href="/needs_index/index.html">Explicit</a>'
+    Then I should see 'explicit_link_to: <a href="/needs_index/">Explicit</a>'
     Then I should see 'unknown_link_to: <a href="/unknown.html">Unknown</a>'
     Then I should see 'relative_link_to: <a href="/needs_index/">Relative</a>'
     Then I should see 'link_to_with_spaces: <a href="/evil%20spaces/">Spaces</a>'
-

--- a/middleman-core/lib/middleman-core/util.rb
+++ b/middleman-core/lib/middleman-core/util.rb
@@ -183,7 +183,16 @@ module Middleman
         current_source_dir = Pathname('/' + this_resource.path).dirname
         url_path = current_source_dir.join(url_path) if url_path.relative?
         resource = app.sitemap.find_resource_by_path(url_path.to_s)
-        resource_url = resource.url if resource
+        if resource
+          resource_url = resource.url
+        else
+          # Try to find a resource relative to destination paths
+          url_path = Pathname(uri.path)
+          current_source_dir = Pathname('/' + this_resource.destination_path).dirname
+          url_path = current_source_dir.join(url_path) if url_path.relative?
+          resource = app.sitemap.find_resource_by_destination_path(url_path.to_s)
+          resource_url = resource.url if resource
+        end
       elsif options[:find_resource] && uri.path
         resource = app.sitemap.find_resource_by_path(uri.path)
         resource_url = resource.url if resource


### PR DESCRIPTION
...as well as their source paths. This would fix #818.

I'm not 100% sure I like this (it feels like we're trying too hard, and I'm worried we'd "find" links that we shouldn't, or that people would lose what little concept they have of how Middleman is supposed to work) but it would fix some confusion we've seen.

Take special note of the change I had to make to the directory_indexes test.
