### PR TITLE
Allow logging to be sent to a file

### DIFF
--- a/middleman-core/lib/middleman-core/logger.rb
+++ b/middleman-core/lib/middleman-core/logger.rb
@@ -1,15 +1,14 @@
 # Use the Ruby/Rails logger
-require 'active_support/core_ext/logger'
+require 'active_support/notifications'
+require 'active_support/buffered_logger'
 require 'thread'
 
 module Middleman
 
   # The Middleman Logger
-  class Logger < ::Logger
-
-    # Force output to STDOUT
-    def initialize(log_level=1, is_instrumenting=false, target=STDOUT)
-      super(STDOUT)
+  class Logger < ActiveSupport::BufferedLogger
+    def initialize(log_level=1, is_instrumenting=false, target=$stdout)
+      super(target)
 
       self.level = log_level
       @instrumenting = is_instrumenting

--- a/middleman-core/lib/middleman-core/util.rb
+++ b/middleman-core/lib/middleman-core/util.rb
@@ -48,6 +48,9 @@ module Middleman
     # @return [Middleman::Logger] The logger
     def self.logger(*args)
       if !@_logger || args.length > 0
+        if args.length == 1 && (args.first.is_a?(::String) || args.first.respond_to?(:write))
+          args = [0, false, args.first]
+        end
         @_logger = ::Middleman::Logger.new(*args)
       end
 


### PR DESCRIPTION
In config.rb, you can write:

``` ruby
logger 'middleman.log'
```

It's not the best - I'd rather have the logfile be a config setting (along with log level and instrumenting) but this is the best I can do right now without major surgery. This should help #1004 if not completely solve it.
