### PR TITLE
Gracefully handle syntax (and other) errors when reloading config.rb.

### DIFF
--- a/middleman-core/fixtures/padrino-helpers-app/config.rb
+++ b/middleman-core/fixtures/padrino-helpers-app/config.rb
@@ -1,0 +1,7 @@
+helpers do
+  def title
+    content_tag :h1 do
+      "Title"
+    end
+  end
+end


### PR DESCRIPTION
With this change, config.rb modifications that result in an error will print the error to the logs but will not kill the server - the previous version of the application will still be running just fine, so that you can try and fix your config.rb without having to restart. The server no longer simply hangs with no message, which was the previous behavior. This fixes #702.
