### PR TITLE
Adding -B option as an alias to --skip-bundle

### DIFF
--- a/middleman-core/lib/middleman-core/cli/init.rb
+++ b/middleman-core/lib/middleman-core/cli/init.rb
@@ -34,6 +34,7 @@ module Middleman::Cli
       :desc    => "Don't create a Gemfile"
     method_option "skip-bundle",
       :type    => :boolean,
+      :aliases => "-B",
       :default => false,
       :desc    => "Don't run bundle install"
     method_option "skip-git",


### PR DESCRIPTION
On creating new project, when we don't want middleman to execute `bundle install`, we use `--skip-bundle` option.

```
$ middleman init my_new_project --skip-bundle
```

That's happy enough, but in rails, `--skip-bundle` option has an alias, `-B` short option, so maybe middleman can have the same interface.

```
$ middleman init my_new_project -B
```

How do you feel about it?
