### PR TITLE
add the missing file back for the automatic_alt_tag feature

### DIFF
--- a/middleman-core/lib/middleman-more/extensions/automatic_alt_tags.rb
+++ b/middleman-core/lib/middleman-more/extensions/automatic_alt_tags.rb
@@ -1,0 +1,32 @@
+# Automatic Image alt tags from image names extension
+class Middleman::Extensions::AutomaticAltTags < ::Middleman::Extension
+
+  def initialize(app, options_hash={}, &block)
+    super
+  end
+
+  helpers do
+    # Override default image_tag helper to automatically insert alt tag
+    # containing image name.
+
+    def image_tag(path)
+      if !path.include?("://")
+        params[:alt] ||= ""
+
+        real_path = path
+        real_path = File.join(images_dir, real_path) unless real_path.start_with?('/')
+        full_path = File.join(source_dir, real_path)
+
+        if File.exists?(full_path)
+          begin
+            alt_text = File.basename(full_path, ".*")
+            alt_text.capitalize!
+            params[:alt] = alt_text
+          end
+        end
+      end
+
+      super(path)
+    end
+  end
+end


### PR DESCRIPTION
Just noticed this working off master for the meta page asset paths --- I believe this is coming from the removal of the automatic_alt_tags.rb file in b813db397f51a35bddb80b7afafea4a00ccc51ba

```
/Users/username/code/middleman/middleman-core/lib/middleman-core/core_extensions.rb:94:in `require': cannot load such file -- middleman-more/extensions/automatic_alt_tags (LoadError)
```

Assuming the specs are good -- should be good to go from here.
