### PR TITLE
Add link contents in maito in kramdown test

### DIFF
--- a/middleman-core/features/markdown_kramdown.feature
+++ b/middleman-core/features/markdown_kramdown.feature
@@ -26,7 +26,7 @@ Feature: Markdown (Kramdown) support
 
       ![image](blank.gif)
 
-      (mailto:mail@mail.com)
+      [mail@mail.com](mailto:mail@mail.com)
       """
     Given the Server is running at "markdown-app"
     When I go to "/link_and_image/"


### PR DESCRIPTION
Last little bit I promise :)

Just noticed this failing test as the mailto link didn't have any contents --- I didn't see anything in the Kramdown specs suggesting that it should work as such -- so adding the contents.
