### PR TITLE
Handle UTF-8-MAC filename on MacOS

### DIFF
--- a/middleman-core/lib/middleman-core/cli/build.rb
+++ b/middleman-core/lib/middleman-core/cli/build.rb
@@ -205,8 +205,13 @@ module Middleman::Cli
 
         output_path = render_to_file(resource)
 
-        if should_clean?
-          @to_clean.delete(output_path.realpath) if output_path.exist?
+        if should_clean? && output_path.exist?
+          if RUBY_PLATFORM =~ /darwin/
+            # handle UTF-8-MAC filename on MacOS
+            @to_clean.delete_if { |path| path.to_s.encode('UTF-8', 'UTF-8-MAC')  == output_path.realpath.to_s }
+          else
+            @to_clean.delete(output_path.realpath)
+          end
         end
       end
 


### PR DESCRIPTION
Hi, I'm using middleman with Japanese on MaxOSX, and I noticed that there is a `UTF-8-MAC` filename issue.

log:

```
fk82% bundle exec middleman version
Middleman 3.2.0

# first build
fk82% bundle exec middleman build
   identical  build/feed.xml
   identical  build/index.html
   identical  build/2012/09/02/tddbc-yokohama-2nd/index.html
      create  build/tags/ルビー/index.html
   identical  build/tags/tdd/index.html
   identical  build/2012/index.html
   identical  build/2012/09/index.html
   identical  build/2012/09/02/index.html

# second build (source files are not changed)
fk82% bundle exec middleman build
   identical  build/feed.xml
   identical  build/index.html
   identical  build/2012/09/02/tddbc-yokohama-2nd/index.html
   identical  build/tags/ルビー/index.html
   identical  build/tags/tdd/index.html
   identical  build/2012/index.html
   identical  build/2012/09/index.html
   identical  build/2012/09/02/index.html
      remove  build/tags/ルビー/index.html
      remove  build/tags/ルビー
```

In the seccond build, `build/tags/ルビー/index.html` is identical but removed. Because paths in `@to_clean` are  `UTF-8-MAC` (and `output_path.realpath.to_s` is `UTF-8`),  `@to_clean.delete(output_path.realpath)` do nothing.

link:
- [Ruby 1.9.3 Dir.glob not returning NFC UTF-8 strings, returns NFD instead - Stack Overflow](http://stackoverflow.com/questions/13193329/ruby-1-9-3-dir-glob-not-returning-nfc-utf-8-strings-returns-nfd-instead)
