### PR TITLE
Fix a perf regression when building

### DIFF
--- a/middleman-core/lib/middleman-core/cli/build.rb
+++ b/middleman-core/lib/middleman-core/cli/build.rb
@@ -162,6 +162,11 @@ module Middleman::Cli
       @to_clean += paths.select do |path|
         path.to_s !~ /\/\./ || path.to_s =~ /\.(htaccess|htpasswd)/
       end
+
+      if RUBY_PLATFORM =~ /darwin/
+        # handle UTF-8-MAC filename on MacOS
+        @to_clean.map { |path| path.to_s.encode('UTF-8', 'UTF-8-MAC') }
+      end
     end
 
     # Actually build the app
@@ -206,12 +211,7 @@ module Middleman::Cli
         output_path = render_to_file(resource)
 
         if should_clean? && output_path.exist?
-          if RUBY_PLATFORM =~ /darwin/
-            # handle UTF-8-MAC filename on MacOS
-            @to_clean.delete_if { |path| path.to_s.encode('UTF-8', 'UTF-8-MAC')  == output_path.realpath.to_s }
-          else
-            @to_clean.delete(output_path.realpath)
-          end
+          @to_clean.delete(output_path.realpath)
         end
       end
 


### PR DESCRIPTION
Commit 8e99d3957019c8924b9f2a88ac37891be751a210 introduced a serious regression by encoding filenames within a "delete_if" block, meaning that every path in the list of all previously built files was re-encoded every time a file was built. For large projects this causes serious slowdowns - for a 4000 file test, it went from 14s to build to around 8 minutes to build. This change fixes the builder to only encode files when the file list is initially build, removing the bottleneck.
