### PR TITLE
Specify the full path to the NEWLINE constant

### DIFF
--- a/middleman-core/features/helpers_select_tag.feature
+++ b/middleman-core/features/helpers_select_tag.feature
@@ -1,0 +1,19 @@
+Feature: select_tag helper
+
+  Scenario: select_tag produces correct options
+    Given a fixture app "indexable-app"
+    And an empty file named "config.rb"
+    And a file named "source/select_tag.html.erb" with:
+    """
+    options as array: <%= select_tag :colors, options: ["red", "blue", "blorange"], include_blank: "Choose a color" %>
+    """
+    And the Server is running at "indexable-app"
+    When I go to "/select_tag.html"
+    Then I should see:
+    """
+    <select name="colors"><option value="">Choose a color</option>
+    <option value="red">red</option>
+    <option value="blue">blue</option>
+    <option value="blorange">blorange</option>
+    </select>
+    """

--- a/middleman-core/lib/middleman-more/core_extensions/default_helpers.rb
+++ b/middleman-core/lib/middleman-more/core_extensions/default_helpers.rb
@@ -49,7 +49,7 @@ class Middleman::CoreExtensions::DefaultHelpers < ::Middleman::Extension
       output = ActiveSupport::SafeBuffer.new
       output.safe_concat "<#{name}#{attributes}>"
       if content.respond_to?(:each) && !content.is_a?(String)
-        content.each { |c| output.safe_concat c; output.safe_concat NEWLINE }
+        content.each { |c| output.safe_concat c; output.safe_concat ::Padrino::Helpers::TagHelpers::NEWLINE }
       else
         output.safe_concat "#{content}"
       end


### PR DESCRIPTION
I was getting the following error when trying to use the `select_tag` helper:

```
NameError: uninitialized constant Middleman::CoreExtensions::DefaultHelpers::NEWLINE
    /Users/matt/.rvm/gems/ruby-2.0.0-p353/gems/middleman-core-3.2.1/lib/middleman-more/core_extensions/default_helpers.rb:52:in `block in content_tag'
    /Users/matt/.rvm/gems/ruby-2.0.0-p353/gems/middleman-core-3.2.1/lib/middleman-more/core_extensions/default_helpers.rb:52:in `each'
    /Users/matt/.rvm/gems/ruby-2.0.0-p353/gems/middleman-core-3.2.1/lib/middleman-more/core_extensions/default_helpers.rb:52:in `content_tag'
    /Users/matt/.rvm/gems/ruby-2.0.0-p353/gems/middleman-core-3.2.1/lib/vendored-middleman-deps/padrino-helpers-0.11.4/lib/padrino-helpers/tag_helpers.rb:146:in `safe_content_tag'
    /Users/matt/.rvm/gems/ruby-2.0.0-p353/gems/middleman-core-3.2.1/lib/vendored-middleman-deps/padrino-helpers-0.11.4/lib/padrino-helpers/form_helpers.rb:626:in `select_tag'
...truncated
```

After investigating it, I created the included feature to test this, and fixed the code by specifying `::Padrino::Helpers::TagHelpers::NEWLINE`, assuming that is the `NEWLINE` constant that you wanted to use in this method.

Let me know if there is anything else I can do to get this in, or if I missed something here.
