### PR TITLE
Put template rendering in a jail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - rvm: ruby-head
+    - rvm: 2.1.0
     - rvm: jruby-19mode
 env: TEST=true
 before_install: git submodule update --init --recursive

--- a/middleman-core/lib/middleman-core/application.rb
+++ b/middleman-core/lib/middleman-core/application.rb
@@ -44,15 +44,6 @@ module Middleman
     # Runs after the build is finished
     define_hook :after_build
 
-    # Mix-in helper methods. Accepts either a list of Modules
-    # and/or a block to be evaluated
-    # @return [void]
-    def self.helpers(*extensions, &block)
-      class_eval(&block)   if block_given?
-      include(*extensions) if extensions.any?
-    end
-    delegate :helpers, :to => :"self.class"
-
     # Root project directory (overwritten in middleman build/server)
     # @return [String]
     def self.root
@@ -170,11 +161,16 @@ module Middleman
     # Template cache
     attr_reader :cache
 
+    attr_reader :generic_template_context
+    delegate :link_to, :image_tag, :to => :generic_template_context
+
     # Initialize the Middleman project
     def initialize(&block)
       @cache = ::Tilt::Cache.new
       @logger = ::Middleman::Logger.singleton
-      @config_context = ConfigContext.new(self)
+      @template_context_class = Class.new(Middleman::TemplateContext)
+      @generic_template_context = @template_context_class.new(self)
+      @config_context = ConfigContext.new(self, @template_context_class)
 
       # Setup the default values from calls to set before initialization
       self.class.config.load_settings(self.class.superclass.config.all_settings)

--- a/middleman-core/lib/middleman-core/config_context.rb
+++ b/middleman-core/lib/middleman-core/config_context.rb
@@ -6,14 +6,30 @@ module Middleman
     attr_reader :app
 
     # Whitelist methods that can reach out.
-    delegate :config, :logger, :activate, :use, :map, :mime_type, :data, :helpers, :template_extensions, :root, :to => :app
+    delegate :config, :logger, :activate, :use, :map, :mime_type, :data, :template_extensions, :root, :to => :app
 
-    def initialize(app)
+    def initialize(app, template_context_class)
       @app = app
+      @template_context_class = template_context_class
+
       @ready_callbacks = []
       @after_build_callbacks = []
       @after_configuration_callbacks = []
       @configure_callbacks = {}
+    end
+
+    def helpers(*helper_modules, &block)
+      helper_modules ||= []
+
+      if block_given?
+        block_module = Module.new
+        block_module.module_eval(&block)
+        helper_modules << block_module
+      end
+
+      helper_modules.each do |mod|
+        @template_context_class.send :include, mod
+      end
     end
 
     def ready(&block)

--- a/middleman-core/lib/middleman-core/core_extensions/extensions.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/extensions.rb
@@ -182,6 +182,11 @@ module Middleman
             end
 
             if klass.is_a?(::Middleman::Extension)
+              # Forward Extension helpers to TemplateContext
+              (klass.class.defined_helpers || []).each do |m|
+                @template_context_class.send(:include, m)
+              end
+
               ::Middleman::Extension.activated_extension(klass)
             end
           end

--- a/middleman-core/lib/middleman-core/core_extensions/external_helpers.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/external_helpers.rb
@@ -24,7 +24,7 @@ module Middleman
             require filename
             next unless Object.const_defined?(module_name.to_sym)
 
-            helpers Object.const_get(module_name.to_sym)
+            @template_context_class.send :include, Object.const_get(module_name.to_sym)
           end
         end
       end

--- a/middleman-core/lib/middleman-core/core_extensions/front_matter.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/front_matter.rb
@@ -81,13 +81,11 @@ module Middleman::CoreExtensions
       end
     end
 
-    helpers do
-      # Get the template data from a path
-      # @param [String] path
-      # @return [String]
-      def template_data_for_file(path)
-        extensions[:frontmatter].data(path).last
-      end
+    # Get the template data from a path
+    # @param [String] path
+    # @return [String]
+    def template_data_for_file(path)
+      data(path).last
     end
 
     def data(path)

--- a/middleman-core/lib/middleman-core/extension.rb
+++ b/middleman-core/lib/middleman-core/extension.rb
@@ -20,7 +20,7 @@ module Middleman
       def helpers(*m, &block)
         self.defined_helpers ||= []
 
-        if block
+        if block_given?
           mod = Module.new
           mod.module_eval(&block)
           m = [mod]
@@ -81,8 +81,11 @@ module Middleman
     def app=(app)
       @app = app
 
-      (self.class.defined_helpers || []).each do |m|
-        app.class.send(:include, m)
+      ext = self
+      if ext.respond_to?(:instance_available)
+        @klass.instance_available do
+          ext.instance_available
+        end
       end
     end
 

--- a/middleman-core/lib/middleman-core/renderers/haml.rb
+++ b/middleman-core/lib/middleman-core/renderers/haml.rb
@@ -4,24 +4,42 @@ require 'haml'
 module Middleman
   module Renderers
 
+    # Haml precompiles filters before the scope is even available,
+    # thus making it impossible to pass our Middleman instance
+    # in. So we have to resort to heavy hackery :(
+    class HamlTemplate < ::Tilt::HamlTemplate
+      def prepare
+      end
+
+      def evaluate(scope, locals, &block)
+        ::Middleman::Renderers::Haml.last_haml_scope = scope
+
+        options = @options.merge(:filename => eval_file, :line => line)
+        @engine = ::Haml::Engine.new(data, options)
+        output = @engine.render(scope, locals, &block)
+
+        ::Middleman::Renderers::Haml.last_haml_scope = nil
+
+        output
+      end
+    end
+
     # Haml Renderer
     module Haml
+      mattr_accessor :last_haml_scope
 
       # Setup extension
       class << self
         # Once registered
         def registered(app)
+          ::Tilt.prefer(::Middleman::Renderers::HamlTemplate, 'haml')
+
           app.before_configuration do
             template_extensions :haml => :html
           end
 
           # Add haml helpers to context
-          app.send :include, ::Haml::Helpers
-
-          # Setup haml helper paths
-          app.ready do
-            init_haml_helpers
-          end
+          ::Middleman::TemplateContext.send :include, ::Haml::Helpers
         end
         alias :included :registered
       end

--- a/middleman-core/lib/middleman-core/renderers/kramdown.rb
+++ b/middleman-core/lib/middleman-core/renderers/kramdown.rb
@@ -7,6 +7,8 @@ module Middleman
     class KramdownTemplate < ::Tilt::KramdownTemplate
       def evaluate(scope, locals, &block)
         @output ||= begin
+          MiddlemanKramdownHTML.scope = ::Middleman::Renderers::Haml.last_haml_scope || scope
+
           output, warnings = MiddlemanKramdownHTML.convert(@engine.root, @engine.options)
           @engine.warnings.concat(warnings)
           output
@@ -16,13 +18,13 @@ module Middleman
 
     # Custom Kramdown renderer that uses our helpers for images and links
     class MiddlemanKramdownHTML < ::Kramdown::Converter::Html
-      cattr_accessor :middleman_app
+      cattr_accessor :scope
 
       def convert_img(el, indent)
         attrs = el.attr.dup
 
         link = attrs.delete('src')
-        middleman_app.image_tag(link, attrs)
+        scope.image_tag(link, attrs)
       end
 
       def convert_a(el, indent)
@@ -37,7 +39,7 @@ module Middleman
 
         attr = el.attr.dup
         link = attr.delete('href')
-        middleman_app.link_to(content, link, attr)
+        scope.link_to(content, link, attr)
       end
     end
   end

--- a/middleman-core/lib/middleman-core/renderers/markdown.rb
+++ b/middleman-core/lib/middleman-core/renderers/markdown.rb
@@ -30,11 +30,9 @@ module Middleman
               if config[:markdown_engine] == :redcarpet
                 require 'middleman-core/renderers/redcarpet'
                 ::Tilt.prefer(::Middleman::Renderers::RedcarpetTemplate, *markdown_exts)
-                MiddlemanRedcarpetHTML.middleman_app = self
               elsif config[:markdown_engine] == :kramdown
                 require 'middleman-core/renderers/kramdown'
                 ::Tilt.prefer(::Middleman::Renderers::KramdownTemplate, *markdown_exts)
-                MiddlemanKramdownHTML.middleman_app = self
               elsif !config[:markdown_engine].nil?
                 # Map symbols to classes
                 markdown_engine_klass = if config[:markdown_engine].is_a? Symbol

--- a/middleman-core/lib/middleman-core/renderers/redcarpet.rb
+++ b/middleman-core/lib/middleman-core/renderers/redcarpet.rb
@@ -40,6 +40,14 @@ module Middleman
         renderer.new(render_options)
       end
 
+      def evaluate(scope, locals, &block)
+        @output ||= begin
+          MiddlemanRedcarpetHTML.scope = ::Middleman::Renderers::Haml.last_haml_scope || scope
+
+          @engine.render(data)
+        end
+      end
+
       private
 
         def covert_options_to_aliases!
@@ -51,7 +59,7 @@ module Middleman
 
     # Custom Redcarpet renderer that uses our helpers for images and links
     class MiddlemanRedcarpetHTML < ::Redcarpet::Render::HTML
-      cattr_accessor :middleman_app
+      cattr_accessor :scope
 
       def initialize(options={})
         @local_options = options.dup
@@ -61,7 +69,7 @@ module Middleman
 
       def image(link, title, alt_text)
         if !@local_options[:no_images]
-          middleman_app.image_tag(link, :title => title, :alt => alt_text)
+          scope.image_tag(link, :title => title, :alt => alt_text)
         else
           link_string = link.dup
           link_string << %Q{"#{title}"} if title && title.length > 0 && title != alt_text
@@ -74,7 +82,7 @@ module Middleman
           attributes = { :title => title }
           attributes.merge!( @local_options[:link_attributes] ) if @local_options[:link_attributes]
 
-          middleman_app.link_to(content, link, attributes )
+          scope.link_to(content, link, attributes )
         else
           link_string = link.dup
           link_string << %Q{"#{title}"} if title && title.length > 0 && title != alt_text

--- a/middleman-core/lib/middleman-core/renderers/sass.rb
+++ b/middleman-core/lib/middleman-core/renderers/sass.rb
@@ -74,7 +74,7 @@ module Middleman
         def sass_options
           more_opts = { :filename => eval_file, :line => line, :syntax => syntax }
 
-          if @context.is_a?(::Middleman::Application) && file
+          if @context.is_a?(::Middleman::TemplateContext) && file
             location_of_sass_file = @context.source_dir
 
             parts = basename.split('.')

--- a/middleman-core/lib/middleman-core/sitemap.rb
+++ b/middleman-core/lib/middleman-core/sitemap.rb
@@ -31,7 +31,7 @@ module Middleman
         }, 'Callbacks that can exclude paths from the sitemap'
 
         # Include instance methods
-        app.send :include, InstanceMethods
+        ::Middleman::TemplateContext.send :include, InstanceMethods
       end
 
     end

--- a/middleman-core/lib/middleman-core/template_context.rb
+++ b/middleman-core/lib/middleman-core/template_context.rb
@@ -1,0 +1,105 @@
+module Middleman
+  class TemplateContext
+    attr_reader :app
+    attr_accessor :current_engine, :current_path
+
+    delegate :config, :logger, :sitemap, :build?, :development?, :data, :extensions, :source_dir, :root, :to => :app
+
+    def initialize(app, locs={}, opts={})
+      @app = app
+      @current_locs = locs
+      @current_opts = opts
+    end
+
+    def save_buffer
+      @_out_buf, _buf_was = '', @_out_buf
+      _buf_was
+    end
+
+    def restore_buffer(_buf_was)
+      @_out_buf = _buf_was
+    end
+
+    # Allow layouts to be wrapped in the contents of other layouts
+    # @param [String, Symbol] layout_name
+    # @return [void]
+    def wrap_layout(layout_name, &block)
+      # Save current buffer for later
+      _buf_was = save_buffer
+
+      layout_path = @app.locate_layout(layout_name, self.current_engine)
+
+      extension = File.extname(layout_path)
+      engine = extension[1..-1].to_sym
+
+      # Store last engine for later (could be inside nested renders)
+      self.current_engine, engine_was = engine, self.current_engine
+
+      begin
+        content = if block_given?
+          capture_html(&block)
+        else
+          ''
+        end
+      ensure
+        # Reset stored buffer
+        restore_buffer(_buf_was)
+      end
+
+      concat_safe_content @app.render_individual_file(layout_path, @current_locs || {}, @current_opts || {}, self) { content }
+    ensure
+      self.current_engine = engine_was
+    end
+
+    # Sinatra/Padrino compatible render method signature referenced by some view
+    # helpers. Especially partials.
+    #
+    # @param [String, Symbol] engine
+    # @param [String, Symbol] data
+    # @param [Hash] options
+    # @return [String]
+    def render(engine, data, options={}, &block)
+      data = data.to_s
+
+      locals = options[:locals]
+
+      found_partial = false
+      engine        = nil
+
+      # If the path is known to the sitemap
+      if resource = sitemap.find_resource_by_path(current_path)
+        current_dir = File.dirname(resource.source_file)
+        engine = File.extname(resource.source_file)[1..-1].to_sym
+
+        # Look for partials relative to the current path
+        relative_dir = File.join(current_dir.sub(%r{^#{Regexp.escape(self.source_dir)}/?}, ''), data)
+
+        # Try to use the current engine first
+        found_partial, found_engine = @app.resolve_template(relative_dir, :preferred_engine => engine, :try_without_underscore => true)
+
+        # Fall back to any engine available
+        if !found_partial
+          found_partial, found_engine = @app.resolve_template(relative_dir, :try_without_underscore => true)
+        end
+      end
+
+      # Look in the partials_dir for the partial with the current engine
+      partials_path = File.join(config[:partials_dir], data)
+      if !found_partial && !engine.nil?
+        found_partial, found_engine = @app.resolve_template(partials_path, :preferred_engine => engine, :try_without_underscore => true)
+      end
+
+      # Look in the root with any engine
+      if !found_partial
+        found_partial, found_engine = @app.resolve_template(partials_path, :try_without_underscore => true)
+      end
+
+      # Render the partial if found, otherwide throw exception
+      if found_partial
+        @app.render_individual_file(found_partial, locals, options, self, &block)
+      else
+        raise ::Middleman::CoreExtensions::Rendering::TemplateNotFound, "Could not locate partial: #{data}"
+      end
+    end
+  end
+end

--- a/middleman-core/lib/middleman-more/extensions/gzip.rb
+++ b/middleman-core/lib/middleman-more/extensions/gzip.rb
@@ -12,6 +12,10 @@
 class Middleman::Extensions::Gzip < ::Middleman::Extension
   option :exts, %w(.js .css .html .htm), 'File extensions to Gzip when building.'
 
+  class NumberHelpers
+    include ::Padrino::Helpers::NumberHelpers
+  end
+
   def initialize(app, options_hash={})
     super
 
@@ -57,11 +61,11 @@ class Middleman::Extensions::Gzip < ::Middleman::Extension
       if output_filename
         total_savings += (old_size - new_size)
         size_change_word = (old_size - new_size) > 0 ? 'smaller' : 'larger'
-        builder.say_status :gzip, "#{output_filename} (#{app.number_to_human_size((old_size - new_size).abs)} #{size_change_word})"
+        builder.say_status :gzip, "#{output_filename} (#{NumberHelpers.new.number_to_human_size((old_size - new_size).abs)} #{size_change_word})"
       end
     end
 
-    builder.say_status :gzip, "Total gzip savings: #{app.number_to_human_size(total_savings)}", :blue
+    builder.say_status :gzip, "Total gzip savings: #{NumberHelpers.new.number_to_human_size(total_savings)}", :blue
     I18n.locale = old_locale
   end
 


### PR DESCRIPTION
Work in progress (not passing all tests yet) move to a `TemplateContext` class to sandbox template rendering.

Pretty happy with most of this. Some things still aren't working, such as partials, `wrap_layout` and template instance variables. The first two make sense, we took all their shared global state away and now they don't know what the hell is going on. I'll figure out how to deal with that.

However... what should be do about template instance variables? Seems like something that v4 would be a good time to remove support for. Are there things you can do with instance vars that you couldn't with locals?
