### PR TITLE
added an alias for `console` command

### DIFF
--- a/middleman-cli/lib/middleman-cli/console.rb
+++ b/middleman-cli/lib/middleman-cli/console.rb
@@ -1,7 +1,9 @@
 # CLI Module
 module Middleman::Cli
+  # Alias "c" to "console"
+  Base.map({ 'c' => 'console' })
 
-  # A thor task for creating new projects
+  # The CLI Console class
   class Console < Thor
     include Thor::Actions
 


### PR DESCRIPTION
Almost every other command has an alias except `console`. Also the comment
above the class definition wrongly said `console` was a command for creating
new projects. Corrected appropriately
