### PR TITLE
Fix dynamic pages link in the config template

### DIFF
--- a/middleman-core/lib/middleman-core/templates/shared/config.tt
+++ b/middleman-core/lib/middleman-core/templates/shared/config.tt
@@ -24,7 +24,7 @@
 #   page "/admin/*"
 # end
 
-# Proxy pages (http://middlemanapp.com/dynamic-pages/)
+# Proxy pages (http://middlemanapp.com/basics/dynamic-pages/)
 # proxy "/this-page-has-no-template.html", "/template-file.html", :locals => {
 #  :which_fake_page => "Rendering a fake page with a local variable" }
 


### PR DESCRIPTION
Hey everyone!

It seems that the page indicated in the config doesn't work anymore (http://middlemanapp.com/dynamic-pages/), so this tiny fix might help people jump to the right page faster.

Thanks!
