### PR TITLE
Update Uglifier to 1.4.0 in middleman.gemspec

### DIFF
--- a/middleman/middleman.gemspec
+++ b/middleman/middleman.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency("haml", [">= 3.1.6"])
   s.add_dependency("sass", [">= 3.1.20"])
   s.add_dependency("compass", [">= 0.12.2"])
-  s.add_dependency("uglifier", ["~> 2.1.0"])
+  s.add_dependency("uglifier", ["~> 2.4.0"])
   s.add_dependency("coffee-script", ["~> 2.2.0"])
   s.add_dependency("execjs", ["~> 1.4.0"])
   s.add_dependency("kramdown", ["~> 1.2"])


### PR DESCRIPTION
Bump Uglifier dependency for backport to v3-stable. All tests pass.

Closes https://github.com/middleman/middleman/issues/1159

~ Jonathan
