### PR TITLE
Update the console to the new logger syntax.

### DIFF
--- a/middleman-core/lib/middleman-core/cli/console.rb
+++ b/middleman-core/lib/middleman-core/cli/console.rb
@@ -32,7 +32,7 @@ module Middleman::Cli
           set :environment, opts[:environment].to_sym
         end
 
-        logger(opts[:debug] ? 0 : 1, opts[:instrumenting] || false)
+        ::Middleman::Logger.singleton(opts[:debug] ? 0 : 1, opts[:instrumenting] || false)
       end
 
       # TODO: get file watcher / reload! working in console


### PR DESCRIPTION
This fixes an issue that prevents the console from running.

``` bash
$ middleman console
/Users/jgreen/.rvm/gems/ruby-2.1.0/gems/middleman-core-3.2.2/lib/middleman-core/cli/console.rb:35:in `block in console': wrong number of arguments (2 for 0) (ArgumentError)
from /Users/jgreen/.rvm/gems/ruby-2.1.0/gems/middleman-core-3.2.2/lib/middleman-core/application.rb:180:in `instance_exec'
from /Users/jgreen/.rvm/gems/ruby-2.1.0/gems/middleman-core-3.2.2/lib/middleman-core/application.rb:180:in `initialize'
from /Users/jgreen/.rvm/gems/ruby-2.1.0/gems/middleman-core-3.2.2/lib/middleman-core/core_extensions/request.rb:52:in `new'
from /Users/jgreen/.rvm/gems/ruby-2.1.0/gems/middleman-core-3.2.2/lib/middleman-core/core_extensions/request.rb:52:in `inst'
from /Users/jgreen/.rvm/gems/ruby-2.1.0/gems/middleman-core-3.2.2/lib/middleman-core/cli/console.rb:30:in `console'
from /Users/jgreen/.rvm/gems/ruby-2.1.0/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
from /Users/jgreen/.rvm/gems/ruby-2.1.0/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
from /Users/jgreen/.rvm/gems/ruby-2.1.0/gems/thor-0.18.1/lib/thor.rb:363:in `dispatch'
from /Users/jgreen/.rvm/gems/ruby-2.1.0/gems/thor-0.18.1/lib/thor/base.rb:439:in `start'
from /Users/jgreen/.rvm/gems/ruby-2.1.0/gems/middleman-core-3.2.2/lib/middleman-core/cli.rb:77:in `method_missing'
from /Users/jgreen/.rvm/gems/ruby-2.1.0/gems/thor-0.18.1/lib/thor/command.rb:29:in `run'
from /Users/jgreen/.rvm/gems/ruby-2.1.0/gems/thor-0.18.1/lib/thor/command.rb:128:in `run'
from /Users/jgreen/.rvm/gems/ruby-2.1.0/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
from /Users/jgreen/.rvm/gems/ruby-2.1.0/gems/thor-0.18.1/lib/thor.rb:363:in `dispatch'
from /Users/jgreen/.rvm/gems/ruby-2.1.0/gems/thor-0.18.1/lib/thor/base.rb:439:in `start'
from /Users/jgreen/.rvm/gems/ruby-2.1.0/gems/middleman-core-3.2.2/lib/middleman-core/cli.rb:22:in `start'
from /Users/jgreen/.rvm/gems/ruby-2.1.0/gems/middleman-core-3.2.2/bin/middleman:18:in `<top (required)>'
from /Users/jgreen/.rvm/gems/ruby-2.1.0/bin/middleman:23:in `load'
from /Users/jgreen/.rvm/gems/ruby-2.1.0/bin/middleman:23:in `<main>'
from /Users/jgreen/.rvm/gems/ruby-2.1.0/bin/ruby_executable_hooks:15:in `eval'
from /Users/jgreen/.rvm/gems/ruby-2.1.0/bin/ruby_executable_hooks:15:in `<main>'
```
