### PR TITLE
Allow array of renderer options

### DIFF
--- a/middleman-core/lib/middleman-core/core_extensions/rendering.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/rendering.rb
@@ -316,8 +316,8 @@ module Middleman
             ::Tilt.mappings.each do |mapping_ext, engines|
               next unless engines.include? extension_class
               engine_options = config[mapping_ext.to_sym] || {}
-              engine_options = engine_options.each_with_object({}) do |k, h|
-                k.is_a?(Array) ? h.store(*k) : h[k] = true
+              if engine_options.is_a?(Array)
+                engine_options = engine_options.each_with_object({}){ |x, h| h[x] = true }
               end
               options.merge!(engine_options)
             end


### PR DESCRIPTION
Options can now be passed with `set :markdown, %i[options here]` and are converted to a hash with true values `{options: true, here: true}` internally.
Previously only hashes were allowed, so this change is fully backwards compatible as it'll only affect arrays.
Mentioned in #1154
