### PR TITLE
Prefer loading layouts from `layouts_dir`

### DIFF
--- a/middleman-core/features/layouts_dir.feature
+++ b/middleman-core/features/layouts_dir.feature
@@ -28,3 +28,11 @@ Feature: Layouts dir
     When I go to "/index.html"
     Then I should see "contents of the layout"
 
+  Scenario: Prefer a layout in the layouts_dir to one with the same name in the root
+    Given a fixture app "layouts-dir-app"
+    And a file named "config.rb" with:
+    """
+    """
+    And the Server is running
+    When I go to "/ambiguous.html"
+    Then I should see "contents of the layout in layouts_dir"

--- a/middleman-core/fixtures/layouts-dir-app/source/ambiguous.html.erb
+++ b/middleman-core/fixtures/layouts-dir-app/source/ambiguous.html.erb
@@ -1,0 +1,5 @@
+---
+layout: other
+---
+
+Hello

--- a/middleman-core/fixtures/layouts-dir-app/source/layouts/other.erb
+++ b/middleman-core/fixtures/layouts-dir-app/source/layouts/other.erb
@@ -1,0 +1,3 @@
+contents of the layout in layouts_dir
+
+<%= yield %>

--- a/middleman-core/fixtures/layouts-dir-app/source/other.erb
+++ b/middleman-core/fixtures/layouts-dir-app/source/other.erb
@@ -1,0 +1,3 @@
+contents of the layout in the root
+
+<%= yield %>


### PR DESCRIPTION
Prefer loading layouts from `layouts_dir` over layouts with the same name in the source root. This also includes a bunch of refactoring/cleanup of rendering.rb. Fixes #1176.
