### PR TITLE
Be quiet about missing extras when middleman-core is used alone

### DIFF
--- a/middleman-core/lib/middleman-core/core_extensions.rb
+++ b/middleman-core/lib/middleman-core/core_extensions.rb
@@ -35,7 +35,6 @@ require 'middleman-more/core_extensions/i18n'
 begin
   require 'middleman-more/core_extensions/compass'
 rescue LoadError
-  $stderr.puts "Compass not installed: #{$!}"
 end
 
 ###

--- a/middleman-core/lib/middleman-core/renderers/markdown.rb
+++ b/middleman-core/lib/middleman-core/renderers/markdown.rb
@@ -49,7 +49,11 @@ module Middleman
                 ::Tilt.prefer(markdown_engine_klass, *markdown_exts)
               end
             rescue LoadError
-              logger.warn "Requested Markdown engine (#{config[:markdown_engine]}) not found. Maybe the gem needs to be installed and required?"
+              # If they just left it at the default engine and don't happen to have it,
+              # then they're using middleman-core bare and we shouldn't bother them.
+              if config.setting(:markdown_engine).value_set?
+                logger.warn "Requested Markdown engine (#{config[:markdown_engine]}) not found. Maybe the gem needs to be installed and required?"
+              end
             end
           end
         end


### PR DESCRIPTION
I've been playing around a bit with using `middleman-core` on its own, and it complains too much about dependencies that should be totally optional.
