### PR TITLE
Requiring extensions inconsistent with RubyGems

### DIFF
--- a/middleman-core/lib/middleman-core/extensions.rb
+++ b/middleman-core/lib/middleman-core/extensions.rb
@@ -41,7 +41,12 @@ module Middleman
       end
 
       extensions.each do |spec|
-        require spec.name
+        begin
+          require spec.name
+        rescue LoadError
+          # Fall back to RubyGems convention
+          require spec.name.gsub('-', '/')
+        end
       end
     end
 


### PR DESCRIPTION
At the moment, we require an extension by:
1. Checking for the existence of a `lib/middleman_extension.rb` file.
2. Requiring the gemspec name.

In other words, to make a gem work with Middleman, your gem is required using file located at `lib/<gemspec name>.rb`.

This isn't consistent with [RubyGems' naming conventions](http://guides.rubygems.org/name-your-gem/).

RubyGems expects that a gem with the name `middleman-some_library` should be required with `require 'middleman/some_library'`. It would be good to support this.

If this seems reasonable, I'd be happy to contribute a patch that supports the existing behaviour, but that also supports the RubyGems convention.
