### PR TITLE
Prevent the file watcher from recursively enumerating into paths that it should ignore

### DIFF
--- a/middleman-core/lib/middleman-core/preview_server.rb
+++ b/middleman-core/lib/middleman-core/preview_server.rb
@@ -133,10 +133,12 @@ module Middleman
             @webrick.stop
           else
             added_and_modified.each do |path|
+              next if app.files.ignored?(path)
               app.files.did_change(path)
             end
 
             removed.each do |path|
+              next if app.files.ignored?(path)
               app.files.did_delete(path)
             end
           end


### PR DESCRIPTION
This should fix the issue in #1197 as well as provide a performance boost when starting 'middleman server'.
