### PR TITLE
FileWatcher Refactor

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,8 @@ AllCops:
     - 'middleman-core/fixtures/**/*'
     - 'middleman-core/features/**/*'
     - 'middleman-core/spec/**/*'
+DoubleNegation:
+  Enabled: false
 LineLength:
   Enabled: false
 MethodLength:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 master
 ===
 
+* New FileWatcher API.
 * Remove the `partials_dir` setting. Partials should live next to content, or be addressed with absolute paths.
 * Partials must be named with a leading underscore. `_my_snippet.html.erb`, not `my_snippet.html.erb`.
 * Removed the `proxy` and `ignore` options for the `page` command in `config.rb`. Use the `proxy` and `ignore` commands instead of passing these options to `page`.

--- a/middleman-cli/lib/middleman-cli/build.rb
+++ b/middleman-cli/lib/middleman-cli/build.rb
@@ -194,7 +194,7 @@ module Middleman::Cli
       logger.debug '== Checking for generated images'
 
       # Double-check for generated images
-      @app.extensions[:file_watcher].api.find_new_files((@source_dir + @app.config[:images_dir]).relative_path_from(@app.root_path))
+      @app.files.find_new_files((@source_dir + @app.config[:images_dir]).relative_path_from(@app.root_path))
       @app.sitemap.ensure_resource_list_updated!
 
       # Sort paths to be built by the above order. This is primarily so Compass can

--- a/middleman-core/lib/middleman-core/core_extensions/data.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/data.rb
@@ -20,10 +20,15 @@ module Middleman
 
         # Setup data files before anything else so they are available when
         # parsing config.rb
-        file_watcher.changed(data_file_matcher, &app.extensions[:data].data_store.method(:touch_file))
-        file_watcher.deleted(data_file_matcher, &app.extensions[:data].data_store.method(:remove_file))
+        app.files.changed(data_file_matcher, &app.extensions[:data].data_store.method(:touch_file))
+        app.files.deleted(data_file_matcher, &app.extensions[:data].data_store.method(:remove_file))
 
-        file_watcher.reload_path(app.config[:data_dir])
+        # Tell the file watcher to observe the :data_dir
+        app.files.watch :data do |path, _app|
+          path.match data_file_matcher
+        end
+
+        app.files.reload_path(app.config[:data_dir])
       end
 
       helpers do

--- a/middleman-core/lib/middleman-core/core_extensions/front_matter.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/front_matter.rb
@@ -27,8 +27,8 @@ module Middleman::CoreExtensions
     end
 
     def before_configuration
-      file_watcher.changed(&method(:clear_data))
-      file_watcher.deleted(&method(:clear_data))
+      app.files.changed(&method(:clear_data))
+      app.files.deleted(&method(:clear_data))
     end
 
     # @return Array<Middleman::Sitemap::Resource>
@@ -96,7 +96,7 @@ module Middleman::CoreExtensions
 
       data = {}
 
-      return [data, nil] if !file_watcher.exists?(full_path) || ::Middleman::Util.binary?(full_path)
+      return [data, nil] if !app.files.exists?(full_path) || ::Middleman::Util.binary?(full_path)
 
       content = File.read(full_path)
 

--- a/middleman-core/lib/middleman-core/extension.rb
+++ b/middleman-core/lib/middleman-core/extension.rb
@@ -179,8 +179,6 @@ module Middleman
     #   @return [void]
     def_delegator :"::Middleman::Extension", :after_extension_activated
 
-    def_delegator :"@app.extensions[:file_watcher]", :api, :file_watcher
-
     # Extensions are instantiated when they are activated.
     # @param [Middleman::Application] app The Middleman::Application instance
     # @param [Hash] options_hash The raw options hash. Subclasses should not manipulate this directly - it will be turned into {#options}.
@@ -242,8 +240,7 @@ module Middleman
     end
 
     def bind_before_configuration
-      return unless respond_to?(:before_configuration)
-      @app.before_configuration(&method(:before_configuration))
+      @app.before_configuration(&method(:before_configuration)) if respond_to?(:before_configuration)
     end
 
     def bind_after_configuration

--- a/middleman-core/lib/middleman-core/renderers/sass.rb
+++ b/middleman-core/lib/middleman-core/renderers/sass.rb
@@ -59,6 +59,10 @@ module Middleman
         require 'middleman-core/renderers/sass_functions'
       end
 
+      def before_configuration
+        app.files.watch :sass_cache, /(^|\/)\.sass-cache\//
+      end
+
       # A SassTemplate for Tilt which outputs debug messages
       class SassPlusCSSFilenameTemplate < ::Tilt::SassTemplate
         def initialize(*args, &block)

--- a/middleman-core/lib/middleman-core/sitemap/extensions/on_disk.rb
+++ b/middleman-core/lib/middleman-core/sitemap/extensions/on_disk.rb
@@ -24,8 +24,8 @@ module Middleman
 
         Contract None => Any
         def before_configuration
-          file_watcher.changed(&method(:touch_file))
-          file_watcher.deleted(&method(:remove_file))
+          app.files.changed(&method(:touch_file))
+          app.files.deleted(&method(:remove_file))
         end
 
         # Update or add an on-disk file path

--- a/middleman-core/lib/middleman-core/step_definitions/middleman_steps.rb
+++ b/middleman-core/lib/middleman-core/step_definitions/middleman_steps.rb
@@ -9,9 +9,9 @@ Then /^the file "([^\"]*)" is removed$/ do |path|
 end
 
 Then /^the file "([^\"]*)" did change$/ do |path|
-  @server_inst.extensions[:file_watcher].api.did_change(path)
+  @server_inst.files.did_change(path)
 end
 
 Then /^the file "([^\"]*)" did delete$/ do |path|
-  @server_inst.extensions[:file_watcher].api.did_delete(path)
+  @server_inst.files.did_delete(path)
 end

--- a/middleman-core/lib/middleman-core/util.rb
+++ b/middleman-core/lib/middleman-core/util.rb
@@ -223,14 +223,16 @@ module Middleman
     def self.all_files_under(path, &ignore)
       path = Pathname(path)
 
-      return [] if ignore && ignore.call(path)
-
       if path.directory?
         path.children.flat_map do |child|
           all_files_under(child, &ignore)
         end.compact
       elsif path.file?
-        [path]
+        if block_given? && ignore.call(path)
+          []
+        else
+          [path]
+        end
       else
         []
       end


### PR DESCRIPTION
This is a work-in-progress refactor of how the `FileWatcher` (the public API that Sitemap builds upon) decides which files are relevant.

Before, there was a single list of ignore regexes. This meant we constantly had to add new items to avoid processing stuff we shouldn't (`node_modules`, swap files, etc).

Now, there is an opt-in list (`source`, `lib`, `data`, `locales`, etc) AND an opt-out (git, swap files, etc).

The opt-in items can now be either a regex OR a Proc. The Proc lets us keep the list up to date when items are based on config values (`source`, `data_dir`, etc).

It it also possible to add new ignores and watchers from `config.rb`. I'm not happy with the naming of these methods, but for now, they are:

```
watcher_add :xml_stuff, /^xml/.*\.xml$/
ignore_add :subversion, /\.svn/
```

Would love some input, @bhollis @karlfreeman 
