### PR TITLE
Webrick should not do reverse DNS lookups

### DIFF
--- a/middleman-core/lib/middleman-core/preview_server.rb
+++ b/middleman-core/lib/middleman-core/preview_server.rb
@@ -166,9 +166,10 @@ module Middleman
       # @return [void]
       def setup_webrick(is_logging)
         http_opts = {
-          :BindAddress => host,
-          :Port        => port,
-          :AccessLog   => []
+          :BindAddress        => host,
+          :Port               => port,
+          :AccessLog          => [],
+          :DoNotReverseLookup => true
         }
 
         if is_logging


### PR DESCRIPTION
This prevents Middleman server from being terribly slow over network. Closes #1118.
