### PR TITLE
Move middleman-templates to cli

### DIFF
--- a/middleman-cli/middleman-cli.gemspec
+++ b/middleman-cli/middleman-cli.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.required_ruby_version = '>= 1.9.3'
 
+  s.add_dependency('middleman-templates', Middleman::VERSION)
+
   # CLI
   s.add_dependency('thor', ['>= 0.17.0', '< 2.0'])
 end

--- a/middleman/middleman.gemspec
+++ b/middleman/middleman.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency('middleman-core', Middleman::VERSION)
   s.add_dependency('middleman-cli', Middleman::VERSION)
-  s.add_dependency('middleman-templates', Middleman::VERSION)
   s.add_dependency('middleman-sprockets', '>= 3.1.2')
   s.add_dependency('haml', ['>= 3.1.6'])
   s.add_dependency('sass', ['>= 3.1.20'])


### PR DESCRIPTION
Pull request for a discussion.

@bhollis [quite rightly pointed](https://github.com/middleman/middleman/commit/772de85ce332d8c4e50cb486c8671d8688dfd3a2#commitcomment-5841776) out that I had'nt made `middleman-templates` a dependency on `middleman-cli`. A quick solution is to do just that and move the dependency.

When thinking about it I started to wonder if it might be worth gracefully handling when `middleman-templates` is not available. Eg. continue to make `middleman-templates` a `middleman` dependency and when failing to `require 'middleman-templates'` not load the `init` command.

It might not be worth it but just fielding the question. @tdreyno Is the intention of `middleman-cli` to encapsulate all actions or is the decision for abstracting `middleman-cli` to allow for it to be used standalone?
