### PR TITLE
Mobile friendly host & windows fix

### DIFF
--- a/middleman-core/lib/middleman-core/preview_server.rb
+++ b/middleman-core/lib/middleman-core/preview_server.rb
@@ -15,7 +15,7 @@ module Middleman
       # @return [void]
       def start(opts={})
         @options = opts
-        @host = @options[:host] || Socket.gethostname
+        @host = @options[:host] || Socket.ip_address_list.find(&:ipv4_private?).ip_address
         @port = @options[:port] || DEFAULT_PORT
 
         mount_instance(new_app)


### PR DESCRIPTION
Address `0.0.0.0` isn't valid on windows, use localhost instead
Finds a local IP that will allow the development server to also run on mobiles

Will overwrite https://github.com/middleman/middleman/commit/87acf687d57bb6a4e259e7e66b7c97cc4543278d on master (#1199)
