### PR TITLE
CLI: Always require 'middleman-core/version'

### DIFF
--- a/middleman-core/lib/middleman-core/cli.rb
+++ b/middleman-core/lib/middleman-core/cli.rb
@@ -25,7 +25,6 @@ module Middleman
 
       desc 'version', 'Show version'
       def version
-        require 'middleman-core/version'
         say "Middleman #{Middleman::VERSION}"
       end
 
@@ -80,6 +79,9 @@ module Middleman
     end
   end
 end
+
+# Require the Middleman version
+require 'middleman-core/version'
 
 # Include the core CLI items
 require 'middleman-core/cli/init'


### PR DESCRIPTION
The `init` command will fail if the `VERSION` was not required because it is needed for the Gemfile generation. Unfortunately this was not catched by the specs because the specs require the version and the child process is not correctly reset.

I was not able to change this easily :-(
