### PR TITLE
Don't hang on to the first Logger instance you see

### DIFF
--- a/middleman-core/lib/middleman-core/application.rb
+++ b/middleman-core/lib/middleman-core/application.rb
@@ -149,7 +149,9 @@ module Middleman
     include Middleman::CoreExtensions::ExternalHelpers
 
     # Reference to Logger singleton
-    attr_reader :logger
+    def logger
+      ::Middleman::Logger.singleton
+    end
 
     # New container for config.rb commands
     attr_reader :config_context
@@ -167,7 +169,6 @@ module Middleman
 
     # Initialize the Middleman project
     def initialize(&block)
-      @logger = ::Middleman::Logger.singleton
       @template_context_class = Class.new(Middleman::TemplateContext)
       @generic_template_context = @template_context_class.new(self)
       @config_context = ConfigContext.new(self, @template_context_class)


### PR DESCRIPTION
If the main app instance hangs on to the logger that ::Middleman::Logger.singleton returns, then subsequent calls to re-init the logger won't have any effect (for instance, when setting up the preview server's logger based on CLI params).

Redefining logger to be a pass-through to ::Middleman::Logger.singleton instead of an ivar seems more in keeping with the sprit of a singleton, anyways.

This fixes an issue where running `middleman server --verbose` doesn't output any debug info.
