### PR TITLE
Change default IP for CLI server

### DIFF
--- a/middleman-core/lib/middleman-core/cli/server.rb
+++ b/middleman-core/lib/middleman-core/cli/server.rb
@@ -15,7 +15,7 @@ module Middleman::Cli
     method_option :host,
       :type    => :string,
       :aliases => '-h',
-      :default => '0.0.0.0',
+      :default => Socket.ip_address_list.find(&:ipv4_private?).ip_address,
       :desc    => 'Bind to HOST address'
     method_option :port,
       :aliases => '-p',


### PR DESCRIPTION
Enables https://github.com/middleman/middleman/pull/1248 by default.
Was sure I tested that PR and it worked... or I'm just going crazy. :eyes:
I believe both are still needed because `middleman-core` doesn't include the CLI stuff I'm patching here.
