### PR TITLE
Fix rubocop config.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,10 @@
 AllCops:
-  Includes:
+  Include:
     - Rakefile
     - Gemfile
     - config.ru
     - gem_rake_helper.rb
-  Excludes:
+  Exclude:
     - script/**
     - vendor/**
     - bin/**


### PR DESCRIPTION
Hi!
Don't know if it is still used, but still.

Since rubocop v0.20.0 'AllCops/Excludes' and 'AllCops/Includes' where renamed to
'AllCops/Exclude' and 'AllCops/Include'.

This pull request fixes the config.
Cheers!
