### PR TITLE
Abstracted HTML rewriter

### DIFF
--- a/middleman-core/features/asset_hash.feature
+++ b/middleman-core/features/asset_hash.feature
@@ -94,7 +94,7 @@ Feature: Assets get a file hash appended to their and references to them are upd
       activate :relative_assets
       activate :directory_indexes
       require 'lib/middleware.rb'
-      use Middleware
+      use ::Middleware
       """
     Given the Server is running at "asset-hash-app"
     When I go to "/"

--- a/middleman-core/lib/middleman-core/middleware/inline_url_rewriter.rb
+++ b/middleman-core/lib/middleman-core/middleware/inline_url_rewriter.rb
@@ -1,0 +1,67 @@
+require 'middleman-core/util'
+require 'rack'
+require 'rack/response'
+
+module Middleman
+  module Middleware
+    class InlineURLRewriter
+      def initialize(app, options={})
+        @rack_app = app
+        @middleman_app = options[:middleman_app]
+
+        @uid = options[:id]
+        @proc = options[:proc]
+
+        raise "InlineURLRewriter requires a :proc to call with inline URL results" unless @proc
+
+        @exts = options[:url_extensions]
+
+        @source_exts = options[:source_extensions]
+        @source_exts_regex_text = Regexp.union(@source_exts).to_s
+
+        @ignore = options[:ignore]
+      end
+
+      def call(env)
+        status, headers, response = @rack_app.call(env)
+
+        # Allow upstream request to skip all rewriting
+        return [status, headers, response] if env['bypass_inline_url_rewriter'] == 'true'
+
+        # Allow upstream request to skip this specific rewriting
+        if @uid
+          uid_key = "bypass_inline_url_rewriter_#{@uid}"
+          return [status, headers, response] if env[uid_key] == 'true'
+        end
+
+        path = ::Middleman::Util.full_path(env['PATH_INFO'], @middleman_app)
+    
+        if path =~ /(^\/$)|(#{@source_exts_regex_text}$)/
+          if body = ::Middleman::Util.extract_response_text(response)
+            dirpath = Pathname.new(File.dirname(path))
+
+            rewritten = ::Middleman::Util.rewrite_paths(body, path, @exts) do |asset_path|
+              relative_path = Pathname.new(asset_path).relative?
+
+              full_asset_path = if relative_path
+                dirpath.join(asset_path).to_s
+              else
+                asset_path
+              end
+
+              @ignore.none? { |r| full_asset_path.match(r) } && @proc.call(asset_path, dirpath)
+            end
+
+            status, headers, response = ::Rack::Response.new(
+              rewritten,
+              status,
+              headers
+            ).finish
+          end
+        end
+
+        [status, headers, response]
+      end
+    end
+  end
+end

--- a/middleman-core/lib/middleman-core/util.rb
+++ b/middleman-core/lib/middleman-core/util.rb
@@ -222,6 +222,19 @@ module Middleman
         end
       end
 
+      def rewrite_paths(body, path, exts, &block)
+        body.dup.gsub(/([=\'\"\(]\s*)([^\s\'\"\)]+(#{Regexp.union(exts)}))/) do |match|
+          opening_character = $1
+          asset_path = $2
+
+          if result = yield(asset_path)
+            "#{opening_character}#{result}"
+          else
+            match
+          end
+        end
+      end
+
       private
 
       # Is mime type known to be non-binary?


### PR DESCRIPTION
This is a first pass at taking the `asset_hash` code for finding URLs in documents and replacing them and making it available to the rest of Middleman.

The first pass, included, is to provide a generic URL rewriting Rack Middleware. I'm planning on abstracting this further to operate on a plain string.

This will let us to things like `asset_url` or `cache_buster` without Compass and directly on the output HTML.

Thoughts? @bhollis @karlfreeman 
