### PR TITLE
Fix after_render

### DIFF
--- a/middleman-core/lib/middleman-core/core_extensions/rendering.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/rendering.rb
@@ -265,7 +265,12 @@ module Middleman
 
           # Allow hooks to manipulate the result after render
           self.class.callbacks_for_hook(:after_render).each do |callback|
-            content = callback.call(content, path, locs, template_class)
+            # Uber::Options::Value doesn't respond to call
+            if callback.respond_to?(:call)
+              content = callback.call(content, path, locs, template_class)
+            elsif callback.respond_to?(:evaluate)
+              content = callback.evaluate(self, content, path, locs, template_class)
+            end
           end
 
           output = ::ActiveSupport::SafeBuffer.new ''


### PR DESCRIPTION
Example usage from config.rb:

Fix #1277

``` ruby
after_render do |content, path, locs, template_class|
  # restore character entities such as &amp;#96;
  content ||= ''
  content.gsub! '&amp;', '&'
  content
end
```
