### PR TITLE
Resource list manipulator priority

### DIFF
--- a/middleman-core/lib/middleman-core/extension.rb
+++ b/middleman-core/lib/middleman-core/extension.rb
@@ -81,6 +81,12 @@ module Middleman
     #   @return [Symbol] the name this extension is registered under. This is the symbol used to activate the extension.
     class_attribute :ext_name, instance_reader: false, instance_writer: false
 
+    # @!attribute resource_list_manipulator_priority
+    #   @!scope class
+    #   @return [Numeric] the priority for this extension's `manipulate_resource_list` method, if it has one.
+    #   @see Middleman::Sitemap::Store#register_resource_list_manipulator
+    class_attribute :resource_list_manipulator_priority, instance_reader: false, instance_writer: false
+
     class << self
       # @api private
       # @return [Middleman::Configuration::ConfigurationManager] The defined options for this extension.
@@ -150,7 +156,7 @@ module Middleman
       # @return [void]
       def activated_extension(instance)
         name = instance.class.ext_name
-        return unless @_extension_activation_callbacks && @_extension_activation_callbacks.has_key?(name)
+        return unless @_extension_activation_callbacks && @_extension_activation_callbacks.key?(name)
         @_extension_activation_callbacks[name].each do |block|
           block.arity == 1 ? block.call(instance) : block.call
         end
@@ -276,7 +282,7 @@ module Middleman
 
         # rubocop:disable IfUnlessModifier
         if ext.respond_to?(:manipulate_resource_list)
-          ext.app.sitemap.register_resource_list_manipulator(ext.class.ext_name, ext)
+          ext.app.sitemap.register_resource_list_manipulator(ext.class.ext_name, ext, ext.class.resource_list_manipulator_priority)
         end
       end
     end

--- a/middleman-core/lib/middleman-core/extensions/directory_indexes.rb
+++ b/middleman-core/lib/middleman-core/extensions/directory_indexes.rb
@@ -1,5 +1,9 @@
 # Directory Indexes extension
 class Middleman::Extensions::DirectoryIndexes < ::Middleman::Extension
+  # This should run after most other sitemap manipulators so that it
+  # gets a chance to modify any new resources that get added.
+  self.resource_list_manipulator_priority = 100
+
   # Update the main sitemap resource list
   # @return [void]
   def manipulate_resource_list(resources)


### PR DESCRIPTION
Add the ability to set a priority order for sitemap resource list manipulators.

This allows us to do things like forcing `:directory_indexes` to always run last, alleviating the problem of the sitemap output differing depending on when you activate your extensions. I envision it being useful in other scenarios where manipulator ordering is significant.
