### PR TITLE
Revert 1f98d0f

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ master
 * Remove deprecated `request` instance
 * Remove old module-style extension support
 * Placed all `config.rb` evaluation inside the `ConfigContext` class
-* Add :format and :keep_original options to :asset_hash
 
 3.3.0-3.3.2
 ===

--- a/middleman-core/features/asset_hash.feature
+++ b/middleman-core/features/asset_hash.feature
@@ -34,60 +34,6 @@ Feature: Assets get a file hash appended to their and references to them are upd
     And the file "other/index.html" should contain 'src="../javascripts/application-1d8d5276.js"'
     And the file "other/index.html" should contain 'src="../images/100px-5fd6fb90.jpg"'
 
-  Scenario: Keep Originals
-    Given a fixture app "asset-hash-app"
-    And a file named "config.rb" with:
-      """
-      activate :asset_hash, :keep_original => true
-      """
-    And a successfully built app at "asset-hash-app"
-    When I cd to "build"
-    Then the following files should exist:
-      | images/100px-1242c368.png |
-      | images/100px-5fd6fb90.jpg |
-      | images/100px-5fd6fb90.gif |
-      | javascripts/application-1d8d5276.js |
-      | stylesheets/site-171eb3c0.css |
-      | images/100px.png |
-      | images/100px.jpg |
-      | images/100px.gif |
-      | javascripts/application.js |
-      | stylesheets/site.css |
-
-  Scenario: Custom format
-    Given a fixture app "asset-hash-app"
-    And a file named "config.rb" with:
-      """
-      activate :asset_hash, :format => ':basename-.-:digest.:ext'
-      activate :directory_indexes
-      """
-    And a successfully built app at "asset-hash-app"
-    When I cd to "build"
-    Then the following files should exist:
-      | images/100px-.-1242c368.png |
-      | images/100px-.-5fd6fb90.jpg |
-      | images/100px-.-5fd6fb90.gif |
-      | javascripts/application-.-1d8d5276.js |
-      | stylesheets/site-.-171eb3c0.css |
-    And the following files should not exist:
-      | images/100px.png |
-      | images/100px.jpg |
-      | images/100px.gif |
-      | javascripts/application.js |
-      | stylesheets/site.css |
-
-    And the file "javascripts/application-.-1d8d5276.js" should contain "img.src = '/images/100px-.-5fd6fb90.jpg'"
-    And the file "stylesheets/site-.-171eb3c0.css" should contain "background-image: url('/images/100px-.-5fd6fb90.jpg')"
-    And the file "index.html" should contain 'href="/stylesheets/site-.-171eb3c0.css"'
-    And the file "index.html" should contain 'src="/javascripts/application-.-1d8d5276.js"'
-    And the file "index.html" should contain 'src="/images/100px-.-5fd6fb90.jpg"'
-    And the file "subdir/index.html" should contain 'href="/stylesheets/site-.-171eb3c0.css"'
-    And the file "subdir/index.html" should contain 'src="/javascripts/application-.-1d8d5276.js"'
-    And the file "subdir/index.html" should contain 'src="/images/100px-.-5fd6fb90.jpg"'
-    And the file "other/index.html" should contain 'href="/stylesheets/site-.-171eb3c0.css"'
-    And the file "other/index.html" should contain 'src="/javascripts/application-.-1d8d5276.js"'
-    And the file "other/index.html" should contain 'src="/images/100px-.-5fd6fb90.jpg"'
-
   Scenario: Hashed assets work in preview server
     Given the Server is running at "asset-hash-app"
     When I go to "/"

--- a/middleman-core/lib/middleman-core/extensions/asset_hash.rb
+++ b/middleman-core/lib/middleman-core/extensions/asset_hash.rb
@@ -3,8 +3,6 @@ require 'middleman-core/util'
 class Middleman::Extensions::AssetHash < ::Middleman::Extension
   option :exts, %w(.jpg .jpeg .png .gif .js .css .otf .woff .eot .ttf .svg), 'List of extensions that get asset hashes appended to them.'
   option :ignore, [], 'Regexes of filenames to skip adding asset hashes to'
-  option :format, ':basename-:digest.:ext', 'Format of renamed file.'
-  option :keep_original, false, 'Whether the original file name should exist along side the hashed version.'
 
   def initialize(app, options_hash={}, &block)
     super
@@ -26,12 +24,10 @@ class Middleman::Extensions::AssetHash < ::Middleman::Extension
   def manipulate_resource_list(resources)
     @rack_client = ::Rack::MockRequest.new(app.class.to_rack_app)
 
-    proxied_renames = []
-
     # Process resources in order: binary images and fonts, then SVG, then JS/CSS.
     # This is so by the time we get around to the text files (which may reference
     # images and fonts) the static assets' hashes are already calculated.
-    sorted_resources = resources.sort_by do |a|
+    resources.sort_by do |a|
       if %w(.svg).include? a.ext
         0
       elsif %w(.js .css).include? a.ext
@@ -39,49 +35,21 @@ class Middleman::Extensions::AssetHash < ::Middleman::Extension
       else
         -1
       end
-    end
-
-    sorted_resources.each do |resource|
-      next unless options.exts.include?(resource.ext)
-      next if ignored_resource?(resource)
-      next if resource.ignored?
-
-      new_name = hashed_filename(resource)
-
-      if options.keep_original
-        p = ::Middleman::Sitemap::Resource.new(
-          app.sitemap,
-          new_name
-        )
-        p.proxy_to(resource.path)
-
-        proxied_renames << p
-      else
-        resource.destination_path = new_name
-      end
-    end
-
-    sorted_resources + proxied_renames
+    end.each(&method(:manipulate_single_resource))
   end
 
-  def hashed_filename(resource)
+  def manipulate_single_resource(resource)
+    return unless options.exts.include?(resource.ext)
+    return if ignored_resource?(resource)
+    return if resource.ignored?
+
     # Render through the Rack interface so middleware and mounted apps get a shot
     response = @rack_client.get(URI.escape(resource.destination_path), 'bypass_asset_hash' => 'true')
     raise "#{resource.path} should be in the sitemap!" unless response.status == 200
 
     digest = Digest::SHA1.hexdigest(response.body)[0..7]
 
-    file_name = File.basename(resource.destination_path)
-    path = resource.destination_path.split(file_name).first
-
-    ext_without_leading_period = resource.ext.sub(/^\./, '')
-
-    base_name = File.basename(file_name, resource.ext)
-
-    path + options.format.dup
-      .gsub(/:basename/, base_name)
-      .gsub(/:digest/, digest)
-      .gsub(/:ext/, ext_without_leading_period)
+    resource.destination_path = resource.destination_path.sub(/\.(\w+)$/) { |ext| "-#{digest}#{ext}" }
   end
 
   def ignored_resource?(resource)


### PR DESCRIPTION
We talked about this a bit earlier, but I'd prefer if we reverted the change to add `:format` and `:keep_original` options to `:asset_hash`. There was some discussion in #1257 and on Slack. Basically, I think the extra complication is not worth some rather niche options.
