### PR TITLE
Load templates from Git

### DIFF
--- a/middleman-cli/lib/middleman-cli.rb
+++ b/middleman-cli/lib/middleman-cli.rb
@@ -32,6 +32,8 @@ module Middleman
         say "Middleman #{Middleman::VERSION}"
       end
 
+      desc 'help', 'Show help'
+
       # Override the Thor help method to find help for subtasks
       # @param [Symbol, String, nil] meth
       # @param [Boolean] subcommand
@@ -92,3 +94,4 @@ require 'middleman-cli/extension'
 require 'middleman-cli/server'
 require 'middleman-cli/build'
 require 'middleman-cli/console'
+require 'middleman-cli/git'

--- a/middleman-cli/lib/middleman-cli/git.rb
+++ b/middleman-cli/lib/middleman-cli/git.rb
@@ -1,0 +1,52 @@
+# CLI Module
+module Middleman::Cli
+  # A thor task for creating new projects
+  class Git < Thor
+    include Thor::Actions
+    check_unknown_options!
+
+    namespace :git
+
+    desc 'git REPO TARGET [options]', 'Create new project from REPO at TARGET'
+
+    # Do not run bundle install
+    method_option 'skip-bundle',
+                  type: :boolean,
+                  aliases: '-B',
+                  default: false,
+                  desc: "Don't run bundle install"
+
+    # The git task
+    # @param [String] name
+    def git(repo, target='.')
+      require 'rugged'
+      require 'tmpdir'
+
+      path = repository_path(repo)
+
+      Dir.mktmpdir do |dir|
+        Rugged::Repository.clone_at(path, dir)
+
+        source_paths << dir
+
+        directory dir, target, exclude_pattern: /\.git\/|\.gitignore$/
+
+        inside(target) do
+          run('bundle install')
+        end unless ENV['TEST'] || options[:'skip-bundle']
+      end
+    end
+
+    protected
+
+    def repository_path(repo)
+      "git://github.com/#{repo}.git"
+    end
+  end
+
+  def self.exit_on_failure?
+    true
+  end
+
+  Base.map('g' => 'git')
+end

--- a/middleman-cli/middleman-cli.gemspec
+++ b/middleman-cli/middleman-cli.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
   s.add_dependency('thor', ['>= 0.17.0', '< 2.0'])
 
   # Templates
-  s.add_dependency('octokit', ['~> 3.1'])
+  s.add_dependency('rugged', [])
 end


### PR DESCRIPTION
This is the beginning of a re-thinking of how we handle templates.

Step 1, decide on a way of loading remote templates without installing them.
Step 2, move all templates except our default into repos or abandon them in favor of community repos
Step 3, Profit!

This is the beginning of Step 1. This PR adds a `middleman git` command which copies the contents of a Github repo into a tempdir using `rugged` and then hands that tempdir over to Thor to generate a new project. This remote clone happens every time the command is run.

An example:

```
middleman git middleman/middleman-templates-default ~/Desktop/test-project
```

No cache. No gems. And for now, no way to specify non-github repos or non-master branches.

This is mostly a conversation starter. I invision this replacing `middleman init` rather than ever shipping as `middleman git`.

I was worried about bootstrapping a project offline, but given that we immediately call `bundle install`, I don't think that actually matters.

Thoughts?
