### PR TITLE
`Rubocop` is now `RuboCop`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -58,7 +58,7 @@ end
 
 require 'rubocop/rake_task'
 desc 'Run RuboCop to check code consistency'
-Rubocop::RakeTask.new(:rubocop) do |task|
+RuboCop::RakeTask.new(:rubocop) do |task|
   task.fail_on_error = false
 end
 


### PR DESCRIPTION
See https://github.com/bbatsov/rubocop/commit/ff167d8f202baf7a68955db0aaf0dc29afb7e7ee
