### PR TITLE
Update listen gem

### DIFF
--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency("padrino-helpers", ["~> 0.12.1"])
 
   # Watcher
-  s.add_dependency("listen", ["~> 1.1"])
+  s.add_dependency("listen", [">= 2.7.9", "< 3.0"])
 
   # i18n
   s.add_dependency("i18n", ["~> 0.6.9"])


### PR DESCRIPTION
`compass-1.0.0.alpha.20` was released a few days ago and allows upgrading the listen gem, now it falls back to the Sass version like the old version of Compass did.
This should be compatible with the old version of Compass `v3-stable` uses, I'm just gonna look at what travis says...
