### PR TITLE
Fix middleman-compass version, use same as Middleman

### DIFF
--- a/middleman/middleman.gemspec
+++ b/middleman/middleman.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency('middleman-core', Middleman::VERSION)
   s.add_dependency('middleman-cli', Middleman::VERSION)
   s.add_dependency('middleman-sprockets', '>= 3.1.2')
-  s.add_dependency('middleman-compass', '~> 4.0.0')
+  s.add_dependency('middleman-compass', Middleman::VERSION)
   s.add_dependency('haml', ['>= 4.0.5'])
   s.add_dependency('coffee-script', ['~> 2.2.0'])
   s.add_dependency('kramdown', ['~> 1.2'])


### PR DESCRIPTION
I am trying to use middleman from master but got

```
Bundler could not find compatible versions for gem "middleman-compass":
  In Gemfile:
    middleman (>= 0) ruby depends on
      middleman-compass (~> 4.0.0) ruby

    middleman-compass (4.0.0.pre.0)
```
