### PR TITLE
Bump “compass-import-once” dependency to version `1.0.5`.

### DIFF
--- a/middleman/middleman.gemspec
+++ b/middleman/middleman.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency("middleman-sprockets", ">= 3.1.2")
   s.add_dependency("haml", [">= 4.0.5"])
   s.add_dependency("sass", [">= 3.2.17", "< 4.0"])
-  s.add_dependency("compass-import-once", ["1.0.4"])
+  s.add_dependency("compass-import-once", ["1.0.5"])
   s.add_dependency("compass", [">= 0.12.4"])
   s.add_dependency("uglifier", ["~> 2.5"])
   s.add_dependency("coffee-script", ["~> 2.2"])


### PR DESCRIPTION
Hey there,

just a tiny change which bump “compass-import-once” dependency to version `1.0.5`. This enables support for the latest compass version (`1.0.0.rc.1`).
