### PR TITLE
Allow setting of imagesdir from asciidoc_attributes

### DIFF
--- a/middleman-core/lib/middleman-core/renderers/asciidoc.rb
+++ b/middleman-core/lib/middleman-core/renderers/asciidoc.rb
@@ -20,7 +20,7 @@ module Middleman
             config[:asciidoc][:base_dir] = source_dir
             config[:asciidoc][:attributes].concat(config[:asciidoc_attributes] || [])
             # set imagesdir unless already defined
-            unless config[:asciidoc][:attributes].find{|e| e =~ /imagesdir=.*/}.any?
+            unless config[:asciidoc][:attributes].find{|e| e =~ /imagesdir=.*/}
               config[:asciidoc][:attributes] << %(imagesdir=#{File.join((config[:http_prefix] || '/').chomp('/'), config[:images_dir])})
             end
             sitemap.provides_metadata(/\.adoc$/) do |path|


### PR DESCRIPTION
I wanted to be able to set `imagesdir=` myself, the current code will overwrite the user provided setting no matter what. This PR adds a check to only set the default path if one has not been provided via `asciidoc_attributes`.
