### PR TITLE
Accept pandoc-style YAML frontmatter

### DIFF
--- a/middleman-core/features/front-matter.feature
+++ b/middleman-core/features/front-matter.feature
@@ -21,6 +21,17 @@ Feature: YAML Front Matter
     Then I should see "<?php"
     Then I should not see "---"
 
+  Scenario: Rendering markdown (template-less) (yaml)
+    Given the Server is running at "frontmatter-app"
+    When I go to "/front-matter-pandoc.html"
+    Then I should see ">This is a document</h1>"
+    Then I should see "<p>To be or not to be</p>"
+    Then I should see "The meaning of life is 42"
+    Then I should not see "..."
+    Then I should not see "layout: false"
+    Then I should not see "title: Pandoc likes trailing dots..."
+
+
   Scenario: YAML not on first line, no encoding
     Given the Server is running at "frontmatter-app"
     When I go to "/front-matter-line-2.html"

--- a/middleman-core/fixtures/frontmatter-app/source/front-matter-pandoc.html.md.erb
+++ b/middleman-core/fixtures/frontmatter-app/source/front-matter-pandoc.html.md.erb
@@ -1,0 +1,13 @@
+---
+layout: false
+title: Pandoc likes trailing dots...
+dotty_string: "..."
+famous_quote: To be or not to be
+popular_number: 42
+...
+
+# This is a document
+
+<%= current_page.data.famous_quote %>
+
+The meaning of life is <%= current_page.data.popular_number %>.

--- a/middleman-core/lib/middleman-core/core_extensions/front_matter.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/front_matter.rb
@@ -119,7 +119,7 @@ module Middleman::CoreExtensions
     # @param [String] content
     # @return [Array<Hash, String>]
     def parse_yaml_front_matter(content, full_path)
-      yaml_regex = /\A(---\s*\n.*?\n?)^(---\s*$\n?)/m
+      yaml_regex = /\A(---\s*\n.*?\n?)^((---|\.\.\.)\s*$\n?)/m
       if content =~ yaml_regex
         content = content.sub(yaml_regex, '')
 


### PR DESCRIPTION
Pandoc (and some other tools) have decided to end their YAML frontmatter
with `...` instead of `---`.  In the name of flexibility, this patch
allows either to mark the end of YAML frontmatter.

Example:

```

---
title: No place like home
...
```

This is driving me nuts because I use pandoc to normalize, reflow and cleanup
my markdown and I cannot figure out how to fix pandoc...
