### PR TITLE
Parsing HTML with regular expressions

### DIFF
--- a/middleman-core/features/minify_css.feature
+++ b/middleman-core/features/minify_css.feature
@@ -106,9 +106,7 @@ Feature: Minify CSS
     When I go to "/inline-css.html"
     Then I should see:
     """
-    <style>
-      Hello
-    </style>
+    <style>Hello</style>
     """
     
   Scenario: Rendering inline css with the feature enabled
@@ -121,7 +119,5 @@ Feature: Minify CSS
     When I go to "/inline-css.html"
     Then I should see:
     """
-    <style>
-      body{test:style;good:deal}
-    </style>
+    <style>body{test:style;good:deal}</style>
     """

--- a/middleman-core/features/minify_javascript.feature
+++ b/middleman-core/features/minify_javascript.feature
@@ -26,7 +26,7 @@ Feature: Minify Javascript
       })();
     </script>
     <script type='text/javascript'>
-      //<!--
+      <!--
       ;(function() {
         one;
         line();
@@ -74,8 +74,8 @@ Feature: Minify Javascript
         too();
       })();
     </script>
-    <script type='text/javascript'>
-      //<!--
+    <script type="text/javascript">
+      <!--
       ;(function() {
         one;
         line();
@@ -83,7 +83,7 @@ Feature: Minify Javascript
       })();
       //-->
     </script>
-    <script type='text/html'>
+    <script type="text/html">
       I'm a jQuery {{template}}.
     </script>
     """
@@ -106,18 +106,14 @@ Feature: Minify Javascript
     When I go to "/inline-js.html"
     Then I should see:
     """
-    <script>
+    <script>Hello</script>
+    <script>Hello</script>
+    <script type="text/javascript">
+      <!--
       Hello
-    </script>
-    <script>
-      Hello
-    </script>
-    <script type='text/javascript'>
-      //<!--
-    Hello
       //-->
     </script>
-    <script type='text/html'>
+    <script type="text/html">
       I'm a jQuery {{template}}.
     </script>
     """
@@ -132,18 +128,14 @@ Feature: Minify Javascript
     When I go to "/inline-js.html"
     Then I should see:
     """
-    <script>
-      !function(){should(),all.be(),on={one:line}}();
-    </script>
-    <script>
-      !function(){should(),too()}();
-    </script>
-    <script type='text/javascript'>
-      //<!--
-    !function(){one,line(),here()}();
+    <script>!function(){should(),all.be(),on={one:line}}();</script>
+    <script>!function(){should(),too()}();</script>
+    <script type="text/javascript">
+      <!--
+      !function(){one,line(),here()}();
       //-->
     </script>
-    <script type='text/html'>
+    <script type="text/html">
       I'm a jQuery {{template}}.
     </script>
     """
@@ -173,7 +165,7 @@ Feature: Minify Javascript
       """
     And the Server is running at "minify-js-app"
     When I go to "/inline-coffeescript.html"
-    Then I should see "3" lines
+    Then I should see "1" lines
   
   Scenario: Rendering external js (coffeescript) with the feature enabled
     Given a fixture app "minify-js-app"

--- a/middleman-core/fixtures/minify-css-app/source/inline-css.html.haml
+++ b/middleman-core/fixtures/minify-css-app/source/inline-css.html.haml
@@ -3,3 +3,6 @@
     test: style;
     good: deal;
   }
+
+:javascript
+  '<style type="text/css">' + generate() + '</style>';

--- a/middleman-core/fixtures/minify-js-app/source/inline-js.html.haml
+++ b/middleman-core/fixtures/minify-js-app/source/inline-js.html.haml
@@ -16,7 +16,7 @@
 
 %script(type="text/javascript")
   :plain
-    //<!--
+    <!--
     ;(function() {
       one;
       line();

--- a/middleman-core/fixtures/passthrough-app/source/inline-js.html.haml
+++ b/middleman-core/fixtures/passthrough-app/source/inline-js.html.haml
@@ -16,7 +16,7 @@
 
 %script(type="text/javascript")
   :plain
-    //<!--
+    <!--
     ;(function() {
       one;
       line();

--- a/middleman-core/lib/middleman-more/extensions/minify_css.rb
+++ b/middleman-core/lib/middleman-more/extensions/minify_css.rb
@@ -8,6 +8,8 @@ class Middleman::Extensions::MinifyCss < ::Middleman::Extension
     super
 
     app.config.define_setting :css_compressor, nil, 'Set the CSS compressor to use. Deprecated in favor of the :compressor option when activating :minify_css'
+
+    require 'oga'
   end
 
   def after_configuration
@@ -29,8 +31,6 @@ class Middleman::Extensions::MinifyCss < ::Middleman::Extension
 
   # Rack middleware to look for CSS and compress it
   class Rack
-    INLINE_CSS_REGEX = /(<style[^>]*>\s*(?:\/\*<!\[CDATA\[\*\/\n)?)(.*?)((?:(?:\n\s*)?\/\*\]\]>\*\/)?\s*<\/style>)/m
-
     # Init
     # @param [Class] app
     # @param [Hash] options
@@ -48,10 +48,7 @@ class Middleman::Extensions::MinifyCss < ::Middleman::Extension
       status, headers, response = @app.call(env)
 
       if inline_html_content?(env['PATH_INFO'])
-        minified = ::Middleman::Util.extract_response_text(response)
-        minified.gsub!(INLINE_CSS_REGEX) do
-          $1 << @compressor.compress($2) << $3
-        end
+        minified = minify_inline(::Middleman::Util.extract_response_text(response))
 
         headers['Content-Length'] = ::Rack::Utils.bytesize(minified).to_s
         response = [minified]
@@ -73,6 +70,20 @@ class Middleman::Extensions::MinifyCss < ::Middleman::Extension
 
     def standalone_css_content?(path)
       path.end_with?('.css') && @ignore.none? { |ignore| Middleman::Util.path_match(ignore, path) }
+    end
+
+    # Detect and minify inline content
+    # @param [String] content
+    # @return [String]
+    def minify_inline(content)
+      document = Oga.parse_html(content)
+
+      # NOTE: not(ancestor::script) is a workaround for YorickPeterse/oga#22.
+      document.xpath('descendant-or-self::style[not(ancestor::script)]').each do |style|
+        style.inner_text = @compressor.compress(style.inner_text)
+      end
+
+      document.to_xml
     end
   end
 end

--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -40,4 +40,7 @@ Gem::Specification.new do |s|
 
   # i18n
   s.add_dependency("i18n", ["~> 0.7.0"])
+
+  # Extensions
+  s.add_dependency("oga", ["~> 0.2.0"])
 end


### PR DESCRIPTION
I've hit the bug illustrated by this failing test in which `' + generate() + '` is fed into Sass.

I'm not terribly excited about patching [this regex][regex]; what are your thoughts on using Nokogiri/[Oga][replace] here instead? How much of a concern is performance?

  [regex]: https://github.com/AndrewKvalheim/middleman/blob/429e7d64bd306c5139748ad578c47616bc4dfef2/middleman-core/lib/middleman-more/extensions/minify_css.rb#L32
  [replace]: https://github.com/middleman/middleman-blog/pull/226