### PR TITLE
Switch to current working directory during testing

### DIFF
--- a/middleman-core/features/working_directory.feature
+++ b/middleman-core/features/working_directory.feature
@@ -1,0 +1,33 @@
+Feature: Honour working directory 
+  Honour the working directory during testing
+  In order to support helpers which work with the current directories
+
+  Scenario: Set working directory for helpers in tests
+    Given a fixture app "empty-app"
+    And a file named "source/index.erb" with:
+    """
+    <%= Dir.getwd %>
+    """
+    And the Server is running
+    When I go to "/index.html"
+    Then I should see:
+    """
+    aruba
+    """
+
+  Scenario: Set working directory for config.rb in tests
+    Given a fixture app "empty-app"
+    And a file named "config.rb" with:
+    """
+    set :my_working_directory, Dir.getwd
+    """
+    And a file named "source/index.erb" with:
+    """
+    <%= my_working_directory %>
+    """
+    And the Server is running
+    When I go to "/index.html"
+    Then I should see:
+    """
+    aruba
+    """

--- a/middleman-core/lib/middleman-core/step_definitions/server_steps.rb
+++ b/middleman-core/lib/middleman-core/step_definitions/server_steps.rb
@@ -34,6 +34,7 @@ end
 Given /^the Server is running$/ do
   root_dir = File.expand_path(current_dir)
 
+
   if File.exists?(File.join(root_dir, 'source'))
     ENV['MM_SOURCE'] = 'source'
   else
@@ -48,9 +49,11 @@ Given /^the Server is running$/ do
     set :show_exceptions, false
   }
 
-  @server_inst = Middleman::Application.server.inst do
-    initialize_commands.each do |p|
-      instance_exec(&p)
+  in_current_dir do
+    @server_inst = Middleman::Application.server.inst do
+      initialize_commands.each do |p|
+        instance_exec(&p)
+      end
     end
   end
 
@@ -68,41 +71,61 @@ Given /^a template named "([^\"]*)" with:$/ do |name, string|
 end
 
 When /^I go to "([^\"]*)"$/ do |url|
-  @browser.get(URI.escape(url))
+  in_current_dir do
+    @browser.get(URI.escape(url))
+  end
 end
 
 Then /^going to "([^\"]*)" should not raise an exception$/ do |url|
-  expect{ @browser.get(URI.escape(url)) }.to_not raise_exception
+  in_current_dir do
+    expect{ @browser.get(URI.escape(url)) }.to_not raise_exception
+  end
 end
 
 Then /^the content type should be "([^\"]*)"$/ do |expected|
-  expect(@browser.last_response.content_type).to start_with(expected)
+  in_current_dir do
+    expect(@browser.last_response.content_type).to start_with(expected)
+  end
 end
 
 Then /^I should see "([^\"]*)"$/ do |expected|
-  expect(@browser.last_response.body).to include(expected)
+  in_current_dir do
+    expect(@browser.last_response.body).to include(expected)
+  end
 end
 
 Then /^I should see '([^\']*)'$/ do |expected|
-  expect(@browser.last_response.body).to include(expected)
+  in_current_dir do
+    expect(@browser.last_response.body).to include(expected)
+  end
 end
 
 Then /^I should see:$/ do |expected|
-  expect(@browser.last_response.body).to include(expected)
+  in_current_dir do
+    expect(@browser.last_response.body).to include(expected)
+  end
 end
 
 Then /^I should not see "([^\"]*)"$/ do |expected|
-  expect(@browser.last_response.body).to_not include(expected)
+  in_current_dir do
+    expect(@browser.last_response.body).to_not include(expected)
+  end
 end
 
 Then /^I should not see:$/ do |expected|
-  expect(@browser.last_response.body).to_not include(expected.chomp)
+  in_current_dir do
+    expect(@browser.last_response.body).to_not include(expected.chomp)
+  end
 end
 
 Then /^the status code should be "([^\"]*)"$/ do |expected|
-  expect(@browser.last_response.status).to eq expected.to_i
+  in_current_dir do
+    expect(@browser.last_response.status).to eq expected.to_i
+  end
 end
 
 Then /^I should see "([^\"]*)" lines$/ do |lines|
-  expect(@browser.last_response.body.chomp.split($/).length).to eq(lines.to_i)
+  in_current_dir do
+    expect(@browser.last_response.body.chomp.split($/).length).to eq(lines.to_i)
+  end
 end


### PR DESCRIPTION
Hi,

In one of my projects I use some code which depends on the current working directory to be set correctly. My code works fine with `middleman server`, but not with the `cucumber`-step: `When I go to "/XY"`. I think the missing part here is `#in_current_dir`. I found some places where `When I cd to "abc"` is used, but the `current_dir` is not honoured by the steps which use `@browser`. 

I know, you set the `MM_ROOT`-variable, but if you use the current working directory in a helper, this does not help. For this code to work the `PWD`-environment-variable needs to be set correctly, which is done by `#in_current_dir` from the `aruba`-project.

This PR makes helpers run in `@browser`-context to have the same working directory like helpers in `middleman server`-context.

Thanks a lot. :-)

Cheers,
maxmeyer
