### PR TITLE
failure to coerce

### DIFF
--- a/middleman-core/lib/middleman-core/load_paths.rb
+++ b/middleman-core/lib/middleman-core/load_paths.rb
@@ -38,7 +38,7 @@ module Middleman
 
     # Recursive method to find a file in parent directories
     def findup(filename, cwd=Pathname.new(Dir.pwd))
-      return cwd.to_s if (cwd + filename).exist?
+      return cwd.to_s if Pathname.new(cwd + filename).exist?
       return false if cwd.root?
       findup(filename, cwd.parent)
     end


### PR DESCRIPTION
ruby 2.1 getting a coercion error when trying middleman 4.0.0.alpha.2
.rvm/gems/ruby-2.1.1/gems/middleman-core-4.0.0.alpha.2/lib/middleman-core/load_paths.rb:41:in `findup': undefined method`exist?' for "./midtest/test1Gemfile":String (NoMethodError)
fixed
