### PR TITLE
exclude .git folder when init'ing a local template

### DIFF
--- a/middleman-core/lib/middleman-core/templates/local.rb
+++ b/middleman-core/lib/middleman-core/templates/local.rb
@@ -9,7 +9,7 @@ class Middleman::Templates::Local < Middleman::Templates::Base
   # Just copy from the template path
   # @return [void]
   def build_scaffold!
-    directory options[:template].to_s, location, force: options[:force]
+    directory options[:template].to_s, location, force: options[:force], exclude_pattern: /\.git\/.*/
   end
 end
 


### PR DESCRIPTION
Like [a few other people on the middleman forum](http://forum.middlemanapp.com/t/templates-doubts-post-install-note-and-not-keeping-the-git-history/1017/), I noticed the git history is brought along when a new project is `init`'d using a local template whose source is a git repo.

This behavior doesn't seem right, so I fixed it. (See my comment on the aforementioned forum post.)

I hope you agree my patch is the Right Way to do it!

-Justin
