### PR TITLE
add support for “sidecar” frontmatter at the destination url of proxied resources

### DIFF
--- a/middleman-core/features/front-matter-neighbor.feature
+++ b/middleman-core/features/front-matter-neighbor.feature
@@ -149,3 +149,22 @@ Feature: Neighboring YAML Front Matter
     Then I should see "Layout in use: Override"
     When I go to "/page_mentioned.html.erb.frontmatter"
     Then I should see "File Not Found"
+
+  Scenario: Neighbor frontmatter for destination of proxy resources
+    Given the Server is running at "frontmatter-settings-neighbor-app"
+    And the file "source/proxied_with_frontmatter.html.frontmatter" has the contents
+      """
+      ---
+      title: Proxied title
+      ---
+      """
+    And the file "source/ignored.html.erb" has the contents
+      """
+      ---
+      ignored: true
+      ---
+
+      <%= current_resource.data.title %>
+      """
+    When I go to "/proxied_with_frontmatter.html"
+    Then I should see "Proxied title"

--- a/middleman-core/fixtures/frontmatter-settings-neighbor-app/config.rb
+++ b/middleman-core/fixtures/frontmatter-settings-neighbor-app/config.rb
@@ -1,4 +1,5 @@
 # Proxy ignored.html, which should ignore itself through a frontmatter
 page 'proxied.html', :proxy => 'ignored.html'
+page 'proxied_with_frontmatter.html', :proxy => 'ignored.html'
 page 'override_layout.html', :layout => :alternate
 page 'page_mentioned.html'

--- a/middleman-core/lib/middleman-core/core_extensions/front_matter.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/front_matter.rb
@@ -61,7 +61,14 @@ module Middleman::CoreExtensions
       # @private
       # @return [Hash]
       def raw_data
-        app.extensions[:frontmatter].data(source_file).first
+        data = app.extensions[:frontmatter].data(source_file).first
+
+        if proxy?
+          url_data = app.extensions[:frontmatter].data( File.join( app.source_dir, url ).chomp('/') ).first
+          data     = data.deep_merge(url_data)
+        end
+
+        data
       end
 
       # This page's frontmatter


### PR DESCRIPTION
with v3, was running into similar needs to #1110 (specifically giving a different title to a proxied page), and had the thought that I could use "sidecar" frontmatter to accomplish the task.

That turned out not to be the case, but the patch to get it working is relatively small. While I would agree this isn't the best solution to the issue (especially with the more unified interface for resource metadata coming in v4) -- it provides a need little fix for some cases in v3.
