### PR TITLE
Standardize recursively enhance for hash with indifferent access

### DIFF
--- a/middleman-core/lib/middleman-core/core_extensions/data.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/data.rb
@@ -187,7 +187,7 @@ module Middleman
         end
 
         def key?(key)
-          @local_data.key?(key.to_s) || data_for_path(key)
+          ( @local_data.keys + @local_sources.keys + @callback_sources.keys ).include?(key.to_s)
         end
 
         alias_method :has_key?, :key?

--- a/middleman-core/lib/middleman-core/util.rb
+++ b/middleman-core/lib/middleman-core/util.rb
@@ -80,8 +80,8 @@ module Middleman
     # @private
     # @param [Hash] data Normal hash
     # @return [Middleman::Util::HashWithIndifferentAccess]
-    FrozenDataStructure = Frozen[Or[HashWithIndifferentAccess, Array]]
-    Contract Maybe[Or[Array, Hash, HashWithIndifferentAccess]] => Maybe[FrozenDataStructure]
+    FrozenDataStructure = Frozen[Or[HashWithIndifferentAccess, Array, String, TrueClass, FalseClass, Fixnum]]
+    Contract Maybe[Or[String, Array, Hash, HashWithIndifferentAccess]] => Maybe[FrozenDataStructure]
     def recursively_enhance(data)
       if data.is_a? HashWithIndifferentAccess
         data
@@ -89,8 +89,10 @@ module Middleman
         HashWithIndifferentAccess.new(data)
       elsif data.is_a? Array
         data.map(&method(:recursively_enhance)).freeze
+      elsif data.frozen? || data.nil? || [::TrueClass, ::FalseClass, ::Fixnum].include?(data.class)
+        data
       else
-        nil
+        data.dup.freeze
       end
     end
 

--- a/middleman-core/lib/middleman-core/util/hash_with_indifferent_access.rb
+++ b/middleman-core/lib/middleman-core/util/hash_with_indifferent_access.rb
@@ -19,7 +19,7 @@ module Middleman
         super()
 
         hash.each do |key, val|
-          self[key] = recursively_enhance(val)
+          self[key] = Util.recursively_enhance(val)
         end
 
         freeze
@@ -82,22 +82,6 @@ module Middleman
         end
       end
 
-      private
-
-      Contract Any => Frozen[Any]
-      def recursively_enhance(data)
-        if data.is_a? HashWithIndifferentAccess
-          data
-        elsif data.is_a? Hash
-          self.class.new(data)
-        elsif data.is_a? Array
-          data.map(&method(:recursively_enhance)).freeze
-        elsif data.frozen? || data.nil? || [::TrueClass, ::FalseClass, ::Fixnum].include?(data.class)
-          data
-        else
-          data.dup.freeze
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
Targeting a fix for #1421, but includes changes for two issues:
- (for me at least) I would get `SystemStackErrors` running the test suite
- Util#recursively_enhance would return nil if given a string

For the first issue, I'm not sure why the Travis CI boxes never ran into it. From what I could tell anytime `respond_to?` would get triggered on `CoreExtension::Data` and the key wasn't in the `@local_data` it would raise a `SystemStackError` due to some circular calls between `data_for_path`, `respond_to?`, and `key?`.

The second, I think the history is pretty well explained in #1421. It really makes sense to me for this to be handled in one place. I initially wanted to have `Util#recursively_enhance` just call out to a class method on HashWithIndifferentAccess -- but, for now at least, contracts doesn't support class methods and would cause an error (though after [this](https://github.com/egonSchiele/contracts.ruby/pull/62) goes out that shouldn't be the case). I'm up for making whatever changes make sense to y'all though.