### PR TITLE
don’t override :custom if already set

### DIFF
--- a/middleman-core/lib/middleman-core/renderers/sass.rb
+++ b/middleman-core/lib/middleman-core/renderers/sass.rb
@@ -105,7 +105,7 @@ module Middleman
             filename: eval_file,
             line: line,
             syntax: syntax,
-            custom: (options[:custom] || {}).merge(middleman_context: ctx.app)
+            custom: (options[:custom] || {}).merge(middleman_context: ctx.app)
           }
 
           if ctx.is_a?(::Middleman::TemplateContext) && file

--- a/middleman-core/lib/middleman-core/renderers/sass.rb
+++ b/middleman-core/lib/middleman-core/renderers/sass.rb
@@ -105,7 +105,7 @@ module Middleman
             filename: eval_file,
             line: line,
             syntax: syntax,
-            custom: { middleman_context: ctx.app }
+            custom: (options[:custom] || {}).merge(middleman_context: ctx.app)
           }
 
           if ctx.is_a?(::Middleman::TemplateContext) && file


### PR DESCRIPTION
Sometimes Sprockets needs to access
`options[:custom][:sprockets_context]`. If this is set, it should not be
overridden. This happens when building a LivingStyleGuide file when the
Sass source uses `asset-path`, `image-url` or similar functions.

Background: I’m using Middleman’s Sass template to render Sass in the LivingStyleGuide. To make asset path helper functions work, I need to provide the Sprockets context. Within Rails, this works fine. But it gets overriden in Middleman. Strange thing: This only happens while building.

The error (`undefined method 'asset_path' for nil:NilClass`) happens here:
https://github.com/petebrowne/sprockets-sass/blob/master/lib/sprockets/sass/functions.rb#L36
https://github.com/petebrowne/sprockets-sass/blob/master/lib/sprockets/sass/functions.rb#L128

The option is set here:
https://github.com/hagenburger/livingstyleguide/blob/v2/lib/livingstyleguide/document.rb#L161

This happens in 4.0.0.alpha.6 and 3.3.7.