### PR TITLE
Add Woff2 to asset hash extensions

### DIFF
--- a/middleman-core/lib/middleman-core/builder.rb
+++ b/middleman-core/lib/middleman-core/builder.rb
@@ -16,7 +16,7 @@ module Middleman
     def_delegator :@app, :logger
 
     # Sort order, images, fonts, js/css and finally everything else.
-    SORT_ORDER = %w(.png .jpeg .jpg .gif .bmp .svg .svgz .webp .ico .woff .otf .ttf .eot .js .css)
+    SORT_ORDER = %w(.png .jpeg .jpg .gif .bmp .svg .svgz .webp .ico .woff .woff2 .otf .ttf .eot .js .css)
 
     # Create a new Builder instance.
     # @param [Middleman::Application] app The app to build.

--- a/middleman-core/lib/middleman-core/extensions/asset_hash.rb
+++ b/middleman-core/lib/middleman-core/extensions/asset_hash.rb
@@ -1,7 +1,7 @@
 require 'middleman-core/util'
 
 class Middleman::Extensions::AssetHash < ::Middleman::Extension
-  option :exts, %w(.jpg .jpeg .png .gif .webp .js .css .otf .woff .eot .ttf .svg), 'List of extensions that get asset hashes appended to them.'
+  option :exts, %w(.jpg .jpeg .png .gif .webp .js .css .otf .woff .woff2 .eot .ttf .svg), 'List of extensions that get asset hashes appended to them.'
   option :ignore, [], 'Regexes of filenames to skip adding asset hashes to'
 
   def initialize(app, options_hash={}, &block)

--- a/middleman-core/lib/middleman-core/extensions/relative_assets.rb
+++ b/middleman-core/lib/middleman-core/extensions/relative_assets.rb
@@ -1,6 +1,6 @@
 # Relative Assets extension
 class Middleman::Extensions::RelativeAssets < ::Middleman::Extension
-  option :exts, %w(.css .png .jpg .jpeg .webp .svg .svgz .js .gif .ttf .otf .woff), 'List of extensions that get cache busters strings appended to them.'
+  option :exts, %w(.css .png .jpg .jpeg .webp .svg .svgz .js .gif .ttf .otf .woff .woff2), 'List of extensions that get cache busters strings appended to them.'
   option :sources, %w(.htm .html .css), 'List of extensions that are searched for relative assets.'
   option :ignore, [], 'Regexes of filenames to skip adding query strings to'
 


### PR DESCRIPTION
I had some 404 on my site and it was an issue with font-awesome woff2 file that didn't get the hash