### PR TITLE
Clone template from full repository urls

### DIFF
--- a/middleman-cli/lib/middleman-cli/init.rb
+++ b/middleman-cli/lib/middleman-cli/init.rb
@@ -53,6 +53,11 @@ module Middleman::Cli
 
         run("git clone --depth 1 #{branch_cmd}#{repo_path} #{dir}")
 
+        unless File.directory?(dir)
+          say 'Git clone failed, maybe the url is invalid or you don\'t have the permissions?', :red
+          exit
+        end
+
         inside(target) do
           thorfile = File.join(dir, 'Thorfile')
 
@@ -68,18 +73,18 @@ module Middleman::Cli
           run('bundle install') unless ENV['TEST'] || options[:'skip-bundle']
         end
       ensure
-        FileUtils.remove_entry(dir)
+        FileUtils.remove_entry(dir) if File.directory?(dir)
       end
     end
 
     protected
 
     def shortname?(repo)
-      repo.split('/').length != 2
+      repo.split('/').length == 1
     end
 
     def repository_path(repo)
-      "git://github.com/#{repo}.git"
+      repo.include?('://') ? repo : "git://github.com/#{repo}.git"
     end
 
     # Add to CLI


### PR DESCRIPTION
In the guide https://middlemanapp.com/basics/upgrade-v4/ it says urls without `://` are supposed to be on github, however passing the full repository url doesn't work.

```
$ middleman init -T https://github.com/middleman/middleman-templates-default.git
Template `https://github.com/middleman/middleman-templates-default.git` not found in Middleman Directory.
Did you mean to use a full `user/repo` path?
```

I've added a way to use both middleman directory, github user/repo syntax and full clone urls (with the :// check as the guide) so all of them works.

```
middleman init -T middleman/middleman-templates-default
         run  git clone --depth 1 git://github.com/middleman/middleman-templates-default.git /var/folders/dg/2k1h_3dd44b19cqk00dvs70c0000gn/T/d20150212-13109-1wnvvo2 from "."
Cloning into '/var/folders/dg/2k1h_3dd44b19cqk00dvs70c0000gn/T/d20150212-13109-1wnvvo2'...
remote: Counting objects: 22, done.
remote: Compressing objects: 100% (15/15), done.
....

middleman init -T https://github.com/middleman/middleman-templates-default.git
         run  git clone --depth 1 https://github.com/middleman/middleman-templates-default.git /var/folders/dg/2k1h_3dd44b19cqk00dvs70c0000gn/T/d20150212-13153-15zhooz from "."
Cloning into '/var/folders/dg/2k1h_3dd44b19cqk00dvs70c0000gn/T/d20150212-13153-15zhooz'...
remote: Counting objects: 22, done.
remote: Compressing objects: 100% (15/15), done.
....
```

in this way even people using bitbucket (like us) can use their templates.