### PR TITLE
Clone templates from ssh 'git@' urls

### DIFF
--- a/middleman-cli/lib/middleman-cli/init.rb
+++ b/middleman-cli/lib/middleman-cli/init.rb
@@ -84,7 +84,7 @@ module Middleman::Cli
     end
 
     def repository_path(repo)
-      repo.include?('://') ? repo : "git://github.com/#{repo}.git"
+      repo.include?('://') || repo.include?('git@') ? repo : "git://github.com/#{repo}.git"
     end
 
     # Add to CLI


### PR DESCRIPTION
Added also the ability to fetch ssh based git urls like `git@bitbucket.org:user/repo.git`