### PR TITLE
Fixing broken (outdated) link for the Pessimistic Versioning Constraint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Constraint][pvc] with two digits of precision. For example:
     spec.add_dependency 'middleman-core', '~> 3.0'
 
 [semver]: http://semver.org/
-[pvc]: http://docs.rubygems.org/read/chapter/16#page74
+[pvc]: http://guides.rubygems.org/patterns/#pessimistic-version-constraint
 
 ## License
 


### PR DESCRIPTION
Updating an outdated link in the README for a description of the Pessimistic Versioning Constraint.