### PR TITLE
Fixes computation of `parent`.

### DIFF
--- a/middleman-core/lib/middleman-core/sitemap/extensions/traversal.rb
+++ b/middleman-core/lib/middleman-core/sitemap/extensions/traversal.rb
@@ -9,7 +9,9 @@ module Middleman
           tail = parts.pop
           is_index = (tail == app.index_file)
 
-          return nil if is_index && parts.length < 1
+          if parts.empty?
+            return is_index ? nil : store.find_resource_by_path(app.index_file)
+          end
 
           test_expr = parts.join('\\/')
           # A makeshift for eponymous reverse-lookup


### PR DESCRIPTION
If there is a file without a basename in root, e.g. `.htaccess`,
`#parent` of another file in root finds `.htaccess` instead of
`index.html`.

Adding the `.htaccess` to the traversal-app fixture exposes this error.
The fix is to no longer scan for possible files if we know the parent
must be root.

Fixes #1463 