### PR TITLE
Append assets hash also to .woff2 files

### DIFF
--- a/middleman-core/lib/middleman-core/cli/build.rb
+++ b/middleman-core/lib/middleman-core/cli/build.rb
@@ -178,7 +178,7 @@ module Middleman::Cli
     # @return [void]
     def execute!
       # Sort order, images, fonts, js/css and finally everything else.
-      sort_order = %w(.png .jpeg .jpg .gif .bmp .svg .svgz .ico .webp .woff .otf .ttf .eot .js .css)
+      sort_order = %w(.png .jpeg .jpg .gif .bmp .svg .svgz .ico .webp .woff .woff2 .otf .ttf .eot .js .css)
 
       # Pre-request CSS to give Compass a chance to build sprites
       logger.debug '== Prerendering CSS'

--- a/middleman-core/lib/middleman-core/templates/html5/source/.htaccess
+++ b/middleman-core/lib/middleman-core/templates/html5/source/.htaccess
@@ -21,7 +21,7 @@
 <IfModule mod_headers.c>
   Header set X-UA-Compatible "IE=Edge,chrome=1"
   # mod_headers can't match by content-type, but we don't want to send this header on *everything*...
-  <FilesMatch "\.(js|css|gif|png|jpe?g|pdf|xml|oga|ogg|m4a|ogv|mp4|m4v|webm|svg|svgz|eot|ttf|otf|woff|ico|webp|appcache|manifest|htc|crx|oex|xpi|safariextz|vcf)$" >
+  <FilesMatch "\.(js|css|gif|png|jpe?g|pdf|xml|oga|ogg|m4a|ogv|mp4|m4v|webm|svg|svgz|eot|ttf|otf|woff|woff2|ico|webp|appcache|manifest|htc|crx|oex|xpi|safariextz|vcf)$" >
     Header unset X-UA-Compatible
   </FilesMatch>
 </IfModule>
@@ -70,7 +70,7 @@
 # subdomains like "subdomain.example.com".
 
 <IfModule mod_headers.c>
-  <FilesMatch "\.(ttf|ttc|otf|eot|woff|font.css)$">
+  <FilesMatch "\.(ttf|ttc|otf|eot|woff|woff2|font.css)$">
     Header set Access-Control-Allow-Origin "*"
   </FilesMatch>
 </IfModule>
@@ -107,6 +107,7 @@ AddType application/vnd.ms-fontobject  eot
 AddType application/x-font-ttf         ttf ttc
 AddType font/opentype                  otf
 AddType application/x-font-woff        woff
+AddType application/font-woff2         woff2
 
 # Assorted types
 AddType image/x-icon                        ico
@@ -238,6 +239,7 @@ AddType text/vtt                            vtt
   ExpiresByType application/x-font-ttf    "access plus 1 month"
   ExpiresByType font/opentype             "access plus 1 month"
   ExpiresByType application/x-font-woff   "access plus 1 month"
+  ExpiresByType application/font-woff2    "access plus 1 month"
   ExpiresByType image/svg+xml             "access plus 1 month"
   ExpiresByType application/vnd.ms-fontobject "access plus 1 month"
 

--- a/middleman-core/lib/middleman-more/extensions/asset_hash.rb
+++ b/middleman-core/lib/middleman-more/extensions/asset_hash.rb
@@ -1,7 +1,7 @@
 require 'middleman-core/util'
 
 class Middleman::Extensions::AssetHash < ::Middleman::Extension
-  option :exts, %w(.jpg .jpeg .png .gif .webp .js .css .otf .woff .eot .ttf .svg .svgz), 'List of extensions that get asset hashes appended to them.'
+  option :exts, %w(.jpg .jpeg .png .gif .webp .js .css .otf .woff .woff2 .eot .ttf .svg .svgz), 'List of extensions that get asset hashes appended to them.'
   option :ignore, [], 'Patterns to avoid adding asset hashes to'
 
   def initialize(app, options_hash={}, &block)


### PR DESCRIPTION
Hey, I just found out that my .woff2 files do not get an assets hash. I implemented the support for it.

[Here](https://gist.github.com/sergejmueller/cf6b4f2133bcb3e2f64a) is some information about woff 2.0.