### PR TITLE
Move IRB initialization into a dedicated method.

### DIFF
--- a/middleman-core/features/console.feature
+++ b/middleman-core/features/console.feature
@@ -1,0 +1,10 @@
+Feature: Console
+
+  Scenario: Enter and exit the console
+    Given I run `middleman console` interactively
+    When I type "puts 'Hello from the console.'"
+    And I type "exit"
+    Then it should pass with:
+    """
+    Hello from the console.
+    """

--- a/middleman-core/lib/middleman-core/cli/console.rb
+++ b/middleman-core/lib/middleman-core/cli/console.rb
@@ -34,10 +34,19 @@ module Middleman::Cli
 
       # TODO: get file watcher / reload! working in console
 
+      interact_with @app
+    end
+
+    private
+
+    # Start an interactive console in the context of the provided object.
+    # @param [Object] context
+    # @return [void]
+    def interact_with(context)
       IRB.setup nil
       IRB.conf[:MAIN_CONTEXT] = IRB::Irb.new.context
       require 'irb/ext/multi-irb'
-      IRB.irb nil, @app
+      IRB.irb nil, context
     end
   end
 end


### PR DESCRIPTION
This change would allow for a [cleaner][clean] implementation of the [middleman-pry][middleman-pry] extension.


  [clean]: https://github.com/AndrewKvalheim/middleman-pry/commit/ba5b73a6666e4c1492c9470d762c2254f710e41a
  [middleman-pry]: https://github.com/AndrewKvalheim/middleman-pry