### PR TITLE
Fix #1430 by recreating WEBrick server instead of reusing

### DIFF
--- a/middleman-core/lib/middleman-core/preview_server.rb
+++ b/middleman-core/lib/middleman-core/preview_server.rb
@@ -189,7 +189,7 @@ module Middleman
       def mount_instance(app)
         @app = app
 
-        @webrick ||= setup_webrick(@options[:debug] || false)
+        @webrick = setup_webrick(@options[:debug] || false)
 
         start_file_watcher
 


### PR DESCRIPTION
WEBrick in ruby 2.2.0 uses a pipe which is initialized only when ```#listen``` method is called to detect server shutdown.
WEBrick server should be newly created to restart in the 2.2.0 manner. (Or call ```#listen``` before restarting)
See the commits ruby/ruby@6f226d9d42676860cdabc1e1c85cb9e9202e8ddd and ruby/ruby@33bb38a644c62edadec677465b2b08eea4756593.

I don't have a good idea to test the ```Middleman::PreviewServer``` behavior because in some cases (e.g. ```Errno::EADDRINUSE```) cucumber fails to start the server due to a test environment. So a cuke feature is missing in this PR.