### PR TITLE
shutdown webrick on reload, fixes https://github.com/middleman/middleman...

### DIFF
--- a/middleman-core/lib/middleman-core/preview_server.rb
+++ b/middleman-core/lib/middleman-core/preview_server.rb
@@ -72,6 +72,9 @@ module Middleman
         end
 
         unmount_instance
+        @webrick.shutdown
+        @webrick = nil
+
         mount_instance(app)
 
         logger.info '== The Middleman has reloaded'


### PR DESCRIPTION
.../issues/1430

This fixes the bug referenced.
It may be somewhat broken, and perhaps this should be in unmount_instance.

Basically what is happening is that the ensure block in Webrick.start runs, setting @shutdown_pipe to nil, then it tries to remount with a broken @webrick. Im not sure why the ensure block is running exactly though...