### PR TITLE
Revert "Try to avoid *nix double load issue again"

### DIFF
--- a/middleman-core/lib/middleman-core.rb
+++ b/middleman-core/lib/middleman-core.rb
@@ -8,10 +8,9 @@ $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 module Middleman
   # Backwards compatibility namespace
   module Features; end
-
-  autoload :Application, 'middleman-core/application'
 end
 
 require 'middleman-core/version'
 require 'middleman-core/util'
 require 'middleman-core/extensions'
+require 'middleman-core/application' unless defined?(::Middleman::Application)


### PR DESCRIPTION
rackup doesn't work because config.ru template uses
`Middleman.server` without call `Middleman::Application`

This reverts commit 14104aad70e9431d4891e835474efa7937b396a8.