### PR TITLE
allow setting a destination_dir for SourceWatcher(s)

### DIFF
--- a/middleman-core/features/multiple-sources.feature
+++ b/middleman-core/features/multiple-sources.feature
@@ -25,3 +25,11 @@ Feature: Allow multiple sources to be setup.
     Then I should see "Data 2: Data 2"
     Then I should see "Override in Two: Overridden 2"
     Then I should see "Override in One: Opposite 2"
+
+  Scenario: Set source with destination_dir
+    Given the Server is running at "multiple-sources-with-duplicate-file-names-app"
+    When I go to "/index.html"
+    Then I should see "Default Source"
+
+    When I go to "/source2/index.html"
+    Then I should see "Second Source"

--- a/middleman-core/fixtures/multiple-sources-with-duplicate-file-names-app/config.rb
+++ b/middleman-core/fixtures/multiple-sources-with-duplicate-file-names-app/config.rb
@@ -1,0 +1,2 @@
+files.watch :source, path: File.join(root, 'source2'),
+                     destination_dir: 'source2'

--- a/middleman-core/fixtures/multiple-sources-with-duplicate-file-names-app/source/index.html.erb
+++ b/middleman-core/fixtures/multiple-sources-with-duplicate-file-names-app/source/index.html.erb
@@ -1,0 +1,1 @@
+Default Source

--- a/middleman-core/fixtures/multiple-sources-with-duplicate-file-names-app/source2/index.html.erb
+++ b/middleman-core/fixtures/multiple-sources-with-duplicate-file-names-app/source2/index.html.erb
@@ -1,0 +1,1 @@
+Second Source

--- a/middleman-core/lib/middleman-core/sources/source_watcher.rb
+++ b/middleman-core/lib/middleman-core/sources/source_watcher.rb
@@ -279,8 +279,11 @@ module Middleman
     def path_to_source_file(path)
       types = Set.new([@type])
 
-      ::Middleman::SourceFile.new(
-        path.relative_path_from(@directory), path, @directory, types)
+      relative_path   = path.relative_path_from(@directory)
+      destination_dir = @options.fetch(:destination_dir, false)
+      relative_path   = File.join(destination_dir, relative_path) if destination_dir
+
+      ::Middleman::SourceFile.new(Pathname(relative_path), path, @directory, types)
     end
 
     # Notify callbacks for a file given an array of callbacks


### PR DESCRIPTION
This change lets a source be defined with a destination directory. That way we can mount a source in a namespace and worry less about name collisions with files in other sources.

Currently if you mount a source with an `index.html`, the index at `source/index.html` gets overlooked even if they should have different destinations. The use case behind this (that I'm working on at least), would be for gem documentation -- were we're mounting the `gem_name/docs` directory with a SourceWatcher (so those files can be rendered).