### PR TITLE
Allow preview server to use HTTPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 master
 ===
 
+* The preview server can now serve over HTTPS using the `--https` flag. It will use an automatic self-signed cert which can be overridden using `--ssl_certificate` and `--ssl_private_key`. These settings can also be set in `config.rb`
+
 3.3.11
 ===
 * Add `srcset` option to `image_tag`. Also enables them in Markdown.
@@ -22,7 +24,7 @@ master
 3.3.8
 ===
 * Define a mime type for sourcemaps. #1451
-* Asset hashing for image references in srcset 
+* Asset hashing for image references in srcset
 * Import patch to bugfix from Padrino Helpers #1401
 * Better URI encoding and decoding #1406
 * Update version of i18n

--- a/middleman-core/lib/middleman-core/application.rb
+++ b/middleman-core/lib/middleman-core/application.rb
@@ -75,6 +75,18 @@ module Middleman
     # @return [Fixnum]
     config.define_setting :port, 4567, 'The preview server port'
 
+    # Whether to serve the preview server over HTTPS.
+    # @return [Boolean]
+    config.define_setting :https, false, 'Serve the preview server over SSL/TLS'
+
+    # The (optional) path to the SSL cert to use for the preview server.
+    # @return [String]
+    config.define_setting :ssl_certificate, nil, 'Path to an X.509 certificate to use for the preview server'
+
+    # The (optional) private key for the certificate in :ssl_certificate.
+    # @return [String]
+    config.define_setting :ssl_private_key, nil, "Path to an RSA private key for the preview server's certificate"
+
     # Name of the source directory
     # @return [String]
     config.define_setting :source,      'source', 'Name of the source directory'

--- a/middleman-core/lib/middleman-core/cli/server.rb
+++ b/middleman-core/lib/middleman-core/cli/server.rb
@@ -18,6 +18,13 @@ module Middleman::Cli
     method_option :port,
                   aliases: '-p',
                   desc: 'The port Middleman will listen on'
+    method_option :https,
+                  type: :boolean,
+                  desc: 'Serve the preview server over SSL/TLS'
+    method_option :ssl_certificate,
+                  desc: 'Path to an X.509 certificate to use for the preview server'
+    method_option :ssl_private_key,
+                  desc: "Path to an RSA private key for the preview server's certificate"
     method_option :verbose,
                   type: :boolean,
                   default: false,
@@ -63,6 +70,9 @@ module Middleman::Cli
       params = {
         port: options['port'],
         host: options['host'],
+        https: options['https'],
+        ssl_certificate: options['ssl_certificate'],
+        ssl_private_key: options['ssl_private_key'],
         environment: options['environment'],
         debug: options['verbose'],
         instrumenting: options['instrument'],


### PR DESCRIPTION
The preview server can now serve over HTTPS using the `--https` flag. It will use an automatic self-signed cert which can be overridden using `--ssl_certificate` and `--ssl_private_key`. These settings can also be set in `config.rb`:

```ruby
set :https, true
set :ssl_certificate, 'server.crt'
set :ssl_private_key, 'server.key'
```

Follow [this guide from Heroku](https://devcenter.heroku.com/articles/ssl-certificate-self) to generate a custom self-signed cert.

This is very useful when your actual site will be served over HTTPS - it helps catch references to non-HTTPS resources, enables using APIs that rely on HTTPS-only cookies, and [HTTPS will be required for new web features in the future](https://blog.mozilla.org/security/2015/04/30/deprecating-non-secure-http/).

I followed the example in a71589becde156b87968d63a5087e16c5ea5c5d6 for adding options to the preview server that can also be set in `config.rb`.

If this is merged I will also merge it to the `master` branch.