### PR TITLE
Port "localhost" preview server URL to v3-stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ master
 ===
 
 * The preview server can now serve over HTTPS using the `--https` flag. It will use an automatic self-signed cert which can be overridden using `--ssl_certificate` and `--ssl_private_key`. These settings can also be set in `config.rb`
+* The preview server URL will use 'localhost' rather than '0.0.0.0'.
 
 3.3.11
 ===

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ master
 
 * The preview server can now serve over HTTPS using the `--https` flag. It will use an automatic self-signed cert which can be overridden using `--ssl_certificate` and `--ssl_private_key`. These settings can also be set in `config.rb`
 * The preview server URL will use 'localhost' rather than '0.0.0.0'.
+* The preview server URL will once again use the machine's hostname if available.
 
 3.3.11
 ===

--- a/middleman-core/lib/middleman-core/application.rb
+++ b/middleman-core/lib/middleman-core/application.rb
@@ -1,3 +1,5 @@
+require 'socket'
+
 # Using Tilt for templating
 require 'tilt'
 
@@ -69,7 +71,7 @@ module Middleman
 
     # Which host preview should start on.
     # @return [Fixnum]
-    config.define_setting :host, '0.0.0.0', 'The preview server host'
+    config.define_setting :host, Socket.gethostname, 'The preview server host'
 
     # Which port preview should start on.
     # @return [Fixnum]

--- a/middleman-core/lib/middleman-core/preview_server.rb
+++ b/middleman-core/lib/middleman-core/preview_server.rb
@@ -21,9 +21,8 @@ module Middleman
         @options = opts
 
         mount_instance(new_app)
-        scheme = https? ? 'https' : 'http'
-        logger.info "== The Middleman is standing watch at #{scheme}://#{host}:#{port}"
-        logger.info "== Inspect your site configuration at #{scheme}://#{host}:#{port}/__middleman/"
+        logger.info "== The Middleman is standing watch at #{uri}"
+        logger.info "== Inspect your site configuration at #{uri + '__middleman'}"
 
         @initialized ||= false
         return if @initialized
@@ -264,6 +263,15 @@ module Middleman
           end
         end
       end
+
+      # Returns the URI the preview server will run on
+      # @return [URI]
+      def uri
+        host = @host.eql?('0.0.0.0') ? 'localhost' : @host
+        scheme = https? ? 'https' : 'http'
+        URI("#{scheme}://#{host}:#{@port}")
+      end
+
     end
 
     class FilteredWebrickLog < ::WEBrick::Log

--- a/middleman-core/lib/middleman-core/preview_server.rb
+++ b/middleman-core/lib/middleman-core/preview_server.rb
@@ -267,7 +267,7 @@ module Middleman
       # Returns the URI the preview server will run on
       # @return [URI]
       def uri
-        host = @host.eql?('0.0.0.0') ? 'localhost' : @host
+        host = @host == '0.0.0.0' ? 'localhost' : @host
         scheme = https? ? 'https' : 'http'
         URI("#{scheme}://#{host}:#{@port}")
       end


### PR DESCRIPTION
This ports commit 6a5d07028b1a211bb1bfb4b4a39575e29161e431 to `v3-stable`. It looks like at least Chrome on OS X doesn't like `0.0.0.0` URLs.

This also brings back auto-hostname-detection via `Socket.gethostname`. As I recall, the problem with that before was that on Windows, `Socket.gethostname` would return `0.0.0.0` which wouldn't load - but we've fixed that by forcing `0.0.0.0` to `localhost` so we can get our nice hostnames back now. 

Note that the changes to the preview URL (e3946a06d911fa24159e136b5b526c97d4e71d21, 8f75f6516debc28159914c79e9074d2c4e997a47) don't appear to have had a PR justifying them, nor were they mentioned on the changelog. I believe this has been broken since v3.3.2.