### PR TITLE
Address shortcomings in #1508

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@ master
 ===
 
 * The preview server can now serve over HTTPS using the `--https` flag. It will use an automatic self-signed cert which can be overridden using `--ssl_certificate` and `--ssl_private_key`. These settings can also be set in `config.rb`
-* The preview server URL will use 'localhost' rather than '0.0.0.0'.
-* The preview server URL will once again use the machine's hostname if available.
+* The preview server URL will use the local hostname rather than '0.0.0.0'. It will also print out a URL based on the host's public IP in case that's useful.
+* The `--host` flag and `config.rb` setting have been removed - the preview server will always bind to all interfaces.
 
 3.3.11
 ===

--- a/middleman-core/lib/middleman-core/application.rb
+++ b/middleman-core/lib/middleman-core/application.rb
@@ -1,5 +1,3 @@
-require 'socket'
-
 # Using Tilt for templating
 require 'tilt'
 
@@ -68,10 +66,6 @@ module Middleman
       Pathname(root)
     end
     delegate :root_path, to: :"self.class"
-
-    # Which host preview should start on.
-    # @return [Fixnum]
-    config.define_setting :host, Socket.gethostname, 'The preview server host'
 
     # Which port preview should start on.
     # @return [Fixnum]

--- a/middleman-core/lib/middleman-core/cli/server.rb
+++ b/middleman-core/lib/middleman-core/cli/server.rb
@@ -11,10 +11,6 @@ module Middleman::Cli
                   aliases: '-e',
                   default: ENV['MM_ENV'] || ENV['RACK_ENV'] || 'development',
                   desc: 'The environment Middleman will run under'
-    method_option :host,
-                  type: :string,
-                  aliases: '-h',
-                  desc: 'Bind to HOST address'
     method_option :port,
                   aliases: '-p',
                   desc: 'The port Middleman will listen on'
@@ -69,7 +65,6 @@ module Middleman::Cli
 
       params = {
         port: options['port'],
-        host: options['host'],
         https: options['https'],
         ssl_certificate: options['ssl_certificate'],
         ssl_private_key: options['ssl_private_key'],

--- a/middleman-core/lib/middleman-core/preview_server.rb
+++ b/middleman-core/lib/middleman-core/preview_server.rb
@@ -272,7 +272,8 @@ module Middleman
       # An IPv4 address on this machine which should be externally addressable.
       # @return [String]
       def public_ip
-        Socket.ip_address_list.find { |ai| ai.ipv4? && !ai.ipv4_loopback? }.ip_address
+        ip = Socket.ip_address_list.find { |ai| ai.ipv4? && !ai.ipv4_loopback? }
+        ip ? ip.ip_address : '127.0.0.1'
       end
 
     end


### PR DESCRIPTION
Address shortcomings in #1508 by removing the "host" parameter, always binding on all interfaces, and printing the preview URL with both the local hostname and the local public IP address. As a bonus, we also gain the ability to reach the preview server over IPv6 (binding to `0.0.0.0` restricts to IPv4, while simply not passing the `:BindAddress` parameter will listen on all IPv4 and IPv6 interfaces).

One consequence (called out in the change log) is that we will no longer support the `--host` parameter since it doesn't really make sense.

I verified that I can reach the server via the provided URLs (and `localhost`) on local browsers, and via the provided URLs (but not `localhost`) via my iPhone on the same WiFi network.

Sample output on my machine:

```
== The Middleman is loading
== The Middleman is standing watch at http://legion.local:4567/ (http://10.0.1.117:4567/)
== Inspect your site configuration at http://legion.local:4567/__middleman
```

/cc @Arcovion 