### PR TITLE
fixed: Builded text file(html, css, xml, txt...)'s permission is 0600

### DIFF
--- a/middleman-core/features/builder.feature
+++ b/middleman-core/features/builder.feature
@@ -47,3 +47,11 @@ Feature: Builder
     Given a fixture app "large-build-app"
     When I run `middleman b`
     Then was successfully built
+
+  Scenario: Builded text file(ex: html, css, xml, txt)'s permission is 0644
+    Given a successfully built app at "large-build-app"
+    When I cd to "build"
+    Then the mode of filesystem object "index.html" should match "0644"
+    And the mode of filesystem object "stylesheets/static.css" should match "0644"
+    And the mode of filesystem object "feed.xml" should match "0644"
+    And the mode of filesystem object ".htaccess" should match "0644"

--- a/middleman-core/lib/middleman-core/builder.rb
+++ b/middleman-core/lib/middleman-core/builder.rb
@@ -130,6 +130,7 @@ module Middleman
       file.binmode
       file.write(contents)
       file.close
+      File.chmod(0644, file)
       file
     end
 


### PR DESCRIPTION
In v3-stable branch, builded text file's permission are 0644.
![screenshot 2015-05-07 19 36 08](https://cloud.githubusercontent.com/assets/89116/7515447/0300f448-f502-11e4-8948-be8d428193a7.png)

But in master(v4) branch, file's permission are 0600.
![screenshot 2015-05-07 19 40 40](https://cloud.githubusercontent.com/assets/89116/7515448/0a0148a6-f502-11e4-80c5-bc48a52da05c.png)

When I deploy(drug-and-drop with sftp), the website isn't displayed. So
I fixed this problem.