### PR TITLE
Add retina files support on automatic_image_sizes

### DIFF
--- a/middleman-core/lib/middleman-more/extensions/automatic_image_sizes.rb
+++ b/middleman-core/lib/middleman-more/extensions/automatic_image_sizes.rb
@@ -23,6 +23,13 @@ class Middleman::Extensions::AutomaticImageSizes < ::Middleman::Extension
         if File.exist?(full_path)
           begin
             width, height = ::FastImage.size(full_path, raise_on_failure: true)
+            # Check for @2x and @3x image
+            retina = full_path.match/(@(\d)x\.[a-zA-Z]{3,4}$/)
+            if retina
+              factor  = retina[1].to_i
+              width   = width / factor
+              height  = height / factor
+            end
             params[:width]  = width
             params[:height] = height
           rescue FastImage::UnknownImageType

--- a/middleman-core/lib/middleman-more/extensions/automatic_image_sizes.rb
+++ b/middleman-core/lib/middleman-more/extensions/automatic_image_sizes.rb
@@ -24,7 +24,7 @@ class Middleman::Extensions::AutomaticImageSizes < ::Middleman::Extension
           begin
             width, height = ::FastImage.size(full_path, raise_on_failure: true)
             # Check for @2x and @3x image
-            retina = full_path.match/(@(\d)x\.[a-zA-Z]{3,4}$/)
+            retina = full_path.match(/@(\d)x\.[a-zA-Z]{3,4}$/)
             if retina
               factor  = retina[1].to_i
               width   = width / factor


### PR DESCRIPTION
Right now, `automatic_image_sizes` uses actual image dimensions on for the `width` and `height` properties of `<img>`, which in the case of `@2x` or even `@3x` images, is not usually intended.

This commit adds support to retina images, dividing the actual image dimensions by the `@` factor specified in the file path.