### PR TITLE
Fix port suggestion from unused ports

### DIFF
--- a/middleman-core/lib/middleman-core/preview_server.rb
+++ b/middleman-core/lib/middleman-core/preview_server.rb
@@ -1,6 +1,7 @@
 require 'webrick'
 require 'webrick/https'
 require 'openssl'
+require 'socket'
 require 'middleman-core/meta_pages'
 require 'middleman-core/logger'
 require 'middleman-core/rack'
@@ -200,7 +201,7 @@ module Middleman
         begin
           ::WEBrick::HTTPServer.new(http_opts)
         rescue Errno::EADDRINUSE
-          logger.error "== Port #{port} is unavailable. Either close the instance of Middleman already running on #{port} or start this Middleman on a new port with: --port=#{port.to_i + 1}"
+          logger.error "== Port #{port} is unavailable. Either close the instance of Middleman already running on #{port} or start this Middleman on a new port with: --port=#{unused_tcp_port}"
           exit(1)
         end
       end
@@ -233,6 +234,15 @@ module Middleman
         host = (@host == '0.0.0.0') ? 'localhost' : @host
         scheme = https? ? 'https' : 'http'
         URI("#{scheme}://#{host}:#{@port}")
+      end
+
+      # Returns unused TCP port
+      # @return [Fixnum]
+      def unused_tcp_port
+        server = TCPServer.open(0)
+        port = server.addr[1]
+        server.close
+        port
       end
     end
 


### PR DESCRIPTION
When try to start preview server with `--port=65535` during the port 65535 is in use, the Middleman prints following messages.

```
$ bundle exec middleman --port=65535
== The Middleman is loading
== Port 65535 is unavailable. Either close the instance of Middleman already running on 65535 or start this Middleman on a new port with: --port=65536
```

The port 65535 is out of valid TCP ports range.

Additionally the middleman server doesn't avoid used port.  When the port 2999 and 3000 are in use and try to start the server with `--port=2999`,  Middleman prints --port=3000 in face of the port in use.

```
$ bundle exec middleman --port=2999
== The Middleman is loading
== Port 2999 is unavailable. Either close the instance of Middleman already running on 2999 or start this Middleman on a new port with: --port=3000
```