### PR TITLE
Use capybara to make javascript testing possible

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,9 @@ gem 'sinatra', '>= 1.4', require: false
 gem 'redcarpet', '>= 3.1', require: false unless RUBY_ENGINE == 'jruby'
 gem 'asciidoctor', '~> 0.1', require: false
 
+# To test javascript
+gem 'poltergeist', '~> 1.6.0', require: false
+
 # For less, note there is no compatible JS runtime for windows
 gem 'therubyracer', '>= 0.12', platforms: :ruby
 gem 'therubyrhino', '>= 2.0', platforms: :jruby

--- a/middleman-core/features/javascript-testing.feature
+++ b/middleman-core/features/javascript-testing.feature
@@ -1,0 +1,18 @@
+Feature: Test a site with javascript included
+
+  As a software developer
+  I want to develop a site using javascript
+  I would like to have a server step rendering javascript correctly in order to test it
+
+  @javascript
+  Scenario: Existing app with javascript
+    Given the Server is running at "javascript-app"
+    When I go to "/index.html"
+    Then I should see:
+    """
+    Local Hour
+    """
+    And I should see:
+    """
+    Local Minutes
+    """

--- a/middleman-core/features/support/env.rb
+++ b/middleman-core/features/support/env.rb
@@ -4,6 +4,9 @@ ENV["AUTOLOAD_SPROCKETS"] = "false"
 require 'simplecov'
 SimpleCov.root(File.expand_path(File.dirname(__FILE__) + '/../..'))
 
+require 'capybara/poltergeist'
+Capybara.javascript_driver = :poltergeist
+
 require 'coveralls'
 Coveralls.wear!
 

--- a/middleman-core/fixtures/javascript-app/source/index.html
+++ b/middleman-core/fixtures/javascript-app/source/index.html
@@ -1,0 +1,17 @@
+<html>
+  <head>
+    <title>
+      Title
+    </title>
+  </head>
+  <body>
+    <script type="text/javascript" language="JavaScript">
+      <!--
+      current_date = new Date();
+      document.write('Now: ');
+      document.write(current_date.getHours() + " Local H" + "our");
+      document.write(current_date.getMinutes() + " Local M" + "inutes");
+      //-->
+    </script>
+  </body>
+</html>

--- a/middleman-core/lib/middleman-core/step_definitions/server_steps.rb
+++ b/middleman-core/lib/middleman-core/step_definitions/server_steps.rb
@@ -1,6 +1,7 @@
 # encoding: UTF-8
 
-require 'rack/test'
+require 'rspec/expectations'
+require 'capybara/cucumber'
 
 Given /^a clean server$/ do
   @initialize_commands = []
@@ -57,8 +58,7 @@ Given /^the Server is running$/ do
     end
   end
 
-  app_rack = @server_inst.class.to_rack_app
-  @browser = ::Rack::Test::Session.new(::Rack::MockSession.new(app_rack))
+  Capybara.app =  @server_inst.class.to_rack_app
 end
 
 Given /^the Server is running at "([^\"]*)"$/ do |app_path|
@@ -72,60 +72,61 @@ end
 
 When /^I go to "([^\"]*)"$/ do |url|
   in_current_dir do
-    @browser.get(URI.encode(url))
+    visit(URI.encode(url).to_s)
   end
 end
 
 Then /^going to "([^\"]*)" should not raise an exception$/ do |url|
   in_current_dir do
-    expect{ @browser.get(URI.encode(url)) }.to_not raise_exception
+    
+    expect{ visit(URI.encode(url).to_s) }.to_not raise_exception
   end
 end
 
 Then /^the content type should be "([^\"]*)"$/ do |expected|
   in_current_dir do
-    expect(@browser.last_response.content_type).to start_with(expected)
+    expect(page.response_headers['Content-Type']).to start_with expected
   end
 end
 
 Then /^I should see "([^\"]*)"$/ do |expected|
   in_current_dir do
-    expect(@browser.last_response.body).to include(expected)
+    expect(page.body).to include expected
   end
 end
 
 Then /^I should see '([^\']*)'$/ do |expected|
   in_current_dir do
-    expect(@browser.last_response.body).to include(expected)
+    expect(page.body).to include expected
   end
 end
 
 Then /^I should see:$/ do |expected|
   in_current_dir do
-    expect(@browser.last_response.body).to include(expected)
+    expect(page.body).to include expected
   end
 end
 
 Then /^I should not see "([^\"]*)"$/ do |expected|
   in_current_dir do
-    expect(@browser.last_response.body).to_not include(expected)
+    expect(page.body).not_to include expected
   end
 end
 
 Then /^I should not see:$/ do |expected|
   in_current_dir do
-    expect(@browser.last_response.body).to_not include(expected.chomp)
+    expect(page.body).not_to include expected
   end
 end
 
 Then /^the status code should be "([^\"]*)"$/ do |expected|
   in_current_dir do
-    expect(@browser.last_response.status).to eq expected.to_i
+    expect(page.status_code).to eq expected.to_i
   end
 end
 
 Then /^I should see "([^\"]*)" lines$/ do |lines|
   in_current_dir do
-    expect(@browser.last_response.body.chomp.split($/).length).to eq(lines.to_i)
+    expect(page.body.chomp.split($/).length).to eq lines.to_i
   end
 end

--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency("hooks", ["~> 0.3"])
 
   # Builder
-  s.add_dependency("rack-test", ["~> 0.6.2"])
+  s.add_dependency("capybara", ["~> 2.4.4"])
 
   # CLI
   s.add_dependency("thor", [">= 0.15.2", "< 2.0"])


### PR DESCRIPTION
Hi,

with this PR we would switch from using `Rack::Test` directly, to `Capybara` + `Rack::Test` by default. This will make tests of javascript applications easier because one could use `[...]/server_steps.rb` directly.

Background:
I'm going to integrate  `mermaid` into `middleman-presentation`. `mermaid` is a `javascript`-framework to render diagram/graph-definitions. In `middleman-presentation` I use your server steps for tests. Unfortunately this doesn't work for the javascript code now.

I added a test fixture + poltergeist to make test run in background on travis. For users using the server steps: The user need to choose the capybara driver for javascript herself/himself. Will send another PR to change the documentation in `middleman-guides` if this PR is accepted.

Any suggestions? @tdreyno 