### PR TITLE
Remove showtitle attribute from asciidoc renderer

### DIFF
--- a/middleman-core/fixtures/asciidoc-app/source/hello-with-title.adoc
+++ b/middleman-core/fixtures/asciidoc-app/source/hello-with-title.adoc
@@ -1,4 +1,5 @@
 = Page Title
+:showtitle:
 :page-layout: default
 
 Hello, AsciiDoc!

--- a/middleman-core/lib/middleman-core/renderers/asciidoc.rb
+++ b/middleman-core/lib/middleman-core/renderers/asciidoc.rb
@@ -8,7 +8,7 @@ module Middleman
           app.config.define_setting :asciidoc, {
             safe: :safe,
             backend: :html5,
-            attributes: %W(showtitle env=middleman env-middleman middleman-version=#{::Middleman::VERSION})
+            attributes: %W(env=middleman env-middleman middleman-version=#{::Middleman::VERSION})
           }, 'AsciiDoc engine options (Hash)'
           app.config.define_setting :asciidoc_attributes, [], 'AsciiDoc custom attributes (Array)'
           app.before_configuration do


### PR DESCRIPTION
Middleman-called Asciidoctor instance renders title no matter what. The "showtitle" attribute specified in options in asciidoc.rb is not overrideable. This is very annoying if you have custom header (title gets repeated twice: in your header and start of the body).

At the same time the rest of .asciidoc header is only stored in meta.

@mojavelinux I believe that such behaviour was not intended by design and this PR disables the offending attribute.