### PR TITLE
Drop active_support's JSON in favor of native JSON implementation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'yard', '~> 0.8', require: false
 
 # Test tools
 gem 'pry', '~> 0.10', group: :development
-gem 'aruba', '~> 0.6'
+gem 'aruba', '~> 0.7.4'
 gem 'rspec', '~> 3.0'
 gem 'fivemat', '~> 1.3'
 gem 'cucumber', '~> 1.3'

--- a/middleman-core/lib/middleman-core/application.rb
+++ b/middleman-core/lib/middleman-core/application.rb
@@ -8,10 +8,6 @@ require 'i18n'
 # users expect.
 ::I18n.enforce_available_locales = false
 
-# Use ActiveSupport JSON
-require 'active_support/json'
-require 'active_support/core_ext/integer/inflections'
-
 # Simple callback library
 require 'hooks'
 

--- a/middleman-core/lib/middleman-core/core_extensions/data.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/data.rb
@@ -9,7 +9,7 @@ module Middleman
         def registered(app)
           # Data formats
           require 'yaml'
-          require 'active_support/json'
+          require 'json'
 
           app.config.define_setting :data_dir, 'data', 'The directory data files are stored in'
           app.send :include, InstanceMethods
@@ -98,7 +98,7 @@ module Middleman
           if %w(.yaml .yml).include?(extension)
             data = YAML.load_file(full_path)
           elsif extension == '.json'
-            data = ActiveSupport::JSON.decode(full_path.read)
+            data = JSON.parse(full_path.read)
           else
             return
           end

--- a/middleman-core/lib/middleman-core/core_extensions/front_matter.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/front_matter.rb
@@ -5,7 +5,7 @@ require 'pathname'
 require 'yaml'
 
 # Parsing JSON frontmatter
-require 'active_support/json'
+require 'json'
 
 # Extensions namespace
 module Middleman::CoreExtensions
@@ -154,7 +154,7 @@ module Middleman::CoreExtensions
 
         begin
           json = ($1 + $2).sub(';;;', '{').sub(';;;', '}')
-          data = ActiveSupport::JSON.decode(json).symbolize_keys
+          data = JSON.parse(json).symbolize_keys
         rescue => e
           app.logger.error "JSON Exception parsing #{full_path}: #{e.message}"
           return false


### PR DESCRIPTION
Hey, 

This PR drops the `active_support/json` implementation in favor of the native Ruby `json` implementation. 

Quick benchmark: 
```
2.1.2 :019 > abc = {"abc" => "def", "jkl" => "mno", "pqr" => "stu", "vwx" => "yz" }
 => {"abc"=>"def", "jkl"=>"mno", "pqr"=>"stu", "vwx"=>"yz"} 
2.1.2 :020 > Benchmark.bm do |x|
2.1.2 :021 >     x.report { ActiveSupport::JSON.decode(abc.to_json) }
2.1.2 :022?>   x.report { JSON.parse(abc.to_json) }
2.1.2 :023?>   end
       user     system      total        real
   0.000000   0.010000   0.010000 (  0.011342)
   0.000000   0.000000   0.000000 (  0.000126)
```

Also, I removed the `integer/inflections` ActiveSupport extension as it doesn't seem to be used anywhere in the current codebase. 

Cheers! 