### PR TITLE
Removed most deprecation warnings from the build.

### DIFF
--- a/middleman-core/lib/middleman-core/step_definitions/builder_steps.rb
+++ b/middleman-core/lib/middleman-core/step_definitions/builder_steps.rb
@@ -6,8 +6,8 @@ end
 
 Given /^app "([^\"]*)" is using config "([^\"]*)"$/ do |path, config_name|
   target = File.join(PROJECT_ROOT_PATH, 'fixtures', path)
-  config_path = File.join(current_dir, "config-#{config_name}.rb")
-  config_dest = File.join(current_dir, 'config.rb')
+  config_path = File.join(current_directory, "config-#{config_name}.rb")
+  config_dest = File.join(current_directory, 'config.rb')
   FileUtils.cp(config_path, config_dest)
 end
 
@@ -22,12 +22,12 @@ Given /^a fixture app "([^\"]*)"$/ do |path|
 
   # This step can be reentered from several places but we don't want
   # to keep re-copying and re-cd-ing into ever-deeper directories
-  next if File.basename(current_dir) == path
+  next if File.basename(current_directory) == path
 
   step %Q{a directory named "#{path}"}
 
   target_path = File.join(PROJECT_ROOT_PATH, 'fixtures', path)
-  FileUtils.cp_r(target_path, current_dir)
+  FileUtils.cp_r(target_path, current_directory)
 
   step %Q{I cd to "#{path}"}
 end
@@ -58,12 +58,12 @@ Given /^a successfully built app at "([^\"]*)" with flags "([^\"]*)"$/ do |path,
 end
 
 Given /^a modification time for a file named "([^\"]*)"$/ do |file|
-  target = File.join(current_dir, file)
+  target = File.join(current_directory, file)
   @modification_times[target] = File.mtime(target)
 end
 
 Then /^the file "([^\"]*)" should not have been updated$/ do |file|
-  target = File.join(current_dir, file)
+  target = File.join(current_directory, file)
   File.mtime(target).should == @modification_times[target]
 end
 
@@ -73,5 +73,5 @@ Then /^the file "([^"]*)" should contain '([^']*)'$/ do |file, partial_content|
 end
 
 And /the file "(.*)" should be gzipped/ do |file|
-  expect(File.binread(File.join(current_dir, file), 2)).to eq(['1F8B'].pack('H*'))
+  expect(File.binread(File.join(current_directory, file), 2)).to eq(['1F8B'].pack('H*'))
 end

--- a/middleman-core/lib/middleman-core/step_definitions/server_steps.rb
+++ b/middleman-core/lib/middleman-core/step_definitions/server_steps.rb
@@ -31,8 +31,7 @@ Given /^current environment is "([^\"]*)"$/ do |env|
 end
 
 Given /^the Server is running$/ do
-  root_dir = File.expand_path(current_dir)
-
+  root_dir = File.expand_path(current_directory)
 
   if File.exists?(File.join(root_dir, 'source'))
     ENV['MM_SOURCE'] = 'source'
@@ -48,7 +47,7 @@ Given /^the Server is running$/ do
     set :show_exceptions, false
   }
 
-  in_current_dir do
+  in_current_directory do
     @server_inst = Middleman::Application.server.inst do
       initialize_commands.each do |p|
         instance_exec(&p)
@@ -69,62 +68,62 @@ Given /^a template named "([^\"]*)" with:$/ do |name, string|
 end
 
 When /^I go to "([^\"]*)"$/ do |url|
-  in_current_dir do
+  in_current_directory do
     visit(URI.encode(url).to_s)
   end
 end
 
 Then /^going to "([^\"]*)" should not raise an exception$/ do |url|
-  in_current_dir do
-    
+  in_current_directory do
+
     expect{ visit(URI.encode(url).to_s) }.to_not raise_exception
   end
 end
 
 Then /^the content type should be "([^\"]*)"$/ do |expected|
-  in_current_dir do
+  in_current_directory do
     expect(page.response_headers['Content-Type']).to start_with expected
   end
 end
 
 Then /^I should see "([^\"]*)"$/ do |expected|
-  in_current_dir do
+  in_current_directory do
     expect(page.body).to include expected
   end
 end
 
 Then /^I should see '([^\']*)'$/ do |expected|
-  in_current_dir do
+  in_current_directory do
     expect(page.body).to include expected
   end
 end
 
 Then /^I should see:$/ do |expected|
-  in_current_dir do
+  in_current_directory do
     expect(page.body).to include expected
   end
 end
 
 Then /^I should not see "([^\"]*)"$/ do |expected|
-  in_current_dir do
+  in_current_directory do
     expect(page.body).not_to include expected
   end
 end
 
 Then /^I should not see:$/ do |expected|
-  in_current_dir do
+  in_current_directory do
     expect(page.body).not_to include expected
   end
 end
 
 Then /^the status code should be "([^\"]*)"$/ do |expected|
-  in_current_dir do
+  in_current_directory do
     expect(page.status_code).to eq expected.to_i
   end
 end
 
 Then /^I should see "([^\"]*)" lines$/ do |lines|
-  in_current_dir do
+  in_current_directory do
     expect(page.body.chomp.split($/).length).to eq lines.to_i
   end
 end


### PR DESCRIPTION
Hey, 

This PR removes most deprecation warnings from the build, as it's polluting the Travis log. They will be gone entirely after upgrading to `aruba ~> 0.8`, but this should take care of most of them.

Please check it out, thanks! 