### PR TITLE
Substitute whitespace in name

### DIFF
--- a/middleman-core/lib/middleman-core/preview_server/server_hostname.rb
+++ b/middleman-core/lib/middleman-core/preview_server/server_hostname.rb
@@ -3,7 +3,7 @@ module Middleman
     class ServerHostname
       class ServerFullHostname < SimpleDelegator
         def to_s
-          __getobj__
+          __getobj__.gsub(/\s/, '+')
         end
 
         def self.match?(*)
@@ -15,7 +15,7 @@ module Middleman
 
       class ServerPlainHostname < SimpleDelegator
         def to_s
-          __getobj__ + '.local'
+          __getobj__.gsub(/\s/, '+') + '.local'
         end
 
         def self.match?(name)


### PR DESCRIPTION
Replace white space in host name to make Mac Users happy. Should help users using the new preview server version from git. Also see issue #1510