### PR TITLE
Fixes problem with after_render hooks returning nil.

### DIFF
--- a/middleman-core/lib/middleman-core/core_extensions/rendering.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/rendering.rb
@@ -316,9 +316,9 @@ module Middleman
           self.class.callbacks_for_hook(:after_render).each do |callback|
             # Uber::Options::Value doesn't respond to call
             newcontent = if callback.respond_to?(:call)
-              content = callback.call(content, path, locs, template_class)
+              callback.call(content, path, locs, template_class)
             elsif callback.respond_to?(:evaluate)
-              content = callback.evaluate(self, content, path, locs, template_class)
+              callback.evaluate(self, content, path, locs, template_class)
             end
             content = newcontent if newcontent # Allow the callback to return nil to skip it
           end


### PR DESCRIPTION
I was having a problem returning `nil` from an `after_render` hook, and it looks like `content` was being set in each of these `if`/`elsif` blocks, with the result of the assignment being returned. If the hook returns `nil`, then the following statement is ineffective, since `content` is already `nil`.

```ruby
content = newcontent if newcontent # Allow the callback to return nil to skip it
```

I was seeing this surface with the following error:

```
Tried to render a layout (calls yield) at /Users/ash/bin/blog/source/blog/2015-07-27-company-values.html.markdown like it was a template. Non-default layouts need to be in source/layouts.
```

If I should add something to the changelog, let me know. I couldn't figure out the branch structure (master vs v3-stable) so I hope this is merging into the correct branch (maybe add a note in the CONTRIBUTING.md file?), and couldn't find any existing tests to modify. Please let me know if I should add them somewhere. 