### PR TITLE
Fix misnamed config value which was causing --force-polling flag to b…

### DIFF
--- a/middleman-core/lib/middleman-core/core_extensions/file_watcher.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/file_watcher.rb
@@ -30,7 +30,7 @@ module Middleman
         # Setup source collection.
         @sources = ::Middleman::Sources.new(app,
                                             disable_watcher: app.config[:watcher_disable],
-                                            force_polling: app.config[:force_polling],
+                                            force_polling: app.config[:watcher_force_polling],
                                             latency: app.config[:watcher_latency])
 
         # Add default ignores.


### PR DESCRIPTION
…e ignored by file_watcher extension