### PR TITLE
Update middleman-livereload version to more current

### DIFF
--- a/middleman-core/lib/middleman-core/templates/shared/Gemfile.tt
+++ b/middleman-core/lib/middleman-core/templates/shared/Gemfile.tt
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 gem "middleman", "~><%= Middleman::VERSION %>"
 
 # Live-reloading plugin
-gem "middleman-livereload", "~> 3.1.0"
+gem "middleman-livereload", "~> 3.3.0"
 
 # For faster file watcher updates on Windows:
 gem "wdm", "~> 0.1.0", :platforms => [:mswin, :mingw]


### PR DESCRIPTION
As discussed https://github.com/middleman/middleman-livereload/issues/69 but I forgot to apply the fix to source code inside MM. @tdreyno, should it be `~> 3.3.0` or `~> 3.4.0`? I looked into 3.4 changes and they seem to be MM v4 related?