### PR TITLE
Ignore gems installed in local dir.

### DIFF
--- a/middleman-core/lib/middleman-core/templates/shared/gitignore
+++ b/middleman-core/lib/middleman-core/templates/shared/gitignore
@@ -16,3 +16,6 @@
 
 # Ignore .DS_store file
 .DS_Store
+
+# Ignore gems installed in local directory
+vendor/bundle/

--- a/middleman-core/lib/middleman-core/templates/shared/gitignore
+++ b/middleman-core/lib/middleman-core/templates/shared/gitignore
@@ -18,4 +18,4 @@
 .DS_Store
 
 # Ignore gems installed in local directory
-vendor/bundle/
+/vendor/bundle/


### PR DESCRIPTION
When installing gems in the local dir, the convention with Bundler is to install them in `/vendor/bundle`.
Ignoring that folder by default would be helpful to many.
