### PR TITLE
Fix: Can't clean files when the project is under a hidden directory.

### DIFF
--- a/middleman-core/features/clean_build.feature
+++ b/middleman-core/features/clean_build.feature
@@ -42,3 +42,21 @@ Feature: Build Clean
     Then the following files should not exist:
       | sub/dir/about.html         |
       | sub/dir/nested/nested.html |
+
+  Scenario: Build and clean an app under a hidden directory
+    Given a fixture app "clean-app"
+    And app "clean-app" is using config "hidden-dir-before"
+    And a built app at "clean-app"
+    Then the following files should exist:
+      | .build/index.html              |
+      | .build/should_be_ignored.html  |
+      | .build/should_be_ignored2.html |
+      | .build/should_be_ignored3.html |
+    Given app "clean-app" is using config "hidden-dir-after"
+    And a built app at "clean-app"
+    Then the following files should exist:
+      | .build/index.html              |
+    And the following files should not exist:
+      | .build/should_be_ignored.html  |
+      | .build/should_be_ignored2.html |
+      | .build/should_be_ignored3.html |

--- a/middleman-core/fixtures/clean-app/config-hidden-dir-after.rb
+++ b/middleman-core/fixtures/clean-app/config-hidden-dir-after.rb
@@ -1,0 +1,5 @@
+set :build_dir, ".build"
+
+ignore "/should_be_ignored.html"
+page "/should_be_ignored2.html", :ignore => true
+page "/target_ignore.html", :proxy => "/should_be_ignored3.html", :ignore => true

--- a/middleman-core/fixtures/clean-app/config-hidden-dir-before.rb
+++ b/middleman-core/fixtures/clean-app/config-hidden-dir-before.rb
@@ -1,0 +1,1 @@
+set :build_dir, ".build"

--- a/middleman-core/lib/middleman-core/cli/build.rb
+++ b/middleman-core/lib/middleman-core/cli/build.rb
@@ -167,7 +167,7 @@ module Middleman::Cli
       paths = ::Middleman::Util.all_files_under(@build_dir).map(&:realpath).select(&:file?)
 
       @to_clean += paths.select do |path|
-        path.to_s !~ /\/\./ || path.to_s =~ /\.(htaccess|htpasswd)/
+        path.relative_path_from(@build_dir.realpath).to_s !~ /\/\./ || path.to_s =~ /\.(htaccess|htpasswd)/
       end
 
       return unless RUBY_PLATFORM =~ /darwin/


### PR DESCRIPTION
I run middleman in Jenkins. My middleman project is placed at ~/.jenkins/jobs/*/workspace and the build command can't clean files. I want to fix this.