### PR TITLE
remove unnecessary require

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-require 'rubygems' unless defined?(Gem)
 require 'rake'
 
 require File.expand_path('../middleman-core/lib/middleman-core/version.rb', __FILE__)

--- a/gem_rake_helper.rb
+++ b/gem_rake_helper.rb
@@ -1,4 +1,3 @@
-require 'rubygems' unless defined?(Gem)
 require 'rake'
 require 'yard'
 

--- a/middleman-core/Rakefile
+++ b/middleman-core/Rakefile
@@ -3,5 +3,4 @@ RAKE_ROOT = __FILE__
 
 GEM_NAME = ENV['NAME'] || 'middleman-core'
 
-require 'rubygems'
 require File.expand_path(File.dirname(__FILE__) + '/../gem_rake_helper')

--- a/middleman-core/lib/middleman-core/extensions.rb
+++ b/middleman-core/lib/middleman-core/extensions.rb
@@ -56,8 +56,6 @@ module Middleman
     #
     # @private
     def load_extensions_in_path
-      require 'rubygems'
-
       extensions = rubygems_latest_specs.select do |spec|
         spec_has_file?(spec, EXTENSION_FILE)
       end

--- a/middleman-core/lib/middleman-core/templates/shared/config.ru
+++ b/middleman-core/lib/middleman-core/templates/shared/config.ru
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'middleman/rack'
 
 run Middleman.server


### PR DESCRIPTION
`require 'rubygems'` is already required in Ruby 1.9 or later.