### PR TITLE
remove unnecessary require

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-require 'rubygems' unless defined?(Gem)
 require 'rake'
 
 require File.expand_path('../middleman-core/lib/middleman-core/version.rb', __FILE__)

--- a/gem_rake_helper.rb
+++ b/gem_rake_helper.rb
@@ -1,4 +1,3 @@
-require 'rubygems' unless defined?(Gem)
 require 'rake'
 require 'yard'
 

--- a/middleman-core/Rakefile
+++ b/middleman-core/Rakefile
@@ -1,5 +1,4 @@
 # coding:utf-8
 RAKE_ROOT = __FILE__
 GEM_NAME = ENV['NAME'] || 'middleman-core'
-require 'rubygems'
 require File.expand_path(File.dirname(__FILE__) + '/../gem_rake_helper')


### PR DESCRIPTION
`require 'rubygems'` is already required in Ruby 1.9 or later.

This is what was carried out #1616 against the `master` branch.