### PR TITLE
Frontmatter delims

### DIFF
--- a/middleman-core/features/front-matter.feature
+++ b/middleman-core/features/front-matter.feature
@@ -28,13 +28,18 @@ Feature: YAML Front Matter
     Then I should not see "layout: false"
     Then I should not see "title: Pandoc likes trailing dots..."
 
+  Scenario: Rendering Haml (yaml)
+    Given the Server is running at "frontmatter-app"
+    When I go to "/front-matter-haml.html"
+    Then I should see "<h1>This is the title</h1>"
+    Then I should not see "---"
 
   Scenario: YAML not on first line, no encoding
     Given the Server is running at "frontmatter-app"
     When I go to "/front-matter-line-2.html"
     Then I should see "<h1></h1>"
     Then I should see "---"
-    
+
   Scenario: YAML not on first line, with encoding
     Given the Server is running at "frontmatter-app"
     When I go to "/front-matter-encoding.html"

--- a/middleman-core/fixtures/frontmatter-app/config.rb
+++ b/middleman-core/fixtures/frontmatter-app/config.rb
@@ -1,0 +1,1 @@
+config[:frontmatter_delims][:yaml] << %w(\\--- \\---)

--- a/middleman-core/fixtures/frontmatter-app/source/front-matter-haml.html.haml
+++ b/middleman-core/fixtures/frontmatter-app/source/front-matter-haml.html.haml
@@ -1,0 +1,6 @@
+\---
+layout: false
+title: This is the title
+\---
+
+%h1= current_page.data.title

--- a/middleman-core/fixtures/frontmatter-neighbor-app/config.rb
+++ b/middleman-core/fixtures/frontmatter-neighbor-app/config.rb
@@ -15,7 +15,7 @@ class NeighborFrontmatter < ::Middleman::Extension
 
       next unless file
 
-      fmdata = ::Middleman::Util::Data.parse(file[:full_path], :yaml).first
+      fmdata = ::Middleman::Util::Data.parse(file[:full_path], app.config[:frontmatter_delims], :yaml).first
       opts = fmdata.extract!(:layout, :layout_engine, :renderer_options, :directory_index, :content_type)
       opts[:renderer_options].symbolize_keys! if opts.key?(:renderer_options)
       ignored = fmdata.delete(:ignored)

--- a/middleman-core/fixtures/frontmatter-settings-neighbor-app/config.rb
+++ b/middleman-core/fixtures/frontmatter-settings-neighbor-app/config.rb
@@ -26,7 +26,7 @@ class NeighborFrontmatter < ::Middleman::Extension
   end
 
   def apply_neighbor_data(resource, file)
-    fmdata = ::Middleman::Util::Data.parse(file[:full_path], :yaml).first
+    fmdata = ::Middleman::Util::Data.parse(file[:full_path], app.config[:frontmatter_delims], :yaml).first
     opts = fmdata.extract!(:layout, :layout_engine, :renderer_options, :directory_index, :content_type)
     opts[:renderer_options].symbolize_keys! if opts.key?(:renderer_options)
     ignored = fmdata.delete(:ignored)

--- a/middleman-core/lib/middleman-core/application.rb
+++ b/middleman-core/lib/middleman-core/application.rb
@@ -185,6 +185,12 @@ module Middleman
       end
     }, 'Callbacks that can exclude paths from the sitemap'
 
+    # Set textual delimiters that denote the start and end of frontmatter
+    define_setting :frontmatter_delims, {
+      json: [%w(;;; ;;;)],
+      yaml: [%w(--- ---), %w(--- ...)]
+    }, 'Allowed frontmatter delimiters'
+
     define_setting :watcher_disable, false, 'If the Listen watcher should not run'
     define_setting :watcher_force_polling, false, 'If the Listen watcher should run in polling mode'
     define_setting :watcher_latency, nil, 'The Listen watcher latency'

--- a/middleman-core/lib/middleman-core/core_extensions/data.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/data.rb
@@ -99,10 +99,10 @@ module Middleman
           basename  = File.basename(data_path, extension)
 
           if %w(.yaml .yml).include?(extension)
-            data, postscript = ::Middleman::Util::Data.parse(file[:full_path], :yaml)
+            data, postscript = ::Middleman::Util::Data.parse(file[:full_path], @app.config[:frontmatter_delims], :yaml)
             data[:postscript] = postscript if !postscript.nil? && data.is_a?(Hash)
           elsif extension == '.json'
-            data, _postscript = ::Middleman::Util::Data.parse(file[:full_path], :json)
+            data, _postscript = ::Middleman::Util::Data.parse(file[:full_path], @app.config[:frontmatter_delims], :json)
           else
             return
           end

--- a/middleman-core/lib/middleman-core/core_extensions/front_matter.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/front_matter.rb
@@ -65,7 +65,10 @@ module Middleman::CoreExtensions
 
       return [{}, nil] unless file
 
-      @cache[file[:full_path]] ||= ::Middleman::Util::Data.parse(file[:full_path])
+      @cache[file[:full_path]] ||= ::Middleman::Util::Data.parse(
+        file[:full_path],
+        app.config[:frontmatter_delims]
+      )
     end
 
     Contract ArrayOf[IsA['Middleman::SourceFile']], ArrayOf[IsA['Middleman::SourceFile']] => Any


### PR DESCRIPTION
Ok so there is weird stuff going on here, testing with `bundle exec cucumber features/front-matter.feature `:

1. Changing `frontmatter_delims` to `Middleman::Application.config[:frontmatter_delims]` in `data.rb:27` still works, I'm pretty sure it didn't when I tried the other day...
2. The `config[:frontmatter_delims][:yaml]` variable is mutated with `config[:frontmatter_delims][:yaml] << %w(\\--- \\---)` in each step; `%w(\\--- \---)` is added every time (this does not affect the validity of the test).
3. It makes no difference if you change it to `config[:frontmatter_delims][:yaml] = [%w(--- ---), %w(--- ...), %w(\\--- \\---)]`, it still ends up being a mess like `{:json=>[[";;;", ";;;"]], :yaml=>[["---", "---"], ["---", "..."], ["\\---", "\\---"], ["\\---", "\\---"], ["\\---", "\\---"], ["\\---", "\\---"], ["\\---", "\\---"], ["\\---", "\\---"], ["\\---", "\\---"], ["\\---", "\\---"]]}`
4. Commenting out `config.rb` makes no difference, so `# config[:frontmatter_delims][:yaml] << %w(\\--- \\---)` still takes effect even though ruby should not evaluate this code. Removing the line entirely works though, so it's not some cache bug.
5. The `/(?<var>.*)/ =~ text` syntax stopped working when I interpolated the other regexes, making the code much uglier. I don't know if that's a bug in ruby or what...

I passed the config option in from the extension as mentioned in https://github.com/middleman/middleman/pull/1636#issuecomment-150448522, I used the test from https://github.com/DarylWright/middleman/commit/1ab5fcd9d406d5cd36580edc0fb07cf00611fbe5, will wait to see if this breaks other tests...