### PR TITLE
Ignore .ruby-gemset file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ Gemfile.lock
 docs
 .rbenv-*
 .ruby-version
+.ruby-gemset
 .*.swp
 build
 doc


### PR DESCRIPTION
Ignore the .ruby-gemset file used to define an RVM gemset.