### PR TITLE
Add "before_server"-hook to preview server in v4

### DIFF
--- a/middleman-core/features/cli/preview_server-hook.feature
+++ b/middleman-core/features/cli/preview_server-hook.feature
@@ -1,0 +1,17 @@
+Feature: Run preview server before hook
+
+  Scenario: When run
+    Given a fixture app "preview-server-hook-app"
+    And the default aruba timeout is 30 seconds
+    When I run `middleman server --server-name localhost --bind-address 127.0.0.1` interactively
+    And I stop middleman if the output contains:
+    """
+    ### END ###
+    """
+    Then the output should contain:
+    """
+    /// 127.0.0.1:4567 ///
+    /// 4567 ///
+    /// localhost ///
+    /// http://localhost:4567 ///
+    """

--- a/middleman-core/fixtures/preview-server-hook-app/config.rb
+++ b/middleman-core/fixtures/preview-server-hook-app/config.rb
@@ -1,0 +1,19 @@
+set :layout, false
+
+class MyFeature < Middleman::Extension
+  def initialize(app, options_hash = {}, &block)
+    super
+
+    app.before_server do |server_information|
+      puts "/// #{server_information.listeners.first} ///"
+      puts "/// #{server_information.port} ///"
+      puts "/// #{server_information.server_name} ///"
+      puts "/// #{server_information.site_addresses.first} ///"
+      puts "/// ### END ### ///"
+    end
+  end
+end
+
+::Middleman::Extensions.register(:my_feature, MyFeature)
+
+activate :my_feature

--- a/middleman-core/fixtures/preview-server-hook-app/source/index.html.erb
+++ b/middleman-core/fixtures/preview-server-hook-app/source/index.html.erb
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>preview-server-hook-app</title>
+  </head>
+  <body>
+    <h1>preview-server-hook-app</h1>
+  </body>
+</html>

--- a/middleman-core/lib/middleman-core/application.rb
+++ b/middleman-core/lib/middleman-core/application.rb
@@ -216,7 +216,8 @@ module Middleman
         :before_shutdown,
         :before, # Before Rack requests
         :before_render,
-        :after_render
+        :after_render,
+        :before_server
       ])
 
       @middleware = Set.new

--- a/middleman-core/lib/middleman-core/preview_server.rb
+++ b/middleman-core/lib/middleman-core/preview_server.rb
@@ -6,6 +6,7 @@ require 'middleman-core/logger'
 require 'middleman-core/rack'
 require 'middleman-core/preview_server/server_information'
 require 'middleman-core/preview_server/server_url'
+require 'middleman-core/preview_server/server_information_callback_proxy'
 
 # rubocop:disable GlobalVars
 module Middleman
@@ -54,6 +55,8 @@ module Middleman
         # Save the last-used @options so it may be re-used when
         # reloading later on.
         ::Middleman::Profiling.report('server_start')
+
+        app.execute_callbacks(:before_server, [ServerInformationCallbackProxy.new(server_information)])
 
         loop do
           @webrick.start

--- a/middleman-core/lib/middleman-core/preview_server/server_information.rb
+++ b/middleman-core/lib/middleman-core/preview_server/server_information.rb
@@ -20,6 +20,8 @@ module Middleman
 
       public
 
+      attr_writer :https
+
       def initialize(opts={})
         @resolver     = opts.fetch(:resolver, DnsResolver.new)
         @validator    = opts.fetch(:validator, ServerInformationValidator.new)
@@ -64,10 +66,12 @@ module Middleman
         @bind_address = config[:bind_address]
         @port         = config[:port]
         @server_name  = config[:server_name]
+        @https        = config[:https]
 
         config[:bind_address] = bind_address
-        config[:port] = port
-        config[:server_name] = server_name
+        config[:port]         = port
+        config[:server_name]  = server_name
+        config[:https]        = https?
       end
 
       # Make information of internal server class avaible to make debugging
@@ -138,6 +142,11 @@ module Middleman
       #   A list of bind address where the
       def listeners
         information.listeners
+      end
+
+      # Is https enabled?
+      def https?
+        @https == true
       end
     end
   end

--- a/middleman-core/lib/middleman-core/preview_server/server_information_callback_proxy.rb
+++ b/middleman-core/lib/middleman-core/preview_server/server_information_callback_proxy.rb
@@ -1,0 +1,35 @@
+module Middleman
+  class PreviewServer
+    # This class wraps server information to be used in call back
+    #
+    # * listeners
+    # * port
+    # * server name
+    # * site_addresses
+    #
+    # All information is "dupped" and the callback is not meant to be used to
+    # modify these information.
+    class ServerInformationCallbackProxy
+      attr_reader :server_name, :port, :site_addresses, :listeners
+
+      def initialize(server_information)
+        @listeners   = ServerUrl.new(
+          hosts: server_information.listeners,
+          port: server_information.port, 
+          https: server_information.https?,
+          format_output: false
+        ).to_bind_addresses
+
+        @port           = server_information.port
+        @server_name    = server_information.server_name.dup unless server_information.server_name == nil
+
+        @site_addresses = ServerUrl.new(
+          hosts: server_information.site_addresses,
+          port: server_information.port,
+          https: server_information.https?,
+          format_output: false
+        ).to_urls
+      end
+    end
+  end
+end

--- a/middleman-core/lib/middleman-core/preview_server/server_url.rb
+++ b/middleman-core/lib/middleman-core/preview_server/server_url.rb
@@ -6,7 +6,7 @@ module Middleman
     class ServerUrl
       private
 
-      attr_reader :hosts, :port, :https
+      attr_reader :hosts, :port, :https, :format_output
 
       public
 
@@ -14,6 +14,7 @@ module Middleman
         @hosts = opts.fetch(:hosts)
         @port  = opts.fetch(:port)
         @https = opts.fetch(:https, false)
+        @format_output = opts.fetch(:format_output, true)
       end
 
       # Return bind addresses
@@ -21,7 +22,11 @@ module Middleman
       # @return [Array]
       #   List of bind addresses of format host:port
       def to_bind_addresses
-        hosts.map { |l| format('"%s:%s"', l.to_s, port) }
+        if format_output
+          hosts.map { |l| format('"%s:%s"', l.to_s, port) }
+        else
+          hosts.map { |l| format('%s:%s', l.to_s, port) }
+        end
       end
 
       # Return server urls
@@ -29,7 +34,11 @@ module Middleman
       # @return [Array]
       #   List of urls of format http://host:port
       def to_urls
-        hosts.map { |l| format('"%s://%s:%s"', https? ? 'https' : 'http', l.to_browser, port) }
+        if format_output
+          hosts.map { |l| format('"%s://%s:%s"', https? ? 'https' : 'http', l.to_browser, port) }
+        else
+          hosts.map { |l| format('%s://%s:%s', https? ? 'https' : 'http', l.to_browser, port) }
+        end
       end
 
       # Return server config urls
@@ -37,7 +46,11 @@ module Middleman
       # @return [Array]
       #   List of urls of format http://host:port/__middleman
       def to_config_urls
-        hosts.map { |l| format('"%s://%s:%s/__middleman"', https? ? 'https' : 'http', l.to_browser, port) }
+        if format_output
+          hosts.map { |l| format('"%s://%s:%s/__middleman"', https? ? 'https' : 'http', l.to_browser, port) }
+        else
+          hosts.map { |l| format('%s://%s:%s/__middleman', https? ? 'https' : 'http', l.to_browser, port) }
+        end
       end
 
       private


### PR DESCRIPTION
This addresses #1624. @tdreyno @dlitvakb @bhollis @Arcovion 

1. Move HTTPs to server_information to DRY up code and make it reusable in callback_proxy
2. Add hook

This hook get's the same information which are written to STDERR. The main idea for adding this hook, is to support extensions which use libraries like [launchy](https://github.com/copiousfreetime/launchy) to open the preview server site in your local browser.

