### PR TITLE
Upgrade to aruba 0.10.x [WIP]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,4 +37,4 @@ gem 'coveralls', '~> 0.8', require: false
 # Middleman itself
 gem 'middleman-core', path: 'middleman-core'
 gem 'middleman', path: 'middleman'
-gem 'middleman-sprockets', github: 'middleman/middleman-sprockets', branch: 'v3-stable-real'
+gem 'middleman-sprockets', git: 'https://github.com/middleman/middleman-sprockets', branch: 'v3-stable-real'

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'yard', '~> 0.8', require: false
 
 # Test tools
 gem 'pry', '~> 0.10', group: :development
-gem 'aruba', '~> 0.7.4'
+gem 'aruba', '~> 0.10.0'
 gem 'rspec', '~> 3.0'
 gem 'cucumber', '~> 2.0'
 

--- a/middleman-core/features/cli/preview_server.feature
+++ b/middleman-core/features/cli/preview_server.feature
@@ -6,7 +6,7 @@ Feature: Run the preview server
 
   Background:
     Given a fixture app "preview-server-app"
-    And the default aruba timeout is 30 seconds
+    And the default aruba exit timeout is 30 seconds
 
   Scenario: Start the server with defaults
     When I run `middleman server` interactively

--- a/middleman-core/features/data.feature
+++ b/middleman-core/features/data.feature
@@ -54,7 +54,7 @@ Feature: Local Data API
 
   Scenario: Invalid YAML
     Given a fixture app "basic-data-app"
-    And the default aruba timeout is 30 seconds
+    And the default aruba exit timeout is 30 seconds
     And a file named "data/test.yml" with:
       """
       'ASDSFDa:
@@ -68,7 +68,7 @@ Feature: Local Data API
 
   Scenario: Invalid JSON
     Given a fixture app "basic-data-app"
-    And the default aruba timeout is 30 seconds
+    And the default aruba exit timeout is 30 seconds
     And a file named "data/test.json" with:
       """
       'ASDSFDa:

--- a/middleman-core/features/step_definitions/queryable_steps.rb
+++ b/middleman-core/features/step_definitions/queryable_steps.rb
@@ -18,118 +18,195 @@ end
 
 Then /^should raise an exception if the operator is not supported$/ do
   expect {
-    selector = ::Middleman::Sitemap::Queryable::Selector.new :attribute => :author, :operator => 'zomg'
+    ::Middleman::Sitemap::Queryable::Selector.new :attribute => :author, :operator => 'zomg'
   }.to raise_error(::Middleman::Sitemap::Queryable::OperatorNotSupportedError)
 end
 
 Then /^should limit the documents to the number specified$/ do
-  @server_inst.sitemap.order_by(:id).limit(2).all.map { |r| r.raw_data[:id] }.sort.should == [1,2].sort
+  cd '.' do
+    with_environment do
+      @server_inst.sitemap.order_by(:id).limit(2).all.map { |r| r.raw_data[:id] }.sort.should == [1,2].sort
+    end
+  end
 end
 
 Then /^should offset the documents by the number specified$/ do
-  @server_inst.sitemap.order_by(:id).offset(2).all.map { |r| r.raw_data[:id] }.sort.should == [3,4,5].sort
+  cd '.' do
+    with_environment do
+      @server_inst.sitemap.order_by(:id).offset(2).all.map { |r| r.raw_data[:id] }.sort.should == [3,4,5].sort
+    end
+  end
 end
 
 Then /^should support offset and limit at the same time$/ do
-  @server_inst.sitemap.order_by(:id).offset(1).limit(2).all.map { |r| r.raw_data[:id] }.sort.should == [2,3].sort
+  cd '.' do
+    with_environment do
+      @server_inst.sitemap.order_by(:id).offset(1).limit(2).all.map { |r| r.raw_data[:id] }.sort.should == [2,3].sort
+    end
+  end
 end
 
 Then /^should not freak out about an offset higher than the document count$/ do
-  @server_inst.sitemap.order_by(:id).offset(5).all.should == []
+  cd '.' do
+    with_environment do
+      @server_inst.sitemap.order_by(:id).offset(5).all.should == []
+    end
+  end
 end
 
 Then /^should return the right documents$/ do
-  documents = @server_inst.sitemap.resources.select { |r| !r.raw_data.empty? }
-  document_1 = documents[0]
-  document_2 = documents[1]
+  cd '.' do
+    with_environment do
+      documents = @server_inst.sitemap.resources.select { |r| !r.raw_data.empty? }
+      document_1 = documents[0]
+      document_2 = documents[1]
 
-  found_document = @server_inst.sitemap.where(:title => document_1.raw_data[:title]).first
-  document_1.should == found_document
-  
-  found_document = @server_inst.sitemap.where(:title => document_2.raw_data[:title]).first
-  document_2.should == found_document
+      found_document = @server_inst.sitemap.where(:title => document_1.raw_data[:title]).first
+      document_1.should == found_document
+
+      found_document = @server_inst.sitemap.where(:title => document_2.raw_data[:title]).first
+      document_2.should == found_document
+    end
+  end
 end
 
 Then /^should be chainable$/ do
-  documents = @server_inst.sitemap.resources.select { |r| !r.raw_data.empty? }
-  document_1 = documents[0]
+  cd '.' do
+    with_environment do
+      documents = @server_inst.sitemap.resources.select { |r| !r.raw_data.empty? }
+      document_1 = documents[0]
 
-  document_proxy = @server_inst.sitemap.where(:title => document_1.raw_data[:title])
-  document_proxy.where(:id => document_1.raw_data[:id])
-  document_1.should == document_proxy.first
+      document_proxy = @server_inst.sitemap.where(:title => document_1.raw_data[:title])
+      document_proxy.where(:id => document_1.raw_data[:id])
+      document_1.should == document_proxy.first
+    end
+  end
 end
 
 Then /^should not be confused by attributes not present in all documents$/ do
-  result = @server_inst.sitemap.where(:seldom_attribute => 'is seldom').all
-  result.map { |r| r.raw_data[:id] }.should == [4]
+  cd '.' do
+    with_environment do
+      result = @server_inst.sitemap.where(:seldom_attribute => 'is seldom').all
+      result.map { |r| r.raw_data[:id] }.should == [4]
+    end
+  end
 end
 
 Then /^with a gt operator should return the right documents$/ do
   selector = ::Middleman::Sitemap::Queryable::Selector.new :attribute => :id, :operator => 'gt'
-  found_documents = @server_inst.sitemap.where(selector => 2).all
-  found_documents.map { |r| r.raw_data[:id] }.sort.should == [5,3,4].sort
+  cd '.' do
+    with_environment do
+      found_documents = @server_inst.sitemap.where(selector => 2).all
+      found_documents.map { |r| r.raw_data[:id] }.sort.should == [5,3,4].sort
+    end
+  end
 end
 
 Then /^with a gte operator should return the right documents$/ do
   selector = ::Middleman::Sitemap::Queryable::Selector.new :attribute => :id, :operator => 'gte'
-  found_documents = @server_inst.sitemap.where(selector => 2).all
-  found_documents.map { |r| r.raw_data[:id] }.sort.should == [2,5,3,4].sort
+
+  cd '.' do
+    with_environment do
+      found_documents = @server_inst.sitemap.where(selector => 2).all
+      found_documents.map { |r| r.raw_data[:id] }.sort.should == [2,5,3,4].sort
+    end
+  end
 end
 
 Then /^with an in operator should return the right documents$/ do
   selector = ::Middleman::Sitemap::Queryable::Selector.new :attribute => :id, :operator => 'in'
-  found_documents = @server_inst.sitemap.where(selector => [2,3]).all
-  found_documents.map { |r| r.raw_data[:id] }.sort.should == [2,3].sort
+  cd '.' do
+    with_environment do
+      found_documents = @server_inst.sitemap.where(selector => [2,3]).all
+      found_documents.map { |r| r.raw_data[:id] }.sort.should == [2,3].sort
+    end
+  end
 end
 
 Then /^with an lt operator should return the right documents$/ do
   selector = ::Middleman::Sitemap::Queryable::Selector.new :attribute => :id, :operator => 'lt'
-  found_documents = @server_inst.sitemap.where(selector => 2).all
-  found_documents.map { |r| r.raw_data[:id] }.should == [1]
+  cd '.' do
+    with_environment do
+      found_documents = @server_inst.sitemap.where(selector => 2).all
+      found_documents.map { |r| r.raw_data[:id] }.should == [1]
+    end
+  end
 end
 
 Then /^with an lte operator should return the right documents$/ do
   selector = ::Middleman::Sitemap::Queryable::Selector.new :attribute => :id, :operator => 'lte'
-  found_documents = @server_inst.sitemap.where(selector => 2).all
-  found_documents.map { |r| r.raw_data[:id] }.sort.should == [1,2].sort
+  cd '.' do
+    with_environment do
+      found_documents = @server_inst.sitemap.where(selector => 2).all
+      found_documents.map { |r| r.raw_data[:id] }.sort.should == [1,2].sort
+    end
+  end
 end
 
 Then /^with an include operator include should return the right documents$/ do
   selector = ::Middleman::Sitemap::Queryable::Selector.new :attribute => :tags, :operator => 'include'
-  found_documents = @server_inst.sitemap.where(selector => 'ruby').all
-  found_documents.map { |r| r.raw_data[:id] }.sort.should == [1,2].sort
+  cd '.' do
+    with_environment do
+      found_documents = @server_inst.sitemap.where(selector => 'ruby').all
+      found_documents.map { |r| r.raw_data[:id] }.sort.should == [1,2].sort
+    end
+  end
 end
 
 Then /^with mixed operators should return the right documents$/ do
   in_selector = ::Middleman::Sitemap::Queryable::Selector.new :attribute => :id, :operator => 'in'
   gt_selector = ::Middleman::Sitemap::Queryable::Selector.new :attribute => :id, :operator => 'gt'
-  documents_proxy = @server_inst.sitemap.where(in_selector => [2,3])
-  found_documents = documents_proxy.where(gt_selector => 2).all
-  found_documents.map { |r| r.raw_data[:id] }.should == [3]
+  cd '.' do
+    with_environment do
+      documents_proxy = @server_inst.sitemap.where(in_selector => [2,3])
+      found_documents = documents_proxy.where(gt_selector => 2).all
+      found_documents.map { |r| r.raw_data[:id] }.should == [3]
+    end
+  end
 end
 
 Then /^using multiple constrains in one where should return the right documents$/ do
   selector = ::Middleman::Sitemap::Queryable::Selector.new :attribute => :id, :operator => 'lte'
-  found_documents = @server_inst.sitemap.where(selector => 2, :status => :published).all
-  found_documents.map { |r| r.raw_data[:id] }.sort.should == [1,2].sort
+  cd '.' do
+    with_environment do
+      found_documents = @server_inst.sitemap.where(selector => 2, :status => :published).all
+      found_documents.map { |r| r.raw_data[:id] }.sort.should == [1,2].sort
+    end
+  end
 end
 
 Then /^should support ordering by attribute ascending$/ do
-  found_documents = @server_inst.sitemap.order_by(:title => :asc).all
-  found_documents.map { |r| r.raw_data[:id] }.should == [2,3,1,5,4]
+  cd '.' do
+    with_environment do
+      found_documents = @server_inst.sitemap.order_by(:title => :asc).all
+      found_documents.map { |r| r.raw_data[:id] }.should == [2,3,1,5,4]
+    end
+  end
 end
 
 Then /^should support ordering by attribute descending$/ do
-  found_documents = @server_inst.sitemap.order_by(:title => :desc).all
-  found_documents.map { |r| r.raw_data[:id] }.should == [4,5,1,3,2]
+  cd '.' do
+    with_environment do
+      found_documents = @server_inst.sitemap.order_by(:title => :desc).all
+      found_documents.map { |r| r.raw_data[:id] }.should == [4,5,1,3,2]
+    end
+  end
 end
 
 Then /^should order by attribute ascending by default$/ do
-  found_documents = @server_inst.sitemap.order_by(:title).all
-  found_documents.map { |r| r.raw_data[:id] }.should == [2,3,1,5,4]
+  cd '.' do
+    with_environment do
+      found_documents = @server_inst.sitemap.order_by(:title).all
+      found_documents.map { |r| r.raw_data[:id] }.should == [2,3,1,5,4]
+    end
+  end
 end
 
 Then /^should exclude documents that do not own the attribute$/ do
-  found_documents = @server_inst.sitemap.order_by(:status).all
-  found_documents.map { |r| r.raw_data[:id] }.to_set.should == [1,2].to_set
+  cd '.' do
+    with_environment do
+      found_documents = @server_inst.sitemap.order_by(:status).all
+      found_documents.map { |r| r.raw_data[:id] }.to_set.should == [1,2].to_set
+    end
+  end
 end

--- a/middleman-core/lib/middleman-core/step_definitions.rb
+++ b/middleman-core/lib/middleman-core/step_definitions.rb
@@ -1,5 +1,5 @@
 require 'aruba/cucumber'
-require 'aruba/jruby'
+require 'aruba/config/jruby'
 require 'middleman-core/step_definitions/middleman_steps'
 require 'middleman-core/step_definitions/builder_steps'
 require 'middleman-core/step_definitions/server_steps'

--- a/middleman-core/lib/middleman-core/step_definitions/builder_steps.rb
+++ b/middleman-core/lib/middleman-core/step_definitions/builder_steps.rb
@@ -5,29 +5,27 @@ Before do
 end
 
 Given /^app "([^\"]*)" is using config "([^\"]*)"$/ do |path, config_name|
-  target = File.join(PROJECT_ROOT_PATH, 'fixtures', path)
-  config_path = File.join(current_directory, "config-#{config_name}.rb")
-  config_dest = File.join(current_directory, 'config.rb')
-  FileUtils.cp(config_path, config_dest)
+  copy("config-#{config_name}.rb", 'config.rb')
 end
 
 Given /^an empty app$/ do
   step %Q{a directory named "empty_app"}
   step %Q{I cd to "empty_app"}
-  ENV['MM_ROOT'] = nil
+
+  delete_environment_variable 'MM_ROOT'
 end
 
 Given /^a fixture app "([^\"]*)"$/ do |path|
-  ENV['MM_ROOT'] = nil
+  delete_environment_variable 'MM_ROOT'
 
   # This step can be reentered from several places but we don't want
   # to keep re-copying and re-cd-ing into ever-deeper directories
-  next if File.basename(current_directory) == path
+  next if File.basename(expand_path('.')) == path
 
   step %Q{a directory named "#{path}"}
 
   target_path = File.join(PROJECT_ROOT_PATH, 'fixtures', path)
-  FileUtils.cp_r(target_path, current_directory)
+  FileUtils.cp_r(target_path, expand_path('.'))
 
   step %Q{I cd to "#{path}"}
 end
@@ -58,20 +56,20 @@ Given /^a successfully built app at "([^\"]*)" with flags "([^\"]*)"$/ do |path,
 end
 
 Given /^a modification time for a file named "([^\"]*)"$/ do |file|
-  target = File.join(current_directory, file)
+  target = expand_path(file)
   @modification_times[target] = File.mtime(target)
 end
 
 Then /^the file "([^\"]*)" should not have been updated$/ do |file|
-  target = File.join(current_directory, file)
+  target = expand_path(file)
   File.mtime(target).should == @modification_times[target]
 end
 
 # Provide this Aruba overload in case we're matching something with quotes in it
 Then /^the file "([^"]*)" should contain '([^']*)'$/ do |file, partial_content|
-  check_file_content(file, Regexp.new(Regexp.escape(partial_content)), true)
+  expect(file).to have_file_content Regexp.new(Regexp.escape(partial_content))
 end
 
 And /the file "(.*)" should be gzipped/ do |file|
-  expect(File.binread(File.join(current_directory, file), 2)).to eq(['1F8B'].pack('H*'))
+  expect(File.binread(expand_path(file), 2)).to eq(['1F8B'].pack('H*'))
 end

--- a/middleman-core/lib/middleman-core/step_definitions/middleman_steps.rb
+++ b/middleman-core/lib/middleman-core/step_definitions/middleman_steps.rb
@@ -9,9 +9,17 @@ Then /^the file "([^\"]*)" is removed$/ do |path|
 end
 
 Then /^the file "([^\"]*)" did change$/ do |path|
-  @server_inst.files.did_change(path)
+  cd '.' do
+    with_environment do
+      @server_inst.files.did_change(path)
+    end
+  end
 end
 
 Then /^the file "([^\"]*)" did delete$/ do |path|
-  @server_inst.files.did_delete(path)
+  cd '.' do
+    with_environment do
+      @server_inst.files.did_delete(path)
+    end
+  end
 end

--- a/middleman-core/lib/middleman-core/step_definitions/server_steps.rb
+++ b/middleman-core/lib/middleman-core/step_definitions/server_steps.rb
@@ -31,15 +31,13 @@ Given /^current environment is "([^\"]*)"$/ do |env|
 end
 
 Given /^the Server is running$/ do
-  root_dir = File.expand_path(current_directory)
-
-  if File.exists?(File.join(root_dir, 'source'))
-    ENV['MM_SOURCE'] = 'source'
+  if exist? 'source'
+    set_environment_variable 'MM_SOURCE', 'source'
   else
-    ENV['MM_SOURCE'] = ''
+    set_environment_variable 'MM_SOURCE', ''
   end
 
-  ENV['MM_ROOT'] = root_dir
+  set_environment_variable 'MM_ROOT', expand_path('.')
 
   initialize_commands = @initialize_commands || []
   initialize_commands.unshift lambda {
@@ -47,10 +45,12 @@ Given /^the Server is running$/ do
     set :show_exceptions, false
   }
 
-  in_current_directory do
-    @server_inst = Middleman::Application.server.inst do
-      initialize_commands.each do |p|
-        instance_exec(&p)
+  cd '.' do
+    with_environment do
+      @server_inst = Middleman::Application.server.inst do
+        initialize_commands.each do |p|
+          instance_exec(&p)
+        end
       end
     end
   end
@@ -68,61 +68,81 @@ Given /^a template named "([^\"]*)" with:$/ do |name, string|
 end
 
 When /^I go to "([^\"]*)"$/ do |url|
-  in_current_directory do
-    visit(URI.encode(url).to_s)
+  cd '.' do
+    with_environment do
+      visit(URI.encode(url).to_s)
+    end
   end
 end
 
 Then /^going to "([^\"]*)" should not raise an exception$/ do |url|
-  in_current_directory do
-    expect{ visit(URI.encode(url).to_s) }.to_not raise_exception
+  cd '.' do
+    with_environment do
+      expect{ visit(URI.encode(url).to_s) }.to_not raise_exception
+    end
   end
 end
 
 Then /^the content type should be "([^\"]*)"$/ do |expected|
-  in_current_directory do
-    expect(page.response_headers['Content-Type']).to start_with expected
+  cd '.' do
+    with_environment do
+      expect(page.response_headers['Content-Type']).to start_with expected
+    end
   end
 end
 
 Then /^I should see "([^\"]*)"$/ do |expected|
-  in_current_directory do
-    expect(page.body).to include expected
+  cd '.' do
+    with_environment do
+      expect(page.body).to include expected
+    end
   end
 end
 
 Then /^I should see '([^\']*)'$/ do |expected|
-  in_current_directory do
-    expect(page.body).to include expected
+  cd '.' do
+    with_environment do
+      expect(page.body).to include expected
+    end
   end
 end
 
 Then /^I should see:$/ do |expected|
-  in_current_directory do
-    expect(page.body).to include expected
+  cd '.' do
+    with_environment do
+      expect(page.body).to include expected
+    end
   end
 end
 
 Then /^I should not see "([^\"]*)"$/ do |expected|
-  in_current_directory do
-    expect(page.body).not_to include expected
+  cd '.' do
+    with_environment do
+      expect(page.body).not_to include expected
+    end
   end
 end
 
 Then /^I should not see:$/ do |expected|
-  in_current_directory do
-    expect(page.body).not_to include expected
+  cd '.' do
+    with_environment do
+      expect(page.body).not_to include expected
+    end
   end
 end
 
 Then /^the status code should be "([^\"]*)"$/ do |expected|
-  in_current_directory do
-    expect(page.status_code).to eq expected.to_i
+  cd '.' do
+    with_environment do
+      expect(page.status_code).to eq expected.to_i
+    end
   end
 end
 
 Then /^I should see "([^\"]*)" lines$/ do |lines|
-  in_current_directory do
-    expect(page.body.chomp.split($/).length).to eq lines.to_i
+  cd '.' do
+    with_environment do
+      expect(page.body.chomp.split($/).length).to eq lines.to_i
+    end
   end
 end


### PR DESCRIPTION
@tdreyno @Arcovion 

1. I'm tired to change the `Gemfile` on each contribution. Since this is backward-compatible I changed it to download the git repository via HTTP to make it work across HTTP proxies
2. This upgrades your test suite to aruba 0.10.x and removes all methods with deprecation warnings. Since changes to ENV are "bundle" with aruba from 0.8.0 or so, I modified all places where ENV is accessed. I also make sure, that changes of CWD are local to the steps to prevent "leaking".

To see if this works across all of your supported platforms, I sent you this PR. Both changes are made in two separate commits.