### PR TITLE
Allow asset_url to work outside of a resource context when relative: !true

### DIFF
--- a/middleman-core/lib/middleman-more/core_extensions/default_helpers.rb
+++ b/middleman-core/lib/middleman-more/core_extensions/default_helpers.rb
@@ -223,7 +223,7 @@ class Middleman::CoreExtensions::DefaultHelpers < ::Middleman::Extension
     # @return [String] The fully qualified asset url
     def asset_url(path, prefix='', options={})
       # Don't touch assets which already have a full path
-      if path.include?('//') || path.start_with?('data:') || !current_resource
+      if path.include?('//') || path.start_with?('data:')
         path
       else # rewrite paths to use their destination path
         result = if resource = sitemap.find_resource_by_destination_path(url_for(path))
@@ -241,6 +241,10 @@ class Middleman::CoreExtensions::DefaultHelpers < ::Middleman::Extension
         if options[:relative] != true
           result
         else
+          unless current_resource
+            raise ArgumentError, "#asset_url must be run in a context with current_resource if relative: true"
+          end
+
           current_dir = Pathname('/' + current_resource.destination_path)
           Pathname(result).relative_path_from(current_dir.dirname).to_s
         end


### PR DESCRIPTION
Just ran into some issues when running tests on one of my libs after bumping from `3.3.11 -> 3.4` that the `asset_url` method (and others that depend on it) no longer works as expected because they're running outside the context of a resource. Largely this probably isn't too much of an issue, but I could imagine cases trying to fetch urls from an extension or something it would also cause issues.

For an example -- some pseudo code assuming run from an extension:

```ruby
# 3.3.12
app.asset_url 'site.css', 'stylesheets'
# => '/stylesheets/site.css'

# 3.4.0
app.asset_url 'site.css', 'stylesheets'
# => 'site.css'
```

This PR rearranges the logic of the method a bit, adding the check for the `current_resource` only when it's needed for relative assets. I went with the "fail loudly and explicitly", I'm happy to change that to just return the path like it would have originally if you feel that's better.

Also -- I didn't see a light way to add tests for certain helpers outside a resource context -- I'm happy to do a little lifting to port over what I use for testing in rspec if you feel like it's needed (or add tests if there's already a way to do it).


Weeee, and last thing -- looks like v4 would also have this problem (although the code in Middleman::Util is a little different) -- should I open a separate pull request for that?

cheers,
steven