### PR TITLE
Allow asset url to work without passing a current_resource (v4)

### DIFF
--- a/middleman-core/lib/middleman-core/util.rb
+++ b/middleman-core/lib/middleman-core/util.rb
@@ -201,7 +201,7 @@ module Middleman
     Contract IsA['Middleman::Application'], String, String, Hash => String
     def asset_url(app, path, prefix='', options={})
       # Don't touch assets which already have a full path
-      if path.include?('//') || path.start_with?('data:') || !options[:current_resource]
+      if path.include?('//') || path.start_with?('data:')
         path
       else # rewrite paths to use their destination path
         result = if resource = app.sitemap.find_resource_by_destination_path(url_for(app, path))
@@ -218,6 +218,10 @@ module Middleman
         if options[:relative] != true
           result
         else
+          unless options[:current_resource]
+            raise ArgumentError, '#asset_url must be run in a context with current_resource if relative: true'
+          end
+
           current_dir = Pathname('/' + options[:current_resource].destination_path)
           Pathname(result).relative_path_from(current_dir.dirname).to_s
         end

--- a/middleman-core/spec/spec_helper.rb
+++ b/middleman-core/spec/spec_helper.rb
@@ -12,6 +12,8 @@ RSpec.configure do |config|
   config.include Aruba::Api
 end
 
+require_relative 'support/given'
+
 # encoding: utf-8
 RSpec.configure do |config|
   config.filter_run :focus

--- a/middleman-core/spec/support/given.rb
+++ b/middleman-core/spec/support/given.rb
@@ -1,0 +1,42 @@
+module Given
+  ROOT = File.expand_path( '../..', File.dirname( File.realpath(__FILE__) ) )
+  TMP  = File.join( ROOT, 'tmp' )
+
+  class << self
+
+    def fixture name
+      cleanup!
+
+      `rsync -av #{File.join( ROOT, 'fixtures', name )}/ #{TMP}/`
+      Dir.chdir TMP
+      ENV['MM_ROOT'] = TMP
+    end
+
+    def no_file name
+      FileUtils.rm name, force: true
+    end
+
+    def symlink source, destination
+      no_file destination
+      FileUtils.symlink File.expand_path(source),
+                        File.expand_path(destination),
+                        force: true
+    end
+
+    def file name, content
+      file_path = File.join( TMP, name )
+      FileUtils.mkdir_p( File.dirname(file_path) )
+      File.open( file_path, 'w' ) do |file|
+        file.write content
+      end
+    end
+
+    def cleanup!
+      Dir.chdir ROOT
+      if File.exist? TMP
+        `rm -rf #{TMP}`
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
@tdreyno same as #1686 but for v4. This includes some specs (getting an instance to test with is *way* nicer now) that I think cover all the conditional branches for asset_url.

Also includes a fixture helper for rspec, open to any feedback on that (and I'm crossing fingers travis likes it).