### PR TITLE
Skip front matter parsing for ignored resources

### DIFF
--- a/middleman-core/lib/middleman-core/core_extensions/front_matter.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/front_matter.rb
@@ -28,6 +28,7 @@ module Middleman::CoreExtensions
     Contract ResourceList => ResourceList
     def manipulate_resource_list(resources)
       resources.each do |resource|
+        next if resource.ignored?
         next if resource.file_descriptor.nil?
 
         fmdata = data(resource.file_descriptor[:full_path].to_s).first.dup


### PR DESCRIPTION
I believe this is an accurate assumption to make for a resource – that if it is ignored then it shouldn't be parsed by the front matter extension.

Anything I'm missing on this? Should an resource in an ignored path need to have parsed front matter?
