### PR TITLE
Error calling Util#asset_url from DefaultHelpers#asset_url

### DIFF
--- a/middleman-core/lib/middleman-core/core_extensions/default_helpers.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/default_helpers.rb
@@ -201,9 +201,9 @@ class Middleman::CoreExtensions::DefaultHelpers < ::Middleman::Extension
     # @param [String] prefix The type prefix (such as "images")
     # @param [Hash] options Additional options.
     # @return [String] The fully qualified asset url
-    def asset_url(_path, prefix='', options={})
+    def asset_url(path, prefix='', options={})
       options_with_resource = options.merge(current_resource: current_resource)
-      ::Middleman::Util.asset_url(app, prefix, options_with_resource)
+      ::Middleman::Util.asset_url(app, path, prefix, options_with_resource)
     end
 
     # Given a source path (referenced either absolutely or relatively)


### PR DESCRIPTION
I've come across this strange situation in v4 - I'm not sure exactly what provokes it to call this path, but the problem is pretty clear (and I'm surprised Contracts don't catch it):

```
no implicit conversion of Hash into String
/Users/brh/.rvm/gems/ruby-2.2.1/gems/middleman-core-4.0.0/lib/middleman-core/util.rb:211:in `join'
/Users/brh/.rvm/gems/ruby-2.2.1/gems/middleman-core-4.0.0/lib/middleman-core/util.rb:211:in `asset_url'
/Users/brh/.rvm/gems/ruby-2.2.1/gems/middleman-core-4.0.0/lib/middleman-core/core_extensions/default_helpers.rb:206:in `asset_url'
/Users/brh/Documents/websites/brh/source/software/dashboard-widgets/index.html.haml:18:in `block in render'
```

The culprit is https://github.com/middleman/middleman/blob/master/middleman-core/lib/middleman-core/core_extensions/default_helpers.rb#L206, which calls:

```ruby
::Middleman::Util.asset_url(app, prefix, options_with_resource)
```

But the signature for `Util#asset_url` doesn't match:
https://github.com/middleman/middleman/blob/master/middleman-core/lib/middleman-core/util.rb#L202

```ruby
Contract IsA['Middleman::Application'], String, String, Hash => String
def asset_url(app, path, prefix='', options={})
```

See how `path` is in there, between `app` and `prefix`? That's what's killing it.

