### PR TITLE
relative URLs don't work in image_tag

### DIFF
--- a/middleman-core/lib/middleman-core/util.rb
+++ b/middleman-core/lib/middleman-core/util.rb
@@ -203,10 +203,14 @@ module Middleman
       # Don't touch assets which already have a full path
       return path if path.include?('//') || path.start_with?('data:')
 
+      if options[:relative] && !options[:current_resource]
+        raise ArgumentError, '#asset_url must be run in a context with current_resource if relative: true'
+      end
+
       uri = URI(path)
       path = uri.path
 
-      result = if resource = app.sitemap.find_resource_by_destination_path(url_for(app, path))
+      result = if resource = app.sitemap.find_resource_by_destination_path(url_for(app, path, options))
         resource.url
       else
         path = File.join(prefix, path)
@@ -217,15 +221,11 @@ module Middleman
         end
       end
 
-      final_result = if options[:relative] != true
-        result
-      else
-        unless options[:current_resource]
-          raise ArgumentError, '#asset_url must be run in a context with current_resource if relative: true'
-        end
-
+      final_result = if options[:relative]
         current_dir = Pathname('/' + options[:current_resource].destination_path)
         Pathname(result).relative_path_from(current_dir.dirname).to_s
+      else
+        result
       end
 
       result_uri = URI(final_result)
@@ -296,9 +296,6 @@ module Middleman
         else
           resource_url
         end
-      else
-        # If they explicitly asked for relative links but we can't find a resource...
-        raise "No resource exists at #{url}" if relative
       end
 
       # Support a :query option that can be a string or hash

--- a/middleman-core/lib/middleman-core/util.rb
+++ b/middleman-core/lib/middleman-core/util.rb
@@ -221,12 +221,7 @@ module Middleman
         end
       end
 
-      final_result = if options[:relative]
-        current_dir = Pathname('/' + options[:current_resource].destination_path)
-        Pathname(result).relative_path_from(current_dir.dirname).to_s
-      else
-        result
-      end
+      final_result = URI.encode(relative_path_from_resource(options[:current_resource], result, options[:relative]))
 
       result_uri = URI(final_result)
       result_uri.query = uri.query

--- a/middleman-core/spec/middleman-core/util_spec.rb
+++ b/middleman-core/spec/middleman-core/util_spec.rb
@@ -98,6 +98,15 @@ describe Middleman::Util do
       end
     end
 
+    it "returns path relative to the provided current_resource" do
+      Given.fixture 'clean-dir-app'
+      Given.file 'source/a-path/index.html', ''
+      Given.file 'source/a-path/images/blank.gif', ''
+      @mm = Middleman::Application.new
+      current_resource = @mm.sitemap.find_resource_by_path('a-path/index.html')
+      expect( Middleman::Util.asset_url( @mm, 'images/blank.gif', 'images', current_resource: current_resource ) ).to eq '/a-path/images/blank.gif'
+    end
+
     context "when relative is true" do
 
       before(:each) do
@@ -106,7 +115,7 @@ describe Middleman::Util do
       end
 
       it "returns path relative to the provided current_resource" do
-        current_resource = instance_double("Middleman::Sitemap::Resource", destination_path: 'a-path/index.html')
+        current_resource = instance_double("Middleman::Sitemap::Resource", destination_path: 'a-path/index.html', path: 'a-path/index.html')
         expect( Middleman::Util.asset_url( @mm, 'blank.gif', 'images', current_resource: current_resource,
                                                                        relative: true ) ).to eq '../images/blank.gif'
       end


### PR DESCRIPTION
Let's say I'm in some nested subdirectory:

```
/category
  /things
    index.html
    /images
      screenshot.png
```

If I add this to `index.html`:

```
= image_tag "images/screenshot.png"
```

I would expect a link to `/category/things/images/screenshot.png`. I swear this used to work. But in v4, I get `/images/images/screenshot.png`.