### PR TITLE
Added phantomjs as gem to make test suite pass

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'rubydns', '~> 1.0.1', require: false
 
 # To test javascript
 gem 'poltergeist', '~> 1.8', require: false
+gem 'phantomjs', '~> 1.9.8.0', require: false
 
 # For less, note there is no compatible JS runtime for windows
 gem 'therubyrhino', '>= 2.0', platforms: :jruby

--- a/middleman-core/features/support/env.rb
+++ b/middleman-core/features/support/env.rb
@@ -5,7 +5,7 @@ require 'sassc'
 require 'simplecov'
 SimpleCov.root(File.expand_path(File.dirname(__FILE__) + '/../..'))
 
-require 'capybara/poltergeist'
+require 'phantomjs/poltergeist'
 Capybara.javascript_driver = :poltergeist
 
 require 'coveralls'


### PR DESCRIPTION
This addresses the findings of @bhollis in #1722. Now `phantomjs` is installed via gem. If `phantomjs` is not installed it's downloaded to `~/.phantomjs`. 