### PR TITLE
Upgrade aruba to 0.12.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'yard', '~> 0.8', require: false
 
 # Test tools
 gem 'pry', '~> 0.10', group: :development
-gem 'aruba', '~> 0.10.0'
+gem 'aruba', '~> 0.12.0'
 gem 'rspec', '~> 3.0'
 gem 'cucumber', '~> 2.0'
 


### PR DESCRIPTION
This hopefully fix the stylus issue. But let's see what's happening on travis. This is a fix for v3. 
V4 is still on aruba 0.7.4. That needs some more changes.