### PR TITLE
Fixes #1723

### DIFF
--- a/middleman-core/lib/middleman-core/load_paths.rb
+++ b/middleman-core/lib/middleman-core/load_paths.rb
@@ -22,7 +22,7 @@ module Middleman
 
     # Set BUNDLE_GEMFILE and run Bundler setup. Raises an exception if there is no Gemfile
     def setup_bundler
-      ENV['BUNDLE_GEMFILE'] ||= findup('Gemfile', ENV['MM_ROOT'])
+      ENV['BUNDLE_GEMFILE'] ||= File.join(findup('Gemfile', ENV['MM_ROOT']), "Gemfile")
 
       unless File.exist?(ENV['BUNDLE_GEMFILE'])
         ENV['BUNDLE_GEMFILE'] = File.expand_path('../../../../Gemfile', __FILE__)


### PR DESCRIPTION
`BUNDLE_GEMFILE` is the location of Gemfile,  In [load_paths.rb][] [line#25][] initialize `BUNDLE_GEMFILE`  to Gemfile's parent directory, because `findup` just return the parent directory of the file we looking. This will cause error:`Gemfile not found`

[load_paths.rb]: https://github.com/middleman/middleman/blob/master/middleman-core/lib/middleman-core/load_paths.rb
[line#25]: https://github.com/middleman/middleman/blob/master/middleman-core/lib/middleman-core/load_paths.rb#L25