### PR TITLE
Add rewrite_ignore option to asset_hash extension

### DIFF
--- a/middleman-core/features/asset_host.feature
+++ b/middleman-core/features/asset_host.feature
@@ -35,3 +35,17 @@ Feature: Alternate between multiple asset hosts
     When I go to "/stylesheets/asset_host.css"
     Then I should see content matching %r{http://assets1.example.com/}
     Then I should not see content matching %r{http://assets1.example.com//}
+
+  Scenario: Hosts are not rewritten for rewrite ignored paths
+    Given a fixture app "asset-host-app"
+    And a file named "config.rb" with:
+      """
+      activate :asset_host, host: "http://assets1.example.com", rewrite_ignore: [
+        '/stylesheets/asset_host.css',
+      ]
+      """
+    And the Server is running
+    When I go to "/asset_host.html"
+    Then I should see content matching %r{http://assets1.example.com/}
+    When I go to "/stylesheets/asset_host.css"
+    Then I should not see content matching %r{http://assets1.example.com/}

--- a/middleman-core/features/cache_buster.feature
+++ b/middleman-core/features/cache_buster.feature
@@ -40,3 +40,17 @@ Feature: Generate mtime-based query string for busting browser caches
     When I go to "/cache-buster.html"
     Then I should see "site.css?"
     Then I should see "blank.gif?"
+
+  Scenario: URLs are not rewritten for rewrite ignored paths
+    Given a fixture app "cache-buster-app"
+    And a file named "config.rb" with:
+      """
+      activate :cache_buster, rewrite_ignore: [
+        '/cache-buster.html',
+      ]
+      """
+    And the Server is running at "cache-buster-app"
+    When I go to "/cache-buster.html"
+    Then I should see 'site.css"'
+    Then I should see 'empty-with-include.js"'
+    Then I should see 'blank.gif"'

--- a/middleman-core/features/relative_assets.feature
+++ b/middleman-core/features/relative_assets.feature
@@ -132,3 +132,17 @@ Feature: Relative Assets
     And the Server is running at "relative-assets-app"
     When I go to "/sub/image_tag.html"
     Then I should see '<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" />'
+
+  Scenario: URLs are not rewritten for rewrite ignored paths
+    Given a fixture app "relative-assets-app"
+    And a file named "config.rb" with:
+      """
+      activate :relative_assets, rewrite_ignore: [
+        '/stylesheets/fonts.css',
+      ]
+      """
+    And the Server is running at "relative-assets-app"
+    When I go to "/stylesheets/relative_assets.css"
+    Then I should see 'url("../images/blank.gif'
+    When I go to "/stylesheets/fonts.css"
+    Then I should see 'url(/fonts/roboto/roboto-regular-webfont.eot'

--- a/middleman-core/lib/middleman-core/extensions/asset_hash.rb
+++ b/middleman-core/lib/middleman-core/extensions/asset_hash.rb
@@ -5,6 +5,7 @@ require 'middleman-core/rack'
 class Middleman::Extensions::AssetHash < ::Middleman::Extension
   option :exts, %w(.jpg .jpeg .png .gif .webp .js .css .otf .woff .woff2 .eot .ttf .svg .svgz), 'List of extensions that get asset hashes appended to them.'
   option :ignore, [], 'Regexes of filenames to skip adding asset hashes to'
+  option :rewrite_ignore, [], 'Regexes of filenames to skip processing for path rewrites'
 
   def initialize(app, options_hash={}, &block)
     super
@@ -23,6 +24,7 @@ class Middleman::Extensions::AssetHash < ::Middleman::Extension
             url_extensions: options.exts.sort.reverse,
             source_extensions: %w(.htm .html .php .css .js),
             ignore: @ignore,
+            rewrite_ignore: options.rewrite_ignore,
             middleman_app: app,
             proc: method(:rewrite_url)
   end

--- a/middleman-core/lib/middleman-core/extensions/asset_host.rb
+++ b/middleman-core/lib/middleman-core/extensions/asset_host.rb
@@ -6,6 +6,7 @@ class Middleman::Extensions::AssetHost < ::Middleman::Extension
   option :exts, %w(.css .png .jpg .jpeg .webp .svg .svgz .js .gif), 'List of extensions that get cache busters strings appended to them.'
   option :sources, %w(.htm .html .php .css .js), 'List of extensions that are searched for bustable assets.'
   option :ignore, [], 'Regexes of filenames to skip adding query strings to'
+  option :rewrite_ignore, [], 'Regexes of filenames to skip processing for host rewrites'
 
   def ready
     app.use ::Middleman::Middleware::InlineURLRewriter,
@@ -13,6 +14,7 @@ class Middleman::Extensions::AssetHost < ::Middleman::Extension
             url_extensions: options.exts,
             source_extensions: options.sources,
             ignore: options.ignore,
+            rewrite_ignore: options.rewrite_ignore,
             middleman_app: app,
             proc: method(:rewrite_url)
   end

--- a/middleman-core/lib/middleman-core/extensions/cache_buster.rb
+++ b/middleman-core/lib/middleman-core/extensions/cache_buster.rb
@@ -3,6 +3,7 @@ class Middleman::Extensions::CacheBuster < ::Middleman::Extension
   option :exts, %w(.css .png .jpg .jpeg .webp .svg .svgz .js .gif), 'List of extensions that get cache busters strings appended to them.'
   option :sources, %w(.htm .html .php .css .js), 'List of extensions that are searched for bustable assets.'
   option :ignore, [], 'Regexes of filenames to skip adding query strings to'
+  option :rewrite_ignore, [], 'Regexes of filenames to skip processing for path rewrites'
 
   def initialize(app, options_hash={}, &block)
     super
@@ -16,6 +17,7 @@ class Middleman::Extensions::CacheBuster < ::Middleman::Extension
             url_extensions: options.exts,
             source_extensions: options.sources,
             ignore: options.ignore,
+            rewrite_ignore: options.rewrite_ignore,
             middleman_app: app,
             proc: method(:rewrite_url)
   end

--- a/middleman-core/lib/middleman-core/extensions/relative_assets.rb
+++ b/middleman-core/lib/middleman-core/extensions/relative_assets.rb
@@ -5,6 +5,7 @@ class Middleman::Extensions::RelativeAssets < ::Middleman::Extension
   option :exts, %w(.css .png .jpg .jpeg .webp .svg .svgz .js .gif .ttf .otf .woff .woff2 .eot), 'List of extensions that get cache busters strings appended to them.'
   option :sources, %w(.htm .html .css), 'List of extensions that are searched for relative assets.'
   option :ignore, [], 'Regexes of filenames to skip adding query strings to'
+  option :rewrite_ignore, [], 'Regexes of filenames to skip processing for path rewrites'
 
   def initialize(app, options_hash={}, &block)
     super
@@ -18,6 +19,7 @@ class Middleman::Extensions::RelativeAssets < ::Middleman::Extension
             url_extensions: options.exts,
             source_extensions: options.sources,
             ignore: options.ignore,
+            rewrite_ignore: options.rewrite_ignore,
             middleman_app: app,
             proc: method(:rewrite_url)
   end


### PR DESCRIPTION
This allows for configuring the files that will be skipped when performing URL rewriting on the file content. This differs from the existing `ignore` option, which configures the files that won't have hashes added to the filename.

This stemmed from wanting to improve build times on a project by skipping the URL rewriting phase on some large minified JS files didn't contain any asset URLs. The discussion in https://github.com/middleman/middleman/issues/1563#issuecomment-122045822 also points to another potential use for this (skipping problematic files).

I did discover that it's currently possible to do something similar with a custom middleware, like this:

```ruby
class InlineURLRewriterIgnores
  def initialize(app, options= {})
    @app = app
  end

  def call(env)
    if(env["PATH_INFO"] =~ %r{^/example})
      env["bypass_inline_url_rewriter"] = "true"
    end

    @app.call(env)
  end
end
use InlineURLRewriterIgnores
```

However, this seems to use an undocumented option (`bypass_inline_url_rewriter`), and it's a little more cumbersome, so I thought I'd submit this pull request, which would make that same configuration look more like:

```
activate :asset_hash, :rewrite_ignore => [
  %r{^/example},
] 
```

This only adds the new `:rewrite_ignore` option to the `AssetHash` extension, but it would be easy to add this same handling to the other extensions that use the `InlineURLRewriter` middleware (`AssetHost`, `CacheBuster`, and `RelativeAssets`) if you'd be interested.

Let me know if you have any feedback on this approach, the name of the option, etc. Thanks!