### PR TITLE
consider all MS Office files to be binary

### DIFF
--- a/middleman-core/lib/middleman-core/util.rb
+++ b/middleman-core/lib/middleman-core/util.rb
@@ -366,7 +366,7 @@ module Middleman
       case
       when mime.start_with?('text/')
         true
-      when mime.include?('xml')
+      when mime.include?('xml') && !mime.include?('officedocument')
         true
       when mime.include?('json')
         true


### PR DESCRIPTION
I was seeing encoding errors when placing static `.docx` files in my project. After investigating, I found the issue here. The `mime.include?('xml')` being true didn't mean that my `.docx` file was non-binary.

Many MS Office MIME types match `application/vnd.openxmlformats-officedocument.*` (http://www.sitepoint.com/web-foundations/mime-types-summary-list/).

Let me know if I'm doing something incorrectly though. This type of mime type checking was added 3 years ago. I'm not the first one in three years to add a `.docx` to my middleman site, am I?