### PR TITLE
Add app method to detect mode

### DIFF
--- a/middleman-core/lib/middleman-core/application.rb
+++ b/middleman-core/lib/middleman-core/application.rb
@@ -327,18 +327,26 @@ module Middleman
       end
     end
 
+    # Whether we're in a specific mode
+    # @param [Symbol] key
+    # @return [Boolean]
+    Contract Symbol => Bool
+    def mode?(key)
+      config[:mode] == key
+    end
+
     # Whether we're in server mode
     # @return [Boolean] If we're in dev mode
     Contract Bool
     def server?
-      config[:mode] == :server
+      mode?(:server)
     end
 
     # Whether we're in build mode
     # @return [Boolean] If we're in dev mode
     Contract Bool
     def build?
-      config[:mode] == :build
+      mode?(:build)
     end
 
     # Whether we're in a specific environment


### PR DESCRIPTION
Not sure if operating outside the two official "modes" of either `:build` or `:server` is supported, but if so this additional method would be convenient.

An example is the Contentful Middleman library (https://github.com/contentful/contentful_middleman), which for V3 had the concept of a `:contentful` environment when the task that pulls content down was run, but has now switched to setting `:contentful` as the mode for V4.

Anyhow, this method is just a convenience but I expected it's existence based on the parallel existence of the `environment?` method. 