### PR TITLE
Use correct type for removed paths passed to update

### DIFF
--- a/middleman-core/lib/middleman-core/sources/source_watcher.rb
+++ b/middleman-core/lib/middleman-core/sources/source_watcher.rb
@@ -91,7 +91,7 @@ module Middleman
 
       stop_listener! if @listener
 
-      update([], @files.values)
+      update([], @files.values.map { |source_file| source_file[:full_path] })
 
       poll_once!
 
@@ -262,11 +262,13 @@ module Middleman
                         ]) unless valid_updates.empty? && valid_removes.empty?
     end
 
+    Contract IsA['Middleman::SourceFile'] => Any
     def add_file_to_cache(f)
       @files[f[:full_path]] = f
       @extensionless_files[strip_extensions(f[:full_path])] = f
     end
 
+    Contract IsA['Middleman::SourceFile'] => Any
     def remove_file_from_cache(f)
       @files.delete(f[:full_path])
       @extensionless_files.delete(strip_extensions(f[:full_path]))


### PR DESCRIPTION
Ran into an issue today with some testing code that happens to invoke the `Middleman::SourceWatcher#update_path`, which was causing a Contract violation.

Looking closer I discovered that:

* The values stored in `@files.values` are instances of `Middleman::SourceFile` (a struct)
* The `update` method expects to receive an array of `Pathname` objects in the removed_paths parameter
* The `update_path` method was incorrectly passing an array of `SourceFile`s to `update`

To remediate this, this PR:

* Ensures that the value of `removed_paths` sent to `update` is an array of `Pathname`s as it expects
* Adds a Contract to the `add_file_to_cache` and `remove_file_from_cache` which makes it clear that these should be `Middleman::SourceFile`s (this would have made it clearer to me during debugging what the type of `@file.values` was supposed to be).

Second bullet point is sort of optional but I think it's useful to add that additional contract coverage.