### PR TITLE
Fix gzip extension status output

### DIFF
--- a/middleman-core/lib/middleman-core/extensions/gzip.rb
+++ b/middleman-core/lib/middleman-core/extensions/gzip.rb
@@ -64,10 +64,10 @@ class Middleman::Extensions::Gzip < ::Middleman::Extension
 
       total_savings += (old_size - new_size)
       size_change_word = (old_size - new_size) > 0 ? 'smaller' : 'larger'
-      builder.trigger :gzip, "#{output_filename} (#{NumberHelpers.new.number_to_human_size((old_size - new_size).abs)} #{size_change_word})"
+      builder.trigger :created, "#{output_filename} (#{NumberHelpers.new.number_to_human_size((old_size - new_size).abs)} #{size_change_word})"
     end
 
-    builder.trigger :gzip, "Total gzip savings: #{NumberHelpers.new.number_to_human_size(total_savings)}"
+    builder.trigger :gzip, '', "Total gzip savings: #{NumberHelpers.new.number_to_human_size(total_savings)}"
     I18n.locale = old_locale
   end
 


### PR DESCRIPTION
Proposed fix for #1364 

- Changed event name to :created when reporting created output files
- Added empty string as a second parameter to assign total savings summary as extra param which is printed on [Middleman::Cli::Build#on_event](https://github.com/middleman/middleman/blob/d82ac590db5fbb4f7482aed679acef9646d1c45c/middleman-cli/lib/middleman-cli/build.rb#L107) when event type is :gzip