### PR TITLE
Add option for MM_DATA_DIR env var to define :data_dir default value

### DIFF
--- a/middleman-core/lib/middleman-core/core_extensions/data.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/data.rb
@@ -8,7 +8,7 @@ module Middleman
     class Data < Extension
       attr_reader :data_store
 
-      define_setting :data_dir, 'data', 'The directory data files are stored in'
+      define_setting :data_dir, ENV['MM_DATA_DIR'] || 'data', 'The directory data files are stored in'
 
       # Make the internal `data_store` method available as `app.data`
       expose_to_application data: :data_store


### PR DESCRIPTION
This is a simple PR but would be immensely useful.

In setting up some RSpec tests for a custom command --where an instance of Middleman::Application is being instantiated directly --  I'm finding I have to jump through hoops to point my data dir at a separate fixtures directory.

It's sort of a chicken and egg problem, where setting it in config.rb is too late, since the data dir has to be processed in order to make data available from within config.rb.

I'd like to propose this simple change which would allow me to define a default via a `MM_DATA_DIR` environment variable and vastly simplify some of the hoops that one is required to jump through to set up the data dir in advance of config.rb.

Thanks!