### PR TITLE
Minify inline JS when there are other attributes.

### DIFF
--- a/middleman-core/lib/middleman-core/extensions/minify_javascript.rb
+++ b/middleman-core/lib/middleman-core/extensions/minify_javascript.rb
@@ -112,7 +112,7 @@ class Middleman::Extensions::MinifyJavascript < ::Middleman::Extension
 
         # Only compress script tags that contain JavaScript (as opposed to
         # something like jQuery templates, identified with a "text/html" type).
-        if first.include?('<script>') || first.include?('text/javascript')
+        if !first.include?('type=') || first.include?('text/javascript')
           first + minify(inline_content) + last
         else
           match


### PR DESCRIPTION
Previously, this JS would not be minified:

```html
<script async>
  console.log("Hi.");
</script>
```

This is because the inline JS minify extension would only compress a bare script tag `<script>` or one that had `text/javascript` somewhere in it. I fixed the check to be a bit more precise.