### PR TITLE
Disable file watching completely when watcher_disable is true

### DIFF
--- a/middleman-core/lib/middleman-core/preview_server.rb
+++ b/middleman-core/lib/middleman-core/preview_server.rb
@@ -151,19 +151,19 @@ module Middleman
           config[:ssl_private_key] = opts[:ssl_private_key] if opts[:ssl_private_key]
 
           ready do
-            match_against = [
-              %r{^config\.rb$},
-              %r{^environments/[^\.](.*)\.rb$},
-              %r{^lib/[^\.](.*)\.rb$},
-              %r{^#{config[:helpers_dir]}/[^\.](.*)\.rb$}
-            ]
-
-            # config.rb
-            watcher = files.watch :reload,
-                                  path: root,
-                                  only: match_against
-
             unless config[:watcher_disable]
+              match_against = [
+                %r{^config\.rb$},
+                %r{^environments/[^\.](.*)\.rb$},
+                %r{^lib/[^\.](.*)\.rb$},
+                %r{^#{config[:helpers_dir]}/[^\.](.*)\.rb$}
+              ]
+
+              # config.rb
+              watcher = files.watch :reload,
+                                    path: root,
+                                    only: match_against
+
               # Hack around node_modules in root.
               watcher.listener.ignore(/^node_modules/)
 


### PR DESCRIPTION
Right now, when `watcher_disable` is true, Middleman doesn't actually disable the watcher, it merely adds a few additional ignore paths. Not sure if there's a reason for this? It seems like not the desired behavior when one sets watcher disable to true.

It'd be great if it *actually* disabled the watcher entirely.

This is sort of a nuclear option, but the advantage of this is that I can implement my own custom watch behavior separately, under my own ready callback.