### PR TITLE
show version on Middleman Information page

### DIFF
--- a/middleman-core/lib/middleman-core/meta_pages/templates/index.html.erb
+++ b/middleman-core/lib/middleman-core/meta_pages/templates/index.html.erb
@@ -10,7 +10,9 @@
     <div class="container">
       <article id="main">
         <h1>Middleman Information</h1>
-
+        <p>
+          Middleman version <%= Middleman::VERSION %>
+        </p>
         <ul class="nav-list">
           <li>
             <a href="/__middleman/sitemap/">Sitemap</a>


### PR DESCRIPTION
This displays the Middleman version number on the Middleman Information page ([http://localhost:4567/__middleman/](http://localhost:4567/__middleman/)). I did not add this to the other meta pages (sitemap and configuration).