### PR TITLE
Escape path in 404 (not found) page

### DIFF
--- a/middleman-core/lib/middleman-core/rack.rb
+++ b/middleman-core/lib/middleman-core/rack.rb
@@ -2,6 +2,7 @@ require 'rack'
 require 'rack/file'
 require 'rack/lint'
 require 'rack/head'
+require 'rack/utils'
 
 require 'middleman-core/util'
 require 'middleman-core/logger'
@@ -124,6 +125,7 @@ module Middleman
 
     # Halt request and return 404
     def not_found(res, path)
+      path = ::Rack::Utils::escape_html(path)
       res.status = 404
       res.write "<html><head></head><body><h1>File Not Found</h1><p>#{path}</p></body></html>"
       res.finish


### PR DESCRIPTION
This escapes the `path` variable using `escape_html` from `Rack::Utils` to prevent (reflected) [Cross-Site Scripting](https://www.owasp.org/index.php/Cross-site_Scripting_(XSS)) in 404 (Not Found) pages.

PoC: `http://localhost:9292/123<strong>HTML injected</strong>`.

![screenshot 2016-02-15 23 40 37](https://cloud.githubusercontent.com/assets/1312973/13062315/04a52bea-d43e-11e5-83d0-cd76cdd589d6.png)

`escape_html` is a good way to escape HTML from input. I'm not sure what the performance impact of including `Rack::Utils` is, if it even matters. I'm open to suggestions!

I wrote a test but I have no clue where it should go. I verified it though and it passes.

```
Scenario: Escapes HTML when a resource is not found
  Given the Server is running at "asset-hash-app"
  When I go to "/<p>HTML</p>"
  Then I should see "Not Found"
  And I should see "&#x2F;&lt;p&gt;HTML&lt;&#x2F;p&gt;"
  And I should not see "<p>HTML</p>"
```