### PR TITLE
Make build fail when external_pipeline fails

### DIFF
--- a/middleman-core/features/builder.feature
+++ b/middleman-core/features/builder.feature
@@ -20,13 +20,13 @@ Feature: Builder
       | layout                                        |
       | layouts/custom                                |
       | layouts/content_for                           |
-      
+
     And the file "index.html" should contain "Comment in layout"
     And the file "index.html" should contain "<h1>Welcome</h1>"
     And the file "static.html" should contain "Static, no code!"
     And the file "services/index.html" should contain "Services"
     And the file "stylesheets/static.css" should contain "body"
-    
+
   Scenario: Build glob
     Given a successfully built app at "glob-app" with flags "--glob '*.css'"
     When I cd to "build"
@@ -34,13 +34,17 @@ Feature: Builder
       | index.html                                    |
     Then the following files should exist:
       | stylesheets/site.css                          |
-  
+
   Scenario: Build with errors
     Given a built app at "build-with-errors-app"
     Then the exit status should be 1
-  
+
   Scenario: Build empty errors
     Given a built app at "empty-app"
+    Then the exit status should be 1
+
+  Scenario: Build external_pipeline errors
+    Given a built app at "external-pipeline-error"
     Then the exit status should be 1
 
   Scenario: Build alias (b)

--- a/middleman-core/fixtures/external-pipeline-error/config.rb
+++ b/middleman-core/fixtures/external-pipeline-error/config.rb
@@ -1,0 +1,5 @@
+activate :external_pipeline,
+  name: :failing,
+  command: "mv does-not-exist tmp/file.js",
+  source: "tmp",
+  latency: 2

--- a/middleman-core/lib/middleman-core/extensions/external_pipeline.rb
+++ b/middleman-core/lib/middleman-core/extensions/external_pipeline.rb
@@ -34,6 +34,11 @@ class Middleman::Extensions::ExternalPipeline < ::Middleman::Extension
       end
     end
 
+    unless $?.success?
+      logger.error '== External: Command failed with non-zero exit status'
+      exit(1)
+    end
+
     @watcher.poll_once!
   rescue ::Errno::ENOENT => e
     logger.error "== External: Command failed with message: #{e.message}"


### PR DESCRIPTION
This is to fix an issue where the build continues successfully when the external pipeline fails