### PR TITLE
Remove compass importonce use fast blank

### DIFF
--- a/middleman-core/lib/middleman-core/application.rb
+++ b/middleman-core/lib/middleman-core/application.rb
@@ -1,5 +1,3 @@
-require 'active_support/core_ext/integer/inflections'
-
 require 'middleman-core/contracts'
 require 'middleman-core/callback_manager'
 require 'middleman-core/logger'

--- a/middleman-core/lib/middleman-core/preview_server/checks.rb
+++ b/middleman-core/lib/middleman-core/preview_server/checks.rb
@@ -1,4 +1,5 @@
 require 'ipaddr'
+require 'fast_blank'
 
 module Middleman
   class PreviewServer

--- a/middleman-core/lib/middleman-core/preview_server/information.rb
+++ b/middleman-core/lib/middleman-core/preview_server/information.rb
@@ -1,5 +1,5 @@
 require 'ipaddr'
-require 'active_support/core_ext/object/blank'
+require 'fast_blank'
 require 'middleman-core/preview_server/checks'
 require 'middleman-core/preview_server/server_hostname'
 require 'middleman-core/preview_server/server_ip_address'

--- a/middleman/middleman.gemspec
+++ b/middleman/middleman.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.add_dependency('middleman-core', Middleman::VERSION)
   s.add_dependency('middleman-cli', Middleman::VERSION)
   s.add_dependency('sass', ['>= 3.4.0', '< 4.0'])
-  s.add_dependency('compass-import-once', ['1.0.5'])
   s.add_dependency('haml', ['>= 4.0.5'])
   s.add_dependency('coffee-script', ['~> 2.2'])
   s.add_dependency('kramdown', ['~> 1.2'])


### PR DESCRIPTION
This PR uses the faster `blank?` from `fast_blank` instead of ActiveSupport's `blank?`, as the gem was already included but not being used. I also removed `compass-import-once`, which was not being used at all. 

Please check it out, thanks! 
