### PR TITLE
Ensure that misspelled or missing partials generate an error

### DIFF
--- a/middleman-core/features/partials.feature
+++ b/middleman-core/features/partials.feature
@@ -5,25 +5,30 @@ Feature: Provide Sane Defaults for Partial Behavior
     When I go to "/index.html"
     Then I should see "Header"
     And I should see "Footer"
-    
+
   Scenario: Finds shared partials relative to the root (sub)
     Given the Server is running at "partials-app"
     When I go to "/sub/index.html"
     Then I should see "Header"
     And I should see "Footer"
-    
+
+  Scenario: Flags error when partial is not found
+    Given the Server is running at "partials-app"
+    When I go to "/index_missing.html"
+    Then I should see "Error: Could not locate partial"
+
   Scenario: Prefers partials of the same engine type
     Given the Server is running at "partials-app"
     When I go to "/index.html"
     Then I should see "ERb Main"
-  
+
   Scenario: Prefers partials of the same engine type
     Given the Server is running at "partials-app"
     When I go to "/second.html"
     Then I should see "Str Main"
     And I should see "Header"
     And I should see "Footer"
-    
+
   Scenario: Finds partial relative to template
     Given the Server is running at "partials-app"
     When I go to "/sub/index.html"
@@ -33,7 +38,7 @@ Feature: Provide Sane Defaults for Partial Behavior
     Given the Server is running at "partials-app"
     When I go to "/locals.html"
     Then I should see "Local var is bar"
-  
+
   Scenario: Partial and Layout use different engines
     Given the Server is running at "different-engine-partial"
     When I go to "/index.html"

--- a/middleman-core/fixtures/partials-app/source/index_missing.html.erb
+++ b/middleman-core/fixtures/partials-app/source/index_missing.html.erb
@@ -1,0 +1,3 @@
+<%= partial "shared/header" %>
+<%= partial "i_do_not_exist" %>
+<%= partial "shared/footer" %>

--- a/middleman-core/lib/middleman-core/template_context.rb
+++ b/middleman-core/lib/middleman-core/template_context.rb
@@ -104,7 +104,6 @@ module Middleman
 
       partial_file = locate_partial(name, false) || locate_partial(name, true)
 
-      return '' unless partial_file
       raise ::Middleman::TemplateRenderer::TemplateNotFound, "Could not locate partial: #{name}" unless partial_file
 
       source_path = sitemap.file_to_path(partial_file)


### PR DESCRIPTION
Removed what looks like a stray debugging line from the code and added a test.