### PR TITLE
Support CLI options as options

### DIFF
--- a/middleman-cli/lib/middleman-cli/build.rb
+++ b/middleman-cli/lib/middleman-cli/build.rb
@@ -51,6 +51,7 @@ module Middleman::Cli
       env = options['environment'].to_sym
       verbose = options['verbose'] ? 0 : 1
       instrument = options['instrument']
+      cli_options = options.to_hash.symbolize_keys
 
       builder = nil
 
@@ -61,6 +62,7 @@ module Middleman::Cli
           config[:mode] = :build
           config[:environment] = env
           config[:show_exceptions] = false
+          config[:cli_options] = cli_options
         end
 
         builder = Middleman::Builder.new(@app,

--- a/middleman-cli/lib/middleman-cli/build.rb
+++ b/middleman-cli/lib/middleman-cli/build.rb
@@ -36,12 +36,6 @@ module Middleman::Cli
                  default: false,
                  desc: 'Generate profiling report for the build'
 
-    # Allow extensions to verify cli arugments
-    # @return [void]
-    def check_cli_arguments
-      nil
-    end
-
     # Core build Thor command
     # @return [void]
     def build

--- a/middleman-cli/lib/middleman-cli/build.rb
+++ b/middleman-cli/lib/middleman-cli/build.rb
@@ -51,7 +51,7 @@ module Middleman::Cli
       env = options['environment'].to_sym
       verbose = options['verbose'] ? 0 : 1
       instrument = options['instrument']
-      cli_options = options.symbolize_keys.to_hash
+      cli_options = options || options.symbolize_keys.to_hash
 
       builder = nil
 

--- a/middleman-cli/lib/middleman-cli/build.rb
+++ b/middleman-cli/lib/middleman-cli/build.rb
@@ -51,7 +51,7 @@ module Middleman::Cli
       env = options['environment'].to_sym
       verbose = options['verbose'] ? 0 : 1
       instrument = options['instrument']
-      cli_options = options.to_hash.symbolize_keys
+      cli_options = options.symbolize_keys.to_hash
 
       builder = nil
 

--- a/middleman-cli/lib/middleman-cli/build.rb
+++ b/middleman-cli/lib/middleman-cli/build.rb
@@ -36,6 +36,12 @@ module Middleman::Cli
                  default: false,
                  desc: 'Generate profiling report for the build'
 
+    # Allow extensions to verify cli arugments
+    # @return [void]
+    def check_cli_arguments
+      nil
+    end
+
     # Core build Thor command
     # @return [void]
     def build

--- a/middleman-cli/lib/middleman-cli/server.rb
+++ b/middleman-cli/lib/middleman-cli/server.rb
@@ -55,6 +55,12 @@ module Middleman::Cli
                  default: false,
                  desc: 'Daemonize preview server'
 
+    # Allow extensions to verify cli arugments
+    # @return [void]
+    def check_cli_arguments
+      nil
+    end
+
     # Start the server
     def server
       require 'middleman-core'

--- a/middleman-cli/lib/middleman-cli/server.rb
+++ b/middleman-cli/lib/middleman-cli/server.rb
@@ -55,12 +55,6 @@ module Middleman::Cli
                  default: false,
                  desc: 'Daemonize preview server'
 
-    # Allow extensions to verify cli arugments
-    # @return [void]
-    def check_cli_arguments
-      nil
-    end
-
     # Start the server
     def server
       require 'middleman-core'

--- a/middleman-cli/lib/middleman-cli/server.rb
+++ b/middleman-cli/lib/middleman-cli/server.rb
@@ -79,7 +79,8 @@ module Middleman::Cli
         reload_paths: options['reload_paths'],
         force_polling: options['force_polling'],
         latency: options['latency'],
-        daemon: options['daemon']
+        daemon: options['daemon'],
+        cli_options: options.to_hash.symbolize_keys
       }
 
       puts '== The Middleman is loading'

--- a/middleman-core/lib/middleman-core/application.rb
+++ b/middleman-core/lib/middleman-core/application.rb
@@ -193,6 +193,7 @@ module Middleman
     define_setting :watcher_disable, false, 'If the Listen watcher should not run'
     define_setting :watcher_force_polling, false, 'If the Listen watcher should run in polling mode'
     define_setting :watcher_latency, nil, 'The Listen watcher latency'
+    define_setting :cli_options, nil, 'Options passed in from the cli.'
 
     # Delegate convenience methods off to their implementations
     def_delegator :"::Middleman::Logger", :singleton, :logger

--- a/middleman-core/lib/middleman-core/preview_server.rb
+++ b/middleman-core/lib/middleman-core/preview_server.rb
@@ -149,6 +149,7 @@ module Middleman
           config[:https]           = opts[:https] unless opts[:https].nil?
           config[:ssl_certificate] = opts[:ssl_certificate] if opts[:ssl_certificate]
           config[:ssl_private_key] = opts[:ssl_private_key] if opts[:ssl_private_key]
+          config[:cli_options]     = opts[:cli_options]
 
           ready do
             unless config[:watcher_disable]


### PR DESCRIPTION
Supports visibility of the cli arguments in the application's config hash, as these
should/could be considered valid configuration options specified at the time of
application instantiation. The are exposed as config[:cli_options][:thor_key].
Note that this change _does not_ do any of this:
- does not allow the cli to override `config.rb` settings;
- does not define new cli/thor options.

It _does_ allow:
- Extensions can access cli options that they create when overriding Middleman::Cli
  classes, e.g., in `before_build` or `after_configuration`.