### PR TITLE
Avoid prefixing assets with asset dirs if no such file is on disk.

### DIFF
--- a/middleman-core/lib/middleman-core/util/paths.rb
+++ b/middleman-core/lib/middleman-core/util/paths.rb
@@ -80,10 +80,11 @@ module Middleman
       result = if resource = app.sitemap.find_resource_by_destination_path(url_for(app, path, options))
         resource.url
       else
-        path = ::File.join(prefix, path)
-        if resource = app.sitemap.find_resource_by_path(path)
+        prefixed_path = ::File.join(prefix, path)
+        if resource = app.sitemap.find_resource_by_path(prefixed_path)
           resource.url
         else
+          # Don't try to prefix the path (usually with an asset directory)
           ::File.join(app.config[:http_prefix], path)
         end
       end

--- a/middleman-core/spec/middleman-core/util_spec.rb
+++ b/middleman-core/spec/middleman-core/util_spec.rb
@@ -94,7 +94,7 @@ describe Middleman::Util do
       end
 
       it "returns path with http_prefix pre-pended if resource is not found" do
-        expect( Middleman::Util.asset_url( @mm, 'missing.gif', 'images', http_prefix: 'http_prefix' ) ).to eq 'http_prefix/images/missing.gif'
+        expect( Middleman::Util.asset_url( @mm, 'missing.gif', 'images', http_prefix: 'http_prefix' ) ).to eq 'http_prefix/missing.gif'
       end
     end
 


### PR DESCRIPTION
I think the `path` local variable is shadowing the argument `path` and resulting in behaviour I'm not fond of: prefixing assets with asset dirs even when those assets don't exist. This breaks my middleman blog, in which I put HTML templates and images that all pertain to a single blog entry into a directory together.