### PR TITLE
Fix bug with store rebuilding and proxy resources.

### DIFF
--- a/middleman-core/lib/middleman-core/sitemap/store.rb
+++ b/middleman-core/lib/middleman-core/sitemap/store.rb
@@ -237,7 +237,16 @@ module Middleman
                 # Rebuild cache
                 @resources.each do |resource|
                   @_lookup_by_path[resource.path] = resource
+                end
+
+                @resources.each do |resource|
                   @_lookup_by_destination_path[resource.destination_path] = resource
+                end
+
+                # NB: This needs to be done after the previous two steps,
+                # since some proxy resources are looked up by path in order to
+                # get their metadata and subsequently their page_id.
+                @resources.each do |resource|
                   @_lookup_by_page_id[resource.page_id.to_sym] = resource
                 end
 


### PR DESCRIPTION
I was trying to make `middleman-blog` work with middleman version 4.1.2 today. This is the code change I had to make in order to make the two compatible.

The call to `resource.page_id` for a proxy resource involves call to the proxy target's `metadata` which involves looking up the resource by `@store.find_resource_by_path` which fails because `@_lookup_by_path` is not finished re-building at the time of the call.

Splitting these three steps out fixes this problem because `@_lookup_by_path` is complete by the time the proxy resource's `metadata` method is ever called.

I will come back and write a test if that's what it takes to get this PR included. :)