### PR TITLE
Fix asset_url and relative option bug.

### DIFF
--- a/middleman-core/lib/middleman-core/util/paths.rb
+++ b/middleman-core/lib/middleman-core/util/paths.rb
@@ -77,7 +77,11 @@ module Middleman
       uri = URI(path)
       path = uri.path
 
-      result = if resource = app.sitemap.find_resource_by_destination_path(url_for(app, path, options))
+      # Ensure the url we pass into find_resource_by_destination_path is not a
+      # relative path, since it only takes absolute url paths.
+      dest_path = url_for(app, path, options.merge(relative: false))
+
+      result = if resource = app.sitemap.find_resource_by_destination_path(dest_path)
         resource.url
       else
         path = ::File.join(prefix, path)

--- a/middleman-core/spec/middleman-core/util_spec.rb
+++ b/middleman-core/spec/middleman-core/util_spec.rb
@@ -120,6 +120,20 @@ describe Middleman::Util do
                                                                        relative: true ) ).to eq '../images/blank.gif'
       end
 
+      context "when the asset is stored in the same directory as current_resource" do
+        before do
+          Given.file 'source/a-path/index.html', ''
+          Given.file 'source/a-path/blank.gif', ''
+          @mm = Middleman::Application.new
+        end
+
+        it "returns path relative to the provided current_resource" do
+          current_resource = @mm.sitemap.find_resource_by_path('a-path/index.html')
+          expect( Middleman::Util.asset_url( @mm, 'blank.gif', 'images', current_resource: current_resource,
+                                                                        relative: true) ).to eq 'blank.gif'
+        end
+      end
+
       it "raises error if not given a current_resource" do
         expect{
           Middleman::Util.asset_url( @mm, 'blank.gif', 'images', relative: true )


### PR DESCRIPTION
If the relative option is set and the asset is stored in the directory
alongside the resource referencing it, asset_url produces the
wrong path ('../images/image.jpg' rather than just 'image.jpg').