### PR TITLE
Add exts to asset_host extension

### DIFF
--- a/middleman-core/lib/middleman-core/extensions/asset_host.rb
+++ b/middleman-core/lib/middleman-core/extensions/asset_host.rb
@@ -2,7 +2,7 @@ require 'addressable/uri'
 
 class Middleman::Extensions::AssetHost < ::Middleman::Extension
   option :host, nil, 'The asset host to use or a Proc to determine asset host', required: true
-  option :exts, %w(.css .png .jpg .jpeg .webp .svg .svgz .js .gif), 'List of extensions that get cache busters strings appended to them.'
+  option :exts, %w(.jpg .jpeg .png .gif .webp .js .css .otf .woff .woff2 .eot .ttf .svg .svgz .map), 'List of extensions that get cache busters strings appended to them.'
   option :sources, %w(.css .htm .html .js .php .xhtml), 'List of extensions that are searched for bustable assets.'
   option :ignore, [], 'Regexes of filenames to skip adding query strings to'
   option :rewrite_ignore, [], 'Regexes of filenames to skip processing for host rewrites'


### PR DESCRIPTION
Copied the extensions from `asset_hash` helper.

Not a fan of how these extensions are copy and pasted between extensions. I'd like to move `sources` and `exts` into a constant in a different PR so these don't drift apart again. Where is the preferred place to put that constant?