### PR TITLE
Fix server CLI

### DIFF
--- a/middleman-core/lib/middleman-core/preview_server.rb
+++ b/middleman-core/lib/middleman-core/preview_server.rb
@@ -140,7 +140,7 @@ module Middleman
         )
 
         app = ::Middleman::Application.new do
-          cli_options.each_with_object({}) do |(k, v), sum|
+          config[:cli_options] = cli_options.each_with_object({}) do |(k, v), sum|
             sum[k] = v unless v == :undefined
           end
 


### PR DESCRIPTION
While the CLI options are working nicely for build, they're currently broken for server, in that `app.config` doesn't reflect anything in `after_config`.

This fix is identical to what's done in `build`, and properly applies things in the server environment.
