### PR TITLE
WIP - Rendering pipeline.

### DIFF
--- a/middleman-core/lib/middleman-core/extensions/pipeline.rb
+++ b/middleman-core/lib/middleman-core/extensions/pipeline.rb
@@ -1,0 +1,19 @@
+class Middleman::Extensions::Pipeline < Middleman::Extension
+  expose_to_config :pipeline
+
+  def initialize(app, options_hash={}, &block)
+    super
+    @pipelines = []
+  end
+
+  def pipeline(&block)
+    @pipelines << block
+  end
+
+  def manipulate_resource_list(resources)
+    @pipelines.each do |pipeline|
+      pipeline.call resources
+    end
+    resources
+  end
+end

--- a/middleman-core/lib/middleman-core/pipeline.rb
+++ b/middleman-core/lib/middleman-core/pipeline.rb
@@ -1,0 +1,24 @@
+require 'forwardable'
+
+module Middleman
+  class Pipeline
+    extend Forwardable
+    attr_reader :filters
+    attr_reader :resource
+
+    def_delegators :filters, :<<, :push, :unshift, :insert, :shift, :pop, :first, :clear
+
+    def initialize(resource)
+      @resource = resource
+      @filters = []
+    end
+
+    def render(*args)
+      process resource.render *args
+    end
+
+    def process(body)
+      filters.inject(body){ |body, app| app.call(body) }
+    end
+  end
+end

--- a/middleman-core/lib/middleman-core/rack.rb
+++ b/middleman-core/lib/middleman-core/rack.rb
@@ -109,7 +109,7 @@ module Middleman
 
       begin
         # Write out the contents of the page
-        res.write resource.render({}, rack: { request: req })
+        res.write resource.pipeline.render({}, rack: { request: req })
 
         # Valid content is a 200 status
         res.status = 200

--- a/middleman-core/lib/middleman-core/sitemap/resource.rb
+++ b/middleman-core/lib/middleman-core/sitemap/resource.rb
@@ -3,6 +3,7 @@ require 'middleman-core/sitemap/extensions/traversal'
 require 'middleman-core/file_renderer'
 require 'middleman-core/template_renderer'
 require 'middleman-core/contracts'
+require 'middleman-core/pipeline'
 
 module Middleman
   # Sitemap namespace
@@ -40,6 +41,8 @@ module Middleman
 
       attr_accessor :ignored
 
+      attr_reader :pipeline
+
       # Initialize resource with parent store and URL
       # @param [Middleman::Sitemap::Store] store
       # @param [String] path
@@ -50,6 +53,7 @@ module Middleman
         @app         = @store.app
         @path        = path
         @ignored     = false
+        @pipeline    = Pipeline.new(self)
 
         source = Pathname(source) if source && source.is_a?(String)
 


### PR DESCRIPTION
I don't intend to merge this yet; I'm opening this PR as a proposal and as a way to ask questions as they come along.

The motivation for a rendering pipeline is because I don't think Rack is the best place to do `asset_hash`, `asset_host`, and other content substitution for a rendered page because:

1. The HTTP context is not needed. e.g. we can assume all requests to Middleman are `GET` requests.
2. Its difficult to access the `Resource` object from the Rack context. In the case of the inline_url_writer, which is used by the asset extensions, Middleman has to jump through a bunch of hoops to figure out if an asset is of a certain type. For example, the Rack middleware looks at file extensions to determine if something is a css asset. Wouldn't it be cleaner to just iterate through a list of resources and call `Resource#content_type`?

I also think this is a much cleaner API for extension developers to tap into so they don't have to understand all of the stuff going on in rack (don't forget to make the last element in the response array an array!)

Currently the code in this PR is capable of:

```ruby
# From config.rb ... a contrived example of URL rewriting
ready do
  sitemap.resources.each do |r|
    r.pipeline << (body) -> { body.gsub('https://non-cdn-host.com', 'https://cdn-host.com') }
  end
end
```

## Implementation plan

* [x] Get feedback from @tdreyno about the current approach and gain understanding of:
  * `Resource` life-cycle - Is `ready` the right block to configure the pipeline? Where should I add filters to the resource pipeline when the app boots? When a page reloads? When the config reloads?
  * `Pipeline` could be confused with `ExternalPipeline`. Bike shed for 2 seconds on naming (`Filters`?).
  * How can I make these filters performant? e.g. where can I memoize the pipeline? It gets wiped out every time a resource is reloaded.
* [ ] Write unit tests for the new `Pipeline` class.
* [ ] Pick a core extension to port over into the pipeline. The `InlineUrlRewriter` is pretty gnarly so I might start with that.
* [ ] If everything feels right, port over all middleman core extensions (and maybe a few contrib extensions, like `middleman-syntax`) to use the rendering pipeline.