### PR TITLE
Incompatibility of listen with Ruby < 2.2

### DIFF
--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency('memoist', ['~> 0.14'])
 
   # Watcher
-  s.add_dependency('listen', ['~> 3.0'])
+  s.add_dependency('listen', ['~> 3.0.0'])
 
   # Tests
   s.add_dependency("capybara", ["~> 2.5.0"])


### PR DESCRIPTION
The dependency "listen" in version >= 3.1 isn't compatible with Ruby < 2.2.

See https://github.com/guard/listen/pull/371