### PR TITLE
Use https:// to clone templates on init

### DIFF
--- a/middleman-cli/lib/middleman-cli/init.rb
+++ b/middleman-cli/lib/middleman-cli/init.rb
@@ -113,7 +113,7 @@ module Middleman::Cli
     end
 
     def repository_path(repo)
-      repo.include?('://') || repo.include?('git@') ? repo : "git://github.com/#{repo}.git"
+      repo.include?('://') || repo.include?('git@') ? repo : "https://github.com/#{repo}.git"
     end
 
     # Add to CLI


### PR DESCRIPTION
## Summary

This PR replaces git://-protocol in the `middleman init/new`-command through https:// to make it work via HTTP proxies. 

<!-- This sections are meant as guidance for you. If some doesn't fit, skip them. -->

<!--- Provide a general summary of your changes in the Title above -->

## Details

* Using git://-protocol for cloning git repositories does not work via
HTTP proxies. By replacing it with https:// instead it works for more
users. 

* HTTP proxies are quite common in enterprise environments so this PR reduces the barrier for such users.

<!--- Describe your changes in detail -->

## Motivation and Context

I would like to use `middleman` behind an HTTP proxy which fails on `middleman init my_project` since it's no possible for git to clone the template.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

I ran your test suite for cli_init.feature and it succeeded on my local setup `ruby 2.3.x`.

<!--- Please add tests for bugs and new features otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

