### PR TITLE
fix method missing `try`

### DIFF
--- a/middleman-core/lib/middleman-core/extensions/minify_css.rb
+++ b/middleman-core/lib/middleman-core/extensions/minify_css.rb
@@ -1,3 +1,4 @@
+require 'active_support/core_ext/object/try'
 require 'memoist'
 require 'middleman-core/contracts'
 

--- a/middleman-core/lib/middleman-core/extensions/minify_javascript.rb
+++ b/middleman-core/lib/middleman-core/extensions/minify_javascript.rb
@@ -1,3 +1,4 @@
+require 'active_support/core_ext/object/try'
 require 'middleman-core/contracts'
 require 'memoist'
 


### PR DESCRIPTION
Just started up a new middleman app today and it looks like `try` isn't being included from the ActiveSupport core extensions, so when I turned on the minify JavaScript and CSS options the build would fail.