### PR TITLE
Fix asset_url with asset_hash

### DIFF
--- a/middleman-core/features/asset_hash.feature
+++ b/middleman-core/features/asset_hash.feature
@@ -63,8 +63,8 @@ Feature: Assets get file hashes appended to them and references to them are upda
     Given the Server is running at "asset-hash-app"
     When I go to "/"
     Then I should see 'href="apple-touch-icon.png"'
-    And I should see 'href="stylesheets/site-d1a750ca.css"'
-    And I should see 'href="stylesheets/fragment-99b76247.css"'
+    And I should see 'href="stylesheets/site-d2959d87.css"'
+    And I should see 'href="stylesheets/fragment-a06f0dfc.css"'
     And I should see 'src="javascripts/application-1d8d5276.js"'
     And I should see 'src="images/100px-5fd6fb90.jpg"'
     And I should see 'srcset="images/100px-5fd6fb90.jpg 1x, images/200px-c11eb203.jpg 2x, images/300px-59adce76.jpg 3x"'
@@ -72,11 +72,11 @@ Feature: Assets get file hashes appended to them and references to them are upda
     And I should see 'src="images/100px-5fd6fb90.jpg?#test"'
     And I should see 'src="images/100px-5fd6fb90.jpg#test"'
     When I go to "/subdir/"
-    Then I should see 'href="../stylesheets/site-d1a750ca.css"'
+    Then I should see 'href="../stylesheets/site-d2959d87.css"'
     And I should see 'src="../javascripts/application-1d8d5276.js"'
     And I should see 'src="../images/100px-5fd6fb90.jpg"'
     When I go to "/other/"
-    Then I should see 'href="../stylesheets/site-d1a750ca.css"'
+    Then I should see 'href="../stylesheets/site-d2959d87.css"'
     And I should see 'src="../javascripts/application-1d8d5276.js"'
     And I should see 'src="../images/100px-5fd6fb90.jpg"'
     And I should see 'src="../images/100px-5fd6fb90.jpg?test"'
@@ -84,7 +84,7 @@ Feature: Assets get file hashes appended to them and references to them are upda
     And I should see 'src="../images/100px-5fd6fb90.jpg#test"'
     When I go to "/javascripts/application-1d8d5276.js"
     Then I should see "img.src = '/images/100px-5fd6fb90.jpg'"
-    When I go to "/stylesheets/site-d1a750ca.css"
+    When I go to "/stylesheets/site-d2959d87.css"
     Then I should see 'background-image: url("../images/100px-5fd6fb90.jpg");'
     When I go to "/api.json"
     Then I should see 'images/100px-5fd6fb90.gif'
@@ -94,7 +94,7 @@ Feature: Assets get file hashes appended to them and references to them are upda
     Then I should see 'images/100px-5fd6fb90.gif'
     And I should see 'images/100px-5fd6fb90.jpg'
     And I should see 'images/100px-1242c368.png'
-    When I go to "/stylesheets/fragment-99b76247.css"
+    When I go to "/stylesheets/fragment-a06f0dfc.css"
     And I should see 'url("../images/100px-5fd6fb90.jpg");'
     And I should see 'url("../images/100px-5fd6fb90.jpg?test");'
     And I should see 'url("../images/100px-5fd6fb90.jpg?#test");'
@@ -179,14 +179,14 @@ Feature: Assets get file hashes appended to them and references to them are upda
         font-size: 14px
       """
     When I go to "/partials/"
-    Then I should see 'href="../stylesheets/uses_partials-4d4e34e6.css'
+    Then I should see 'href="../stylesheets/uses_partials-44fb2764.css'
     And the file "source/stylesheets/_partial.sass" has the contents
       """
       body
         font-size: 18px !important
       """
     When I go to "/partials/"
-    Then I should see 'href="../stylesheets/uses_partials-ec347271.css'
+    Then I should see 'href="../stylesheets/uses_partials-10d8ae33.css'
 
   Scenario: The asset hash should change when a Rack-based filter changes
     Given a fixture app "asset-hash-app"
@@ -200,8 +200,8 @@ Feature: Assets get file hashes appended to them and references to them are upda
       """
     Given the Server is running at "asset-hash-app"
     When I go to "/"
-    Then I should see 'href="stylesheets/site-5ad7def0.css'
-    When I go to "stylesheets/site-5ad7def0.css"
+    Then I should see 'href="stylesheets/site-30784643.css'
+    When I go to "stylesheets/site-30784643.css"
     Then I should see 'background-image: url("../images/100px-5fd6fb90.jpg")'
     Then I should see 'Added by Rack filter'
 

--- a/middleman-core/features/asset_hash.feature
+++ b/middleman-core/features/asset_hash.feature
@@ -63,8 +63,8 @@ Feature: Assets get file hashes appended to them and references to them are upda
     Given the Server is running at "asset-hash-app"
     When I go to "/"
     Then I should see 'href="apple-touch-icon.png"'
-    And I should see 'href="stylesheets/site-d2959d87.css"'
-    And I should see 'href="stylesheets/fragment-a06f0dfc.css"'
+    And I should see 'href="stylesheets/site-d1a750ca.css"'
+    And I should see 'href="stylesheets/fragment-99b76247.css"'
     And I should see 'src="javascripts/application-1d8d5276.js"'
     And I should see 'src="images/100px-5fd6fb90.jpg"'
     And I should see 'srcset="images/100px-5fd6fb90.jpg 1x, images/200px-c11eb203.jpg 2x, images/300px-59adce76.jpg 3x"'
@@ -72,11 +72,11 @@ Feature: Assets get file hashes appended to them and references to them are upda
     And I should see 'src="images/100px-5fd6fb90.jpg?#test"'
     And I should see 'src="images/100px-5fd6fb90.jpg#test"'
     When I go to "/subdir/"
-    Then I should see 'href="../stylesheets/site-d2959d87.css"'
+    Then I should see 'href="../stylesheets/site-d1a750ca.css"'
     And I should see 'src="../javascripts/application-1d8d5276.js"'
     And I should see 'src="../images/100px-5fd6fb90.jpg"'
     When I go to "/other/"
-    Then I should see 'href="../stylesheets/site-d2959d87.css"'
+    Then I should see 'href="../stylesheets/site-d1a750ca.css"'
     And I should see 'src="../javascripts/application-1d8d5276.js"'
     And I should see 'src="../images/100px-5fd6fb90.jpg"'
     And I should see 'src="../images/100px-5fd6fb90.jpg?test"'
@@ -84,7 +84,7 @@ Feature: Assets get file hashes appended to them and references to them are upda
     And I should see 'src="../images/100px-5fd6fb90.jpg#test"'
     When I go to "/javascripts/application-1d8d5276.js"
     Then I should see "img.src = '/images/100px-5fd6fb90.jpg'"
-    When I go to "/stylesheets/site-d2959d87.css"
+    When I go to "/stylesheets/site-d1a750ca.css"
     Then I should see 'background-image: url("../images/100px-5fd6fb90.jpg");'
     When I go to "/api.json"
     Then I should see 'images/100px-5fd6fb90.gif'
@@ -94,7 +94,7 @@ Feature: Assets get file hashes appended to them and references to them are upda
     Then I should see 'images/100px-5fd6fb90.gif'
     And I should see 'images/100px-5fd6fb90.jpg'
     And I should see 'images/100px-1242c368.png'
-    When I go to "/stylesheets/fragment-a06f0dfc.css"
+    When I go to "/stylesheets/fragment-99b76247.css"
     And I should see 'url("../images/100px-5fd6fb90.jpg");'
     And I should see 'url("../images/100px-5fd6fb90.jpg?test");'
     And I should see 'url("../images/100px-5fd6fb90.jpg?#test");'
@@ -179,14 +179,14 @@ Feature: Assets get file hashes appended to them and references to them are upda
         font-size: 14px
       """
     When I go to "/partials/"
-    Then I should see 'href="../stylesheets/uses_partials-44fb2764.css'
+    Then I should see 'href="../stylesheets/uses_partials-4d4e34e6.css'
     And the file "source/stylesheets/_partial.sass" has the contents
       """
       body
         font-size: 18px !important
       """
     When I go to "/partials/"
-    Then I should see 'href="../stylesheets/uses_partials-10d8ae33.css'
+    Then I should see 'href="../stylesheets/uses_partials-ec347271.css'
 
   Scenario: The asset hash should change when a Rack-based filter changes
     Given a fixture app "asset-hash-app"
@@ -200,8 +200,8 @@ Feature: Assets get file hashes appended to them and references to them are upda
       """
     Given the Server is running at "asset-hash-app"
     When I go to "/"
-    Then I should see 'href="stylesheets/site-30784643.css'
-    When I go to "stylesheets/site-30784643.css"
+    Then I should see 'href="stylesheets/site-5ad7def0.css'
+    When I go to "stylesheets/site-5ad7def0.css"
     Then I should see 'background-image: url("../images/100px-5fd6fb90.jpg")'
     Then I should see 'Added by Rack filter'
 

--- a/middleman-core/lib/middleman-core/util/paths.rb
+++ b/middleman-core/lib/middleman-core/util/paths.rb
@@ -118,7 +118,9 @@ module Middleman
       # relative path, since it only takes absolute url paths.
       dest_path = url_for(app, path, options.merge(relative: false))
 
-      result = if resource = app.sitemap.find_resource_by_destination_path(dest_path)
+      result = if resource = app.sitemap.find_resource_by_path(dest_path)
+        resource.url
+      elsif resource = app.sitemap.find_resource_by_destination_path(dest_path)
         resource.url
       else
         path = ::File.join(prefix, path)

--- a/middleman-core/spec/middleman-core/util_spec.rb
+++ b/middleman-core/spec/middleman-core/util_spec.rb
@@ -162,6 +162,13 @@ describe Middleman::Util do
       expect( Middleman::Util.asset_url( @mm, '/how/about/that.html' ) ).to eq '/how/about/that/'
     end
 
+    it "returns a resource url when asset_hash is on" do
+      Given.fixture 'asset-hash-app'
+      @mm = Middleman::Application.new
+
+      expect( Middleman::Util.asset_url( @mm, '100px.png', 'images') ).to match %r|/images/100px-[a-f0-9]+.png|
+    end
+
   end
 
   describe "::find_related_files" do


### PR DESCRIPTION
Not sure how long this has been broken (at least since MM 3.3), but if you turn on `:asset_hash`, `asset_url`-based helpers like `image_tag` break because they are looking up a resource based on its destination path, which now contains an asset hash (so they don't ever find it). I think there are cases where the text rewriter later fixes this, but it shows up in a bunch of my sites.

This fix simply looks for the normal path first, which is what you'd be using to reference images and other resources most of the time. A new test will hopefully prevent this from breaking again.