### PR TITLE
Enable Tilt 2 support. #1920

### DIFF
--- a/middleman-core/lib/middleman-core/application.rb
+++ b/middleman-core/lib/middleman-core/application.rb
@@ -344,23 +344,11 @@ module Middleman
 
     # Clean up missing Tilt exts
     def prune_tilt_templates!
-      # If Tilt 1.4.x
-      if ::Tilt.respond_to?(:mappings)
-        ::Tilt.mappings.each_key do |key|
-          begin
-            ::Tilt[".#{key}"]
-          rescue LoadError, NameError
-            ::Tilt.mappings.delete(key)
-          end
-        end
-      else
-        # If Tilt 2.x
-        ::Tilt.default_mapping.lazy_map.each_key do |key|
-          begin
-            ::Tilt[".#{key}"]
-          rescue LoadError, NameError
-            ::Tilt.default_mapping.lazy_map.delete(key)
-          end
+      ::Tilt.default_mapping.lazy_map.each_key do |key|
+        begin
+          ::Tilt[".#{key}"]
+        rescue LoadError, NameError
+          ::Tilt.default_mapping.lazy_map.delete(key)
         end
       end
     end

--- a/middleman-core/lib/middleman-core/application.rb
+++ b/middleman-core/lib/middleman-core/application.rb
@@ -344,11 +344,23 @@ module Middleman
 
     # Clean up missing Tilt exts
     def prune_tilt_templates!
-      ::Tilt.mappings.each_key do |key|
-        begin
-          ::Tilt[".#{key}"]
-        rescue LoadError, NameError
-          ::Tilt.mappings.delete(key)
+      # If Tilt 1.4.x
+      if ::Tilt.respond_to?(:mappings)
+        ::Tilt.mappings.each_key do |key|
+          begin
+            ::Tilt[".#{key}"]
+          rescue LoadError, NameError
+            ::Tilt.mappings.delete(key)
+          end
+        end
+      else
+        # If Tilt 2.x
+        ::Tilt.default_mapping.lazy_map.each_key do |key|
+          begin
+            ::Tilt[".#{key}"]
+          rescue LoadError, NameError
+            ::Tilt.default_mapping.lazy_map.delete(key)
+          end
         end
       end
     end

--- a/middleman-core/lib/middleman-core/file_renderer.rb
+++ b/middleman-core/lib/middleman-core/file_renderer.rb
@@ -3,15 +3,8 @@ require 'active_support/core_ext/string/output_safety'
 require 'active_support/core_ext/module/delegation'
 require 'middleman-core/contracts'
 
-# If Tilt 1.4.x
-if ::Tilt.respond_to?(:mappings)
-  ::Tilt.mappings.delete('html') # WTF, Tilt?
-  ::Tilt.mappings.delete('csv')
-# If Tilt 2.x
-else
-  ::Tilt.default_mapping.lazy_map.delete('html')
-  ::Tilt.default_mapping.lazy_map.delete('csv')
-end
+::Tilt.default_mapping.lazy_map.delete('html')
+::Tilt.default_mapping.lazy_map.delete('csv')
 
 module Middleman
   class FileRenderer
@@ -131,20 +124,10 @@ module Middleman
         # config variables of that name and merge it
         extension_class = ::Middleman::Util.tilt_class(ext)
 
-        # If Tilt 1.4.x
-        if ::Tilt.respond_to?(:mappings)
-          ::Tilt.mappings.each do |mapping_ext, engines|
-            next unless engines.include? extension_class
-            engine_options = @app.config[mapping_ext.to_sym] || {}
-            options.merge!(engine_options)
-          end
-        # If Tilt 2.x
-        else
-          ::Tilt.default_mapping.lazy_map.each do |mapping_ext, engines|
-            next unless engines.include? extension_class
-            engine_options = @app.config[mapping_ext.to_sym] || {}
-            options.merge!(engine_options)
-          end
+        ::Tilt.default_mapping.lazy_map.each do |mapping_ext, engines|
+          next unless engines.include? extension_class
+          engine_options = @app.config[mapping_ext.to_sym] || {}
+          options.merge!(engine_options)
         end
 
         options

--- a/middleman-core/lib/middleman-core/file_renderer.rb
+++ b/middleman-core/lib/middleman-core/file_renderer.rb
@@ -124,8 +124,7 @@ module Middleman
         # config variables of that name and merge it
         extension_class = ::Middleman::Util.tilt_class(ext)
 
-        ::Tilt.default_mapping.lazy_map.each do |mapping_ext, engines|
-          next unless engines.include? extension_class
+        ::Tilt.default_mapping.extensions_for(extension_class).each do |mapping_ext|
           engine_options = @app.config[mapping_ext.to_sym] || {}
           options.merge!(engine_options)
         end

--- a/middleman-core/lib/middleman-core/renderers/redcarpet.rb
+++ b/middleman-core/lib/middleman-core/renderers/redcarpet.rb
@@ -3,7 +3,7 @@ require 'active_support/core_ext/module/attribute_accessors'
 
 module Middleman
   module Renderers
-    class RedcarpetTemplate < ::Tilt::RedcarpetTemplate::Redcarpet2
+    class RedcarpetTemplate < ::Tilt::RedcarpetTemplate
       # because tilt has decided to convert these
       # in the wrong direction
       ALIASES = {

--- a/middleman-core/lib/middleman-core/template_renderer.rb
+++ b/middleman-core/lib/middleman-core/template_renderer.rb
@@ -64,18 +64,9 @@ module Middleman
         extension_class = ::Middleman::Util.tilt_class(options[:preferred_engine])
 
         # Get a list of extensions for a preferred engine
-
-        # If Tilt 1.4.x
-        if ::Tilt.respond_to?(:mappings)
-          preferred_engines += ::Tilt.mappings.select do |_, engines|
-            engines.include? extension_class
-          end.keys
-        # If Tilt 2.x
-        else
-          preferred_engines += ::Tilt.default_mapping.lazy_map.select do |_, engines|
-            engines.include? extension_class
-          end.keys
-        end
+        preferred_engines += ::Tilt.default_mapping.lazy_map.select do |_, engines|
+          engines.include? extension_class
+        end.keys
       end
 
       preferred_engines << '*'

--- a/middleman-core/lib/middleman-core/template_renderer.rb
+++ b/middleman-core/lib/middleman-core/template_renderer.rb
@@ -64,9 +64,7 @@ module Middleman
         extension_class = ::Middleman::Util.tilt_class(options[:preferred_engine])
 
         # Get a list of extensions for a preferred engine
-        preferred_engines += ::Tilt.default_mapping.lazy_map.select do |_, engines|
-          engines.include? extension_class
-        end.keys
+        preferred_engines += ::Tilt.default_mapping.extensions_for(extension_class)
       end
 
       preferred_engines << '*'

--- a/middleman-core/lib/middleman-core/template_renderer.rb
+++ b/middleman-core/lib/middleman-core/template_renderer.rb
@@ -64,9 +64,18 @@ module Middleman
         extension_class = ::Middleman::Util.tilt_class(options[:preferred_engine])
 
         # Get a list of extensions for a preferred engine
-        preferred_engines += ::Tilt.mappings.select do |_, engines|
-          engines.include? extension_class
-        end.keys
+
+        # If Tilt 1.4.x
+        if ::Tilt.respond_to?(:mappings)
+          preferred_engines += ::Tilt.mappings.select do |_, engines|
+            engines.include? extension_class
+          end.keys
+        # If Tilt 2.x
+        else
+          preferred_engines += ::Tilt.default_mapping.lazy_map.select do |_, engines|
+            engines.include? extension_class
+          end.keys
+        end
       end
 
       preferred_engines << '*'

--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   # Core
   s.add_dependency('bundler', ['~> 1.1'])
   s.add_dependency('rack', ['>= 1.4.5', '< 2.0'])
-  s.add_dependency('tilt', ['>= 1.4.1', '< 3.0'])
+  s.add_dependency('tilt', ['~> 2.0'])
   s.add_dependency('erubis')
   s.add_dependency('fast_blank')
   s.add_dependency('parallel')

--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   # Core
   s.add_dependency('bundler', ['~> 1.1'])
   s.add_dependency('rack', ['>= 1.4.5', '< 2.0'])
-  s.add_dependency('tilt', ['~> 1.4.1'])
+  s.add_dependency('tilt', ['>= 1.4.1', '< 3.0'])
   s.add_dependency('erubis')
   s.add_dependency('fast_blank')
   s.add_dependency('parallel')


### PR DESCRIPTION
Relaxed requirements for Tilt to `['>= 1.4.1', '< 3.0']`. Check Tilt version and use `Tilt.default_mapping.lazy_map` instead of `Tilt.mappings` with Tilt 2. Drop `RedcarpetTemplate::Redcarpet2` which was removed in Tilt 2.

Some tests checking for markdown configuration options still fail.