### PR TITLE
Convert `latency` option to a Fixnum

### DIFF
--- a/middleman-core/lib/middleman-core/sources/source_watcher.rb
+++ b/middleman-core/lib/middleman-core/sources/source_watcher.rb
@@ -163,7 +163,7 @@ module Middleman
         wait_for_delay: 0.5
       }
 
-      config[:latency] = @latency if @latency
+      config[:latency] = @latency.to_i if @latency
 
       @listener = ::Listen.to(@directory.to_s, config, &method(:on_listener_change))
 


### PR DESCRIPTION
As @vill pointed out in https://github.com/middleman/middleman/issues/1866#issuecomment-222869287
passing `--watcher-latency=2` fails because the gem `listen` expects `latency` to be an `Fixnum`.

This commit fixes this issue.