### PR TITLE
Add prefix option to asset_hash

### DIFF
--- a/middleman-core/features/asset_hash.feature
+++ b/middleman-core/features/asset_hash.feature
@@ -308,3 +308,17 @@ Feature: Assets get file hashes appended to them and references to them are upda
       | javascripts/application.js.map |
 
     And the file "javascripts/application-4553338c.js" should contain "//# sourceMappingURL=application.js-22cc2b5f.map"
+
+  Scenario: Hashes can contain a prefix
+    Given a successfully built app at "asset-hash-prefix"
+    When I cd to "build"
+    Then the following files should exist:
+      | index.html |
+      | javascripts/application-myprefix-4553338c.js |
+      | javascripts/application.js-myprefix-22cc2b5f.map |
+      | index.html |
+    And the following files should not exist:
+      | javascripts/application.js |
+      | javascripts/application.js.map |
+
+    And the file "javascripts/application-myprefix-4553338c.js" should contain "//# sourceMappingURL=application.js-myprefix-22cc2b5f.map"

--- a/middleman-core/fixtures/asset-hash-prefix/config.rb
+++ b/middleman-core/fixtures/asset-hash-prefix/config.rb
@@ -1,0 +1,7 @@
+
+activate :asset_hash,
+  prefix: "myprefix-"
+
+activate :relative_assets
+
+activate :directory_indexes

--- a/middleman-core/fixtures/asset-hash-prefix/lib/middleware.rb
+++ b/middleman-core/fixtures/asset-hash-prefix/lib/middleware.rb
@@ -1,0 +1,16 @@
+class Middleware
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    status, headers, response = @app.call(env)
+    body = ''
+    response.each {|part| body += part }
+    if (env["PATH_INFO"] =~ /css$/)
+      body += "\n/* Added by Rack filter */"
+      status, headers, response = Rack::Response.new(body, status, headers).finish
+    end
+    [status, headers, response]
+  end
+end

--- a/middleman-core/fixtures/asset-hash-prefix/source/index.html.erb
+++ b/middleman-core/fixtures/asset-hash-prefix/source/index.html.erb
@@ -1,0 +1,6 @@
+<% content_for :head do %>
+  <title>The Middleman!</title>
+<% end %>
+
+<h1>Testing the sitemap hashing</h1>
+<br /><br /><br />

--- a/middleman-core/fixtures/asset-hash-prefix/source/javascripts/application.js
+++ b/middleman-core/fixtures/asset-hash-prefix/source/javascripts/application.js
@@ -1,0 +1,2 @@
+function foo(){var message="HEY THERE FRIEND!";var para=document.createElement("p");para.innerHTML=message;var body=document.getElementsByTagName("body")[0];body.insertBefore(para,body.firstChild)}window.onload=foo;
+//# sourceMappingURL=application.js.map

--- a/middleman-core/fixtures/asset-hash-prefix/source/javascripts/application.js.map
+++ b/middleman-core/fixtures/asset-hash-prefix/source/javascripts/application.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["source/javascripts/application.js"],"names":["foo","message","para","document","createElement","innerHTML","body","getElementsByTagName","insertBefore","firstChild","window","onload"],"mappings":"AAAA,QAASA,OACP,GAAIC,SAAU,mBACd,IAAIC,MAAOC,SAASC,cAAc,IAClCF,MAAKG,UAAYJ,OACb,IAAIK,MAAOH,SAASI,qBAAqB,QAAQ,EAC/CD,MAAKE,aAAaN,KAAMI,KAAKG,YAGpCC,OAAOC,OAASX"}

--- a/middleman-core/fixtures/asset-hash-prefix/source/layout.erb
+++ b/middleman-core/fixtures/asset-hash-prefix/source/layout.erb
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+
+    <%= javascript_include_tag "application" %>
+    <%= yield_content :head %>
+  </head>
+
+  <body class="<%= page_classes %>">
+
+    <div id="main" role="main">
+      <%= yield %>
+    </div>
+
+  </body>
+</html>

--- a/middleman-core/lib/middleman-core/extensions/asset_hash.rb
+++ b/middleman-core/lib/middleman-core/extensions/asset_hash.rb
@@ -6,6 +6,7 @@ class Middleman::Extensions::AssetHash < ::Middleman::Extension
   option :exts, nil, 'List of extensions that get asset hashes appended to them.'
   option :ignore, [], 'Regexes of filenames to skip adding asset hashes to'
   option :rewrite_ignore, [], 'Regexes of filenames to skip processing for path rewrites'
+  option :prefix, '', 'Prefix for hash'
 
   def initialize(app, options_hash={}, &block)
     super
@@ -92,7 +93,7 @@ class Middleman::Extensions::AssetHash < ::Middleman::Extension
       ::Digest::SHA1.hexdigest(response.body)[0..7]
     end
 
-    resource.destination_path = resource.destination_path.sub(/\.(\w+)$/) { |ext| "-#{digest}#{ext}" }
+    resource.destination_path = resource.destination_path.sub(/\.(\w+)$/) { |ext| "-#{options.prefix}#{digest}#{ext}" }
     resource
   end
 


### PR DESCRIPTION
This allows manually changing the filename so that fiel header changes
can be reflected on the CDN. E.g. if you turn on crossOrigin serving
(CORS) the asset hash doesn't change, but the CDN cache needs to be
broken in order to pickup the new header.