### PR TITLE
Updating to Active Support version 5

### DIFF
--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency('dotenv')
 
   # Helpers
-  s.add_dependency('activesupport', ['~> 4.2'])
+  s.add_dependency('activesupport', ['~> 5.0'])
   s.add_dependency('padrino-helpers', ['~> 0.13.0'])
   s.add_dependency("addressable", ["~> 2.3"])
   s.add_dependency('memoist', ['~> 0.14'])


### PR DESCRIPTION
As Rails version 5 is out of beta now, we can start using an updated version of Active Support.

I ran `bundle exec rake test` before and after, and nothing changed so this was surprisingly easy.