### PR TITLE
Eliminate quadratic behavior in SourceWatcher::poll_once!

### DIFF
--- a/middleman-core/lib/middleman-core/sources/source_watcher.rb
+++ b/middleman-core/lib/middleman-core/sources/source_watcher.rb
@@ -199,7 +199,7 @@ module Middleman
     Contract ArrayOf[Pathname]
     def poll_once!
       updated = ::Middleman::Util.all_files_under(@directory.to_s, &method(:should_not_recurse?))
-      removed = @files.keys.reject { |p| updated.include?(p) }
+      removed = @files.keys - updated
 
       result = update(updated, removed)
 


### PR DESCRIPTION
Both `Array#reject` and `Array#include?` have linear time complexity. This results in quadratic time complexity when `Array#include?` is called within `Array#reject`'s block. Using `Array`'s difference operator gives the same result in linear time.

In a site with ~14,000 files, this drops the time taken by some calls to `SourceWatcher::poll_once!` from ~15 seconds each to just a few milliseconds.