### PR TITLE
Improve performance of ignoring files

### DIFF
--- a/middleman-core/lib/middleman-core/sitemap/extensions/ignores.rb
+++ b/middleman-core/lib/middleman-core/sitemap/extensions/ignores.rb
@@ -14,7 +14,22 @@ module Middleman
         Contract Or[String, Regexp, Proc] => RespondTo[:execute_descriptor]
         def ignore(path=nil, &block)
           @app.sitemap.invalidate_resources_not_ignored_cache!
-          IgnoreDescriptor.new(path, block)
+
+          if path.is_a? Regexp
+            RegexpIgnoreDescriptor.new(path)
+          elsif path.is_a? String
+            path_clean = ::Middleman::Util.normalize_path(path)
+
+            if path_clean.include?('*') # It's a glob
+              GlobIgnoreDescriptor.new(path_clean)
+            else
+              StringIgnoreDescriptor.new(path_clean)
+            end
+          elsif block
+            BlockIgnoreDescriptor.new(nil, block)
+          else
+            IgnoreDescriptor.new(path, block)
+          end
         end
 
         IgnoreDescriptor = Struct.new(:path, :block) do
@@ -33,27 +48,42 @@ module Middleman
           end
 
           def ignored?(match_path)
+            raise NotImplementedError
+          end
+        end
+
+        class RegexpIgnoreDescriptor < IgnoreDescriptor
+          def ignored?(match_path)
             match_path = ::Middleman::Util.normalize_path(match_path)
+            match_path =~ path
+          end
+        end
 
-            if path.is_a? Regexp
-              match_path =~ path
-            elsif path.is_a? String
-              path_clean = ::Middleman::Util.normalize_path(path)
-
-              if path_clean.include?('*') # It's a glob
-                if defined?(::File::FNM_EXTGLOB)
-                  ::File.fnmatch(path_clean, match_path, ::File::FNM_EXTGLOB)
-                else
-                  ::File.fnmatch(path_clean, match_path)
-                end
-              else
-                match_path == path_clean
-              end
-            elsif block
-              block.call(match_path)
+        class GlobIgnoreDescriptor < IgnoreDescriptor
+          def ignored?(match_path)
+            match_path = ::Middleman::Util.normalize_path(match_path)
+            if defined?(::File::FNM_EXTGLOB)
+              ::File.fnmatch(path, match_path, ::File::FNM_EXTGLOB)
+            else
+              ::File.fnmatch(path, match_path)
             end
           end
         end
+
+        class StringIgnoreDescriptor < IgnoreDescriptor
+          def ignored?(match_path)
+            match_path = ::Middleman::Util.normalize_path(match_path)
+            match_path == path
+          end
+        end
+
+        class BlockIgnoreDescriptor
+          def ignored?(match_path)
+            match_path = ::Middleman::Util.normalize_path(match_path)
+            block.call(match_path)
+          end
+        end
+
       end
     end
   end

--- a/middleman-core/lib/middleman-core/sitemap/extensions/ignores.rb
+++ b/middleman-core/lib/middleman-core/sitemap/extensions/ignores.rb
@@ -36,9 +36,9 @@ module Middleman
           def execute_descriptor(_app, resources)
             resources.map do |r|
               # Ignore based on the source path (without template extensions)
-              if ignored?(r.path)
+              if ignored?(r.normalized_path)
                 r.ignore!
-              elsif !r.is_a?(ProxyResource) && r.file_descriptor && ignored?(r.file_descriptor[:relative_path].to_s)
+              elsif !r.is_a?(ProxyResource) && r.file_descriptor && ignored?(r.file_descriptor.normalized_relative_path)
                 # This allows files to be ignored by their source file name (with template extensions)
                 r.ignore!
               end
@@ -54,14 +54,12 @@ module Middleman
 
         class RegexpIgnoreDescriptor < IgnoreDescriptor
           def ignored?(match_path)
-            match_path = ::Middleman::Util.normalize_path(match_path)
             match_path =~ path
           end
         end
 
         class GlobIgnoreDescriptor < IgnoreDescriptor
           def ignored?(match_path)
-            match_path = ::Middleman::Util.normalize_path(match_path)
             if defined?(::File::FNM_EXTGLOB)
               ::File.fnmatch(path, match_path, ::File::FNM_EXTGLOB)
             else
@@ -72,14 +70,12 @@ module Middleman
 
         class StringIgnoreDescriptor < IgnoreDescriptor
           def ignored?(match_path)
-            match_path = ::Middleman::Util.normalize_path(match_path)
             match_path == path
           end
         end
 
         class BlockIgnoreDescriptor
           def ignored?(match_path)
-            match_path = ::Middleman::Util.normalize_path(match_path)
             block.call(match_path)
           end
         end

--- a/middleman-core/lib/middleman-core/sitemap/extensions/proxies.rb
+++ b/middleman-core/lib/middleman-core/sitemap/extensions/proxies.rb
@@ -47,7 +47,7 @@ module Middleman
           )
 
           if should_ignore
-            d = ::Middleman::Sitemap::Extensions::Ignores::IgnoreDescriptor.new(target)
+            d = ::Middleman::Sitemap::Extensions::Ignores::StringIgnoreDescriptor.new(target)
             d.execute_descriptor(app, resources)
           end
 

--- a/middleman-core/lib/middleman-core/sitemap/resource.rb
+++ b/middleman-core/lib/middleman-core/sitemap/resource.rb
@@ -197,6 +197,13 @@ module Middleman
         options[:content_type] || ::Rack::Mime.mime_type(ext, nil)
       end
 
+      # The normalized source path of this resource (relative to the source directory,
+      # without template extensions)
+      # @return [String]
+      def normalized_path
+        @normalized_path ||= ::Middleman::Util.normalize_path @path
+      end
+
       def to_s
         "#<#{self.class} path=#{@path}>"
       end

--- a/middleman-core/lib/middleman-core/sources.rb
+++ b/middleman-core/lib/middleman-core/sources.rb
@@ -8,6 +8,10 @@ module Middleman
       ::Middleman::Sources.file_cache[full_path] ||= {}
       ::Middleman::Sources.file_cache[full_path][version] ||= ::File.read(full_path)
     end
+
+    def normalized_relative_path
+      @normalized_relative_path ||= ::Middleman::Util.normalize_path relative_path.to_s
+    end
   end
 
   # Sources handle multiple on-disk collections of files which make up


### PR DESCRIPTION
On a site with around 14,000 files and a handful of simple ignore patterns, I was seeing `IgnoreDescriptor::ignored?` account for approximately 6 seconds of middleman's initialization time. This change reduces that time to around 0.6 seconds by:

1. Determining the type of ignore pattern only once per pattern, rather than every time the pattern is used.
2. Caching the normalized paths on `Resource` and `SourceFile`.