### PR TITLE
Tilt 2

### DIFF
--- a/middleman-core/lib/middleman-core/application.rb
+++ b/middleman-core/lib/middleman-core/application.rb
@@ -344,11 +344,11 @@ module Middleman
 
     # Clean up missing Tilt exts
     def prune_tilt_templates!
-      ::Tilt.mappings.each_key do |key|
+      ::Tilt.default_mapping.lazy_map.each_key do |key|
         begin
           ::Tilt[".#{key}"]
         rescue LoadError, NameError
-          ::Tilt.mappings.delete(key)
+          ::Tilt.default_mapping.lazy_map.delete(key)
         end
       end
     end

--- a/middleman-core/lib/middleman-core/file_renderer.rb
+++ b/middleman-core/lib/middleman-core/file_renderer.rb
@@ -3,8 +3,8 @@ require 'active_support/core_ext/string/output_safety'
 require 'active_support/core_ext/module/delegation'
 require 'middleman-core/contracts'
 
-::Tilt.mappings.delete('html') # WTF, Tilt?
-::Tilt.mappings.delete('csv')
+::Tilt.default_mapping.lazy_map.delete('html')
+::Tilt.default_mapping.lazy_map.delete('csv')
 
 module Middleman
   class FileRenderer
@@ -123,7 +123,8 @@ module Middleman
         # Find all the engines which handle this extension in tilt. Look for
         # config variables of that name and merge it
         extension_class = ::Middleman::Util.tilt_class(ext)
-        ::Tilt.mappings.each do |mapping_ext, engines|
+
+        ::Tilt.default_mapping.lazy_map.each do |mapping_ext, engines|
           next unless engines.include? extension_class
           engine_options = @app.config[mapping_ext.to_sym] || {}
           options.merge!(engine_options)

--- a/middleman-core/lib/middleman-core/file_renderer.rb
+++ b/middleman-core/lib/middleman-core/file_renderer.rb
@@ -124,8 +124,7 @@ module Middleman
         # config variables of that name and merge it
         extension_class = ::Middleman::Util.tilt_class(ext)
 
-        ::Tilt.default_mapping.lazy_map.each do |mapping_ext, engines|
-          next unless engines.include? extension_class
+        ::Tilt.default_mapping.extensions_for(extension_class).each do |mapping_ext|
           engine_options = @app.config[mapping_ext.to_sym] || {}
           options.merge!(engine_options)
         end

--- a/middleman-core/lib/middleman-core/renderers/redcarpet.rb
+++ b/middleman-core/lib/middleman-core/renderers/redcarpet.rb
@@ -3,7 +3,7 @@ require 'active_support/core_ext/module/attribute_accessors'
 
 module Middleman
   module Renderers
-    class RedcarpetTemplate < ::Tilt::RedcarpetTemplate::Redcarpet2
+    class RedcarpetTemplate < ::Tilt::RedcarpetTemplate
       # because tilt has decided to convert these
       # in the wrong direction
       ALIASES = {

--- a/middleman-core/lib/middleman-core/template_renderer.rb
+++ b/middleman-core/lib/middleman-core/template_renderer.rb
@@ -64,9 +64,7 @@ module Middleman
         extension_class = ::Middleman::Util.tilt_class(options[:preferred_engine])
 
         # Get a list of extensions for a preferred engine
-        preferred_engines += ::Tilt.default_mapping.lazy_map.select do |_, engines|
-          engines.include? extension_class
-        end.keys
+        preferred_engines += ::Tilt.default_mapping.extensions_for(extension_class)
       end
 
       preferred_engines << '*'

--- a/middleman-core/lib/middleman-core/template_renderer.rb
+++ b/middleman-core/lib/middleman-core/template_renderer.rb
@@ -64,7 +64,7 @@ module Middleman
         extension_class = ::Middleman::Util.tilt_class(options[:preferred_engine])
 
         # Get a list of extensions for a preferred engine
-        preferred_engines += ::Tilt.mappings.select do |_, engines|
+        preferred_engines += ::Tilt.default_mapping.lazy_map.select do |_, engines|
           engines.include? extension_class
         end.keys
       end

--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   # Core
   s.add_dependency('bundler', ['~> 1.1'])
   s.add_dependency('rack', ['>= 1.4.5', '< 2.0'])
-  s.add_dependency('tilt', ['~> 1.4.1'])
+  s.add_dependency('tilt', ['~> 2.0'])
   s.add_dependency('erubis')
   s.add_dependency('fast_blank')
   s.add_dependency('parallel')


### PR DESCRIPTION
- Require any version of tilt between 2 and 3
- Drop RedcarpetTemplate::Redcarpet2 which was removed in Tilt 2
-  Use `Tilt.default_mapping.lazy_map` instead of `Tilt.mappings`
- Make use of `Tilt.default_mapping.extensions_for`

Fixes #1921 
