### PR TITLE
Allow for activesupport 4.2 again

### DIFF
--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency('dotenv')
 
   # Helpers
-  s.add_dependency('activesupport', ['~> 5.0'])
+  s.add_dependency('activesupport', ['>= 4.2', '< 5.1'])
   s.add_dependency('padrino-helpers', ['~> 0.13.0'])
   s.add_dependency("addressable", ["~> 2.3"])
   s.add_dependency('memoist', ['~> 0.14'])


### PR DESCRIPTION
There is no current reason to remove support for 4.2
This now makes for a backwards compatible change whereas before this would
have called for a new major version of middleman-core

Refs #1967