### PR TITLE
Updates to support Rails 5, Rack 3 and Sinatra 2 (beta)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'kramdown', '~> 1.2', require: false
 gem 'slim', '>= 2.0', require: false
 gem 'liquid', '>= 2.6', require: false
 gem 'stylus', '>= 1.0', require: false
-gem 'sinatra', '>= 2.0.0.beta2', require: false
+gem 'sinatra', '>= 1.4', require: false
 gem 'redcarpet', '>= 3.1', require: false
 
 # Dns server to test preview server

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'kramdown', '~> 1.2', require: false
 gem 'slim', '>= 2.0', require: false
 gem 'liquid', '>= 2.6', require: false
 gem 'stylus', '>= 1.0', require: false
-gem 'sinatra', '>= 1.4', require: false
+gem 'sinatra', '>= 2.0.0.beta2', require: false
 gem 'redcarpet', '>= 3.1', require: false
 
 # Dns server to test preview server

--- a/middleman-core/features/asset_host.feature
+++ b/middleman-core/features/asset_host.feature
@@ -25,7 +25,8 @@ Feature: Alternate between multiple asset hosts
     And a file named "config.rb" with:
       """
       activate :asset_host, host: Proc.new { |asset|
-        "http://assets%d.example.com" % (asset.hash % 4)
+        hash = Digest::MD5.digest(asset).bytes.map!(&:ord).reduce(&:+)
+        "http://assets%d.example.com" % (hash % 4)
       }
       """
     And the Server is running

--- a/middleman-core/lib/middleman-core/extensions/minify_css.rb
+++ b/middleman-core/lib/middleman-core/extensions/minify_css.rb
@@ -72,7 +72,7 @@ class Middleman::Extensions::MinifyCss < ::Middleman::Extension
       end
 
       if minified
-        headers['Content-Length'] = ::Rack::Utils.bytesize(minified).to_s
+        headers['Content-Length'] = minified.bytesize.to_s
         response = [minified]
       end
 

--- a/middleman-core/lib/middleman-core/extensions/minify_javascript.rb
+++ b/middleman-core/lib/middleman-core/extensions/minify_javascript.rb
@@ -64,7 +64,7 @@ class Middleman::Extensions::MinifyJavascript < ::Middleman::Extension
       end
 
       if minified
-        headers['Content-Length'] = ::Rack::Utils.bytesize(minified).to_s
+        headers['Content-Length'] = minified.bytesize.to_s
         response = [minified]
       end
 

--- a/middleman-core/lib/middleman-core/rack.rb
+++ b/middleman-core/lib/middleman-core/rack.rb
@@ -133,9 +133,15 @@ module Middleman
 
     # Immediately send static file
     def send_file(resource, env)
-      file      = ::Rack::File.new nil
-      file.path = resource.file_descriptor[:full_path]
-      response = file.serving(env)
+      file     = ::Rack::File.new nil
+      path     = resource.file_descriptor[:full_path]
+      if !file.respond_to?(:path=)
+        request  = ::Rack::Request.new(env)
+        response = file.serving(request, path)
+      else
+        file.path = path
+        response = file.serving(env)
+      end
       status = response[0]
       response[1]['Content-Encoding'] = 'gzip' if %w(.svgz .gz).include?(resource.ext)
       # Do not set Content-Type if status is 1xx, 204, 205 or 304, otherwise

--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   # Core
   s.add_dependency('bundler', ['~> 1.1'])
-  s.add_dependency('rack', ['>= 1.4.5', '< 2.0'])
+  s.add_dependency('rack', ['>= 1.4.5', '< 3'])
   s.add_dependency('tilt', ['~> 2.0'])
   s.add_dependency('erubis')
   s.add_dependency('fast_blank')

--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   # Core
   s.add_dependency('bundler', ['~> 1.1'])
-  s.add_dependency('rack', ['>= 1.4.5', '< 3'])
+  s.add_dependency('rack', ['>= 1.4.5', '< 2.0'])
   s.add_dependency('tilt', ['~> 2.0'])
   s.add_dependency('erubis')
   s.add_dependency('fast_blank')


### PR DESCRIPTION
- Bump upper boundary of version for Rack dependency from 2.0 to 3 (exclusive). 
  - This allows compatibility with `actionpack 5.0.x` (and thus `rails 5.0.x`) which requires `rack 2.x`, while preserving compatibility with `rails < 5`, which requires `rack 1.x`.
- Bump the minimum version of `sinatra` used in CI testing from `1.4` to `2.0.0.beta2` (inclusive).
See #1983.
