### PR TITLE
Added addressable to the gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'byebug'
 gem 'aruba', '~> 0.7.4', require: false
 gem 'rspec', '~> 3.0', require: false
 gem 'cucumber', '~> 2.0', require: false
+gem 'addressable', '~> 2.4.0', require: false
 
 # Optional middleman dependencies, included for tests
 gem 'haml', '>= 4.0.5', require: false


### PR DESCRIPTION
addressable is required for middleman init, but was not installed as part of a fresh install of Middleman