### PR TITLE
Sitemap RedirectResource's know their source file

### DIFF
--- a/middleman-core/lib/middleman-core/sitemap/extensions/redirects.rb
+++ b/middleman-core/lib/middleman-core/sitemap/extensions/redirects.rb
@@ -68,7 +68,7 @@ module Middleman
 
           # rubocop:disable Style/AccessorMethodName
           def get_source_file
-            nil
+            @request_path.source_file
           end
           # rubocop:enable Style/AccessorMethodName
 


### PR DESCRIPTION
So Middleman won't hang while rendering the sitemap in development.

I couldn't actually test this - the middleman specs took ages to run, and I haven't found how to create a middleman site that depends on my version of the gem :/ - but monkey-patching this change in my own middleman site worked.

Fixes #1166