### PR TITLE
Fix addressable require

### DIFF
--- a/middleman-core/lib/middleman-core/util/paths.rb
+++ b/middleman-core/lib/middleman-core/util/paths.rb
@@ -1,7 +1,7 @@
 # Core Pathname library used for traversal
 require 'pathname'
 require 'uri'
-require 'addressable'
+require 'addressable/uri'
 require 'memoist'
 require 'tilt'
 


### PR DESCRIPTION
Must use `require 'addressable/uri'`

(it's a weirdness in the adressable gem that you cannot require the 'root')