### PR TITLE
Add bower_components ignore

### DIFF
--- a/middleman-core/lib/middleman-core/preview_server.rb
+++ b/middleman-core/lib/middleman-core/preview_server.rb
@@ -160,6 +160,9 @@ module Middleman
                                     path: root,
                                     only: match_against
 
+              # Hack around bower_components in root.
+              watcher.listener.ignore(/^bower_components/)
+              
               # Hack around node_modules in root.
               watcher.listener.ignore(/^node_modules/)
 


### PR DESCRIPTION
Server to down, when try to load some bower_components/*.ts files...
```
/Users/c01nd01r/.rvm/gems/ruby-2.3.0/gems/tilt-2.0.5/lib/tilt/typescript.rb:2:in `require': cannot load such file -- typescript-
node (LoadError)
        from /Users/c01nd01r/.rvm/gems/ruby-2.3.0/gems/tilt-2.0.5/lib/tilt/typescript.rb:2:in `<top (required)>'
        from /Users/c01nd01r/.rvm/gems/ruby-2.3.0/gems/tilt-2.0.5/lib/tilt/mapping.rb:243:in `require'
        from /Users/c01nd01r/.rvm/gems/ruby-2.3.0/gems/tilt-2.0.5/lib/tilt/mapping.rb:243:in `block in lazy_load'
        from /Users/c01nd01r/.rvm/gems/ruby-2.3.0/gems/tilt-2.0.5/lib/tilt/mapping.rb:241:in `each'
        from /Users/c01nd01r/.rvm/gems/ruby-2.3.0/gems/tilt-2.0.5/lib/tilt/mapping.rb:241:in `lazy_load'
        from /Users/c01nd01r/.rvm/gems/ruby-2.3.0/gems/tilt-2.0.5/lib/tilt/mapping.rb:216:in `lookup'
        from /Users/c01nd01r/.rvm/gems/ruby-2.3.0/gems/tilt-2.0.5/lib/tilt/mapping.rb:154:in `[]'
        from /Users/c01nd01r/.rvm/gems/ruby-2.3.0/gems/tilt-2.0.5/lib/tilt.rb:48:in `[]'
        from /Users/c01nd01r/.rvm/gems/ruby-2.3.0@global/gems/middleman-core-4.1.11/lib/middleman-core/sources/source_watcher.rb
:336:in `strip_extensions'
```