### PR TITLE
v4.1.13 Always logging boolean on starting up

### DIFF
--- a/middleman-core/lib/middleman-core/application.rb
+++ b/middleman-core/lib/middleman-core/application.rb
@@ -306,7 +306,6 @@ module Middleman
       execute_callbacks(:after_configuration)
 
       # Everything is stable
-      $stderr.puts config[:exit_before_ready].inspect
       execute_callbacks(:ready) unless config[:exit_before_ready]
     end
 


### PR DESCRIPTION
In v4.1.13, Middleman always puts logs like `true`/`false` on starting up.
Though I'm not sure if it is intended, it seems to be logs for debugging for the changes for #2017, so I have simply removed that line.