### PR TITLE
change rack/showexceptions to rack/show_exceptions

### DIFF
--- a/middleman-core/lib/middleman-core/core_extensions/show_exceptions.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/show_exceptions.rb
@@ -1,4 +1,4 @@
-require 'rack/showexceptions'
+require 'rack/show_exceptions'
 
 # Support rack/showexceptions during development
 module Middleman::CoreExtensions


### PR DESCRIPTION
Not sure what changed, but `rack/showexceptions` is now `rack/show_exceptions`.

<http://www.rubydoc.info/github/rack/rack/Rack/ShowExceptions>

Adding that underscore makes my exceptions all pretty again, which is useful since I can't ever seem to type things correctly the first time.