### PR TITLE
Fix syntax for Ruby 2.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ before_script:
   - bundle update
 rvm:
   - ruby-head
+  - 2.4.0
   - 2.3.1
   - 2.2.4
 os:

--- a/middleman-core/lib/middleman-core/application.rb
+++ b/middleman-core/lib/middleman-core/application.rb
@@ -191,9 +191,9 @@ module Middleman
         ignored
       end,
 
-      layout: proc do |file, app|
+      layout: ->(file, app) {
         file[:relative_path].to_s.start_with?('layout.', app.config[:layouts_dir] + '/')
-      end
+      }
     }, 'Callbacks that can exclude paths from the sitemap'
 
     define_setting :skip_build_clean, proc { |p| [/\.git/].any? { |r| p =~ r } }, 'Whether some paths should not be removed during a clean build.'


### PR DESCRIPTION
For some reason Ruby 2.4.0 didn't like `layout: proc do |...|` (but `partials: proc do |...|` right above works fine). I also added Ruby 2.4.0 to the Travis config.