### PR TITLE
Don't ignore Markdown options in Haml filter

### DIFF
--- a/middleman-core/features/markdown_redcarpet_in_haml.feature
+++ b/middleman-core/features/markdown_redcarpet_in_haml.feature
@@ -20,6 +20,26 @@ Feature: Markdown support in Haml
     Then I should see ">H1</h1>"
     Then I should see "<p>paragraph</p>"
 
+  Scenario: Markdown filter options in Haml works
+    Given a fixture app "markdown-in-haml-app"
+    And a file named "config.rb" with:
+      """
+      set :markdown_engine, :redcarpet
+      set :markdown, { with_toc_data: true }
+      activate :directory_indexes
+      """
+    And a file named "source/markdown_filter.html.haml" with:
+      """
+      :markdown
+        # Memorable Title
+
+        paragraph
+      """
+    Given the Server is running at "markdown-in-haml-app"
+    When I go to "/markdown_filter/"
+    Then I should see ">Memorable Title</h1>"
+    Then I should see '<h1 id="memorable-title"'
+    Then I should see "<p>paragraph</p>"
 
   Scenario: Markdown filter in Haml uses our link_to and image_tag helpers
     Given a fixture app "markdown-in-haml-app"

--- a/middleman-core/lib/middleman-core/renderers/haml.rb
+++ b/middleman-core/lib/middleman-core/renderers/haml.rb
@@ -52,6 +52,10 @@ module Middleman
               modified_options = options.dup
               modified_options[:context] = compiler_options[:context]
 
+              renderer_symbol = self.to_s.split(":").last.downcase.to_sym
+              renderer_options = modified_options[:context].app.config[renderer_symbol]
+              modified_options = modified_options.merge(renderer_options || {})
+
               text = template_class.new(nil, 1, modified_options) { text }.render
               super(text, compiler_options)
             end


### PR DESCRIPTION
This issue was detailed in #1152.

Essentially we're not passing the :markdown options defined in config.rb to
the Markdown renderer when we first go through the Haml renderer.

The solution I've found is to fetch the appropriate options (not just for
Markdown but for Sass or SCSS also) within the Haml renderer's filter loop which
means this patch should also fix any ignored options for Sass and SCSS.