### PR TITLE
Remove Compass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,3 @@ Makefile
 .idea
 *.sublime-workspace
 /bin
-middleman-core/fixtures/compass-sprites-app/source/images/icon-s0de2218f58.png

--- a/Gemfile
+++ b/Gemfile
@@ -48,5 +48,4 @@ gem 'codeclimate-test-reporter', '~> 0.3', require: false, group: :test
 gem 'middleman-cli', path: 'middleman-cli'
 gem 'middleman-core', path: 'middleman-core'
 
-# gem 'middleman-compass', github: 'middleman/middleman-compass', require: false
 # gem 'middleman-sprockets', github: 'middleman/middleman-sprockets', require: false

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The preview server allows you to build your site, by modifying the contents of t
 
 To get started, simply develop as you normally would by building HTML, CSS, and Javascript in the `source` directory. When you're ready to use more complex templates, simply add the templating engine's extension to the file and start writing in that format.
 
-For example, say I am working on a stylesheet at `source/stylesheets/site.css` and I'd like to start using Compass and Sass. I would rename the file to `source/stylesheets/site.css.scss` and Middleman will automatically begin processing that file as Sass. The same would apply to CoffeeScript (`.js.coffee`), Haml (`.html.haml`) and any other templating engine you might want to use.
+For example, say I am working on a stylesheet at `source/stylesheets/site.css` and I'd like to start using Sass. I would rename the file to `source/stylesheets/site.css.scss` and Middleman will automatically begin processing that file as Sass. The same would apply to CoffeeScript (`.js.coffee`), Haml (`.html.haml`) and any other templating engine you might want to use.
 
 Finally, you will want to build your project into a stand-alone site. From the project directory:
 

--- a/middleman-cli/middleman-cli.gemspec
+++ b/middleman-cli/middleman-cli.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.email       = ['me@tdreyno.com', 'ben@benhollis.net']
   s.homepage    = 'http://middlemanapp.com'
   s.summary     = 'Hand-crafted frontend development'
-  s.description = 'A static site generator. Provides dozens of templating languages (Haml, Sass, Compass, Slim, CoffeeScript, and more). Makes minification, compression, cache busting, Yaml data (and more) an easy part of your development cycle.'
+  s.description = 'A static site generator. Provides dozens of templating languages (Haml, Sass, Slim, CoffeeScript, and more). Makes minification, compression, cache busting, Yaml data (and more) an easy part of your development cycle.'
 
   s.files        = `git ls-files -z`.split("\0")
   s.test_files   = `git ls-files -z -- {fixtures,features}/*`.split("\0")

--- a/middleman-core/fixtures/generator-test/config.rb
+++ b/middleman-core/fixtures/generator-test/config.rb
@@ -1,17 +1,4 @@
 ###
-# Compass
-###
-
-# Susy grids in Compass
-# First: gem install compass-susy-plugin
-# require 'susy'
-
-# Change Compass configuration
-# compass_config do |config|
-#   config.output_style = :compact
-# end
-
-###
 # Page options, layouts, aliases and proxies
 ###
 
@@ -53,7 +40,6 @@
 
 # Production configuration
 configure :production do
-  # For example, change the Compass output style for deployment
   # activate :minify_css
 
   # Minify Javascript

--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.email       = ['me@tdreyno.com', 'ben@benhollis.net', 'karlfreeman@gmail.com']
   s.homepage    = 'http://middlemanapp.com'
   s.summary     = 'Hand-crafted frontend development'
-  s.description = 'A static site generator. Provides dozens of templating languages (Haml, Sass, Compass, Slim, CoffeeScript, and more). Makes minification, compression, cache busting, Yaml data (and more) an easy part of your development cycle.'
+  s.description = 'A static site generator. Provides dozens of templating languages (Haml, Sass, Slim, CoffeeScript, and more). Makes minification, compression, cache busting, Yaml data (and more) an easy part of your development cycle.'
 
   s.files        = `git ls-files -z`.split("\0")
   s.test_files   = `git ls-files -z -- {fixtures,features}/*`.split("\0")

--- a/middleman/middleman.gemspec
+++ b/middleman/middleman.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.email       = ['me@tdreyno.com', 'ben@benhollis.net', 'karlfreeman@gmail.com']
   s.homepage    = 'http://middlemanapp.com'
   s.summary     = 'Hand-crafted frontend development'
-  s.description = 'A static site generator. Provides dozens of templating languages (Haml, Sass, Compass, Slim, CoffeeScript, and more). Makes minification, compression, cache busting, Yaml data (and more) an easy part of your development cycle.'
+  s.description = 'A static site generator. Provides dozens of templating languages (Haml, Sass, Slim, CoffeeScript, and more). Makes minification, compression, cache busting, Yaml data (and more) an easy part of your development cycle.'
 
   s.files        = `git ls-files -z`.split("\0")
   s.test_files   = `git ls-files -z -- {fixtures,features}/*`.split("\0")
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.add_dependency('middleman-core', Middleman::VERSION)
   s.add_dependency('middleman-cli', Middleman::VERSION)
   s.add_dependency('sass', ['>= 3.4.0', '< 4.0'])
-  s.add_dependency('compass-import-once', ['1.0.5'])
   s.add_dependency('haml', ['>= 4.0.5'])
   s.add_dependency('coffee-script', ['~> 2.2'])
   s.add_dependency('kramdown', ['~> 1.2'])


### PR DESCRIPTION
This is a WIP, as I don’t really know what I’m doing here.

[Compass] is no longer actively maintained, so we should remove it from Middleman.

[Compass]: https://github.com/Compass/compass