### PR TITLE
I18n: Keep fragment and query in url_for

### DIFF
--- a/middleman-core/features/i18n_link_to.feature
+++ b/middleman-core/features/i18n_link_to.feature
@@ -162,6 +162,7 @@ Feature: i18n Paths
       es:
         paths:
           hello: "hola"
+          form: "formulario"
         msg: Hola
       """
     And a file named "source/localizable/hello.html.erb" with:
@@ -171,6 +172,10 @@ Feature: i18n Paths
         Current: <%= url_for "/#{p}" %>
         Other: <%= url_for "/#{p}", locale: ::I18n.locale == :en ? :es : :en %>
       <% end %>
+      """
+    And a file named "source/localizable/form.html.erb" with:
+      """
+      Other: <%= url_for "/form.html", query: { foo: 'bar' }, fragment: "deep", locale: ::I18n.locale == :en ? :es : :en %>
       """
     And a file named "source/localizable/article.html.erb" with:
       """
@@ -199,6 +204,10 @@ Feature: i18n Paths
     Then I should see "Page: Hola"
     Then I should see 'Current: /es/hola.html'
     Then I should see 'Other: /hello.html'
+    When I go to "/form.html"
+    Then I should see 'Other: /es/formulario.html?foo=bar#deep'
+    When I go to "/es/formulario.html"
+    Then I should see 'Other: /form.html?foo=bar#deep'
     When I go to "/article.html"
     Then I should see "Page Lang: Default"
     Then I should see 'Current: /article.html'

--- a/middleman-core/lib/middleman-core/core_extensions/i18n.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/i18n.rb
@@ -194,10 +194,13 @@ class Middleman::CoreExtensions::Internationalization < ::Middleman::Extension
 
   Contract String, Symbol => Maybe[String]
   def localized_path(path, locale)
-    lookup_path = path.dup
-    lookup_path << app.config[:index_file] if lookup_path.end_with?('/')
-
-    @lookup[lookup_path] && @lookup[lookup_path][locale]
+    begin
+      lookup = ::Middleman::Util.parse_uri(path)
+      lookup.path << app.config[:index_file] if lookup.path && lookup.path.end_with?('/')
+      lookup.to_s if @lookup[lookup.path] && lookup.path = @lookup[lookup.path][locale]
+    rescue ::Addressable::URI::InvalidURIError
+      nil
+    end
   end
 
   Contract Symbol => String


### PR DESCRIPTION
As mentioned in a [comment](https://github.com/middleman/middleman/issues/1587#issuecomment-135469826) on #1587 and in #1798, fragments and queries are discarded when a path is internationalized. The failing test is part of this PR (see 9d5a27ef562921bb2ffa38163389e67d1f1f7031).

This happened because the path _including_ fragment and query was looked up in the internationalization hash. This resulted in an unsuccessful lookup with a fallback to the non-internationalized path. My fix (see 9c1ca5c85af193a32dffe48ebccfc216aa47c047) is to _only_ internationalize the path and leave the rest of the url untouched. 