### PR TITLE
find resurce even you have a http_prefix defined

### DIFF
--- a/middleman-core/lib/middleman-core/util/rack.rb
+++ b/middleman-core/lib/middleman-core/util/rack.rb
@@ -43,7 +43,7 @@ module Middleman
           if uri.relative? && uri.host.nil? && !(asset_path =~ /^[^\/].*[a-z]+\.[a-z]+\/.*/)
             dest_path = ::Middleman::Util.url_for(app, asset_path, relative: false, current_resource: current_resource)
 
-            resource = app.sitemap.find_resource_by_destination_path(dest_path)
+            resource = app.sitemap.find_resource_by_destination_path(dest_path.gsub(app.config[:http_prefix], ''))
 
             if resource && (result = yield(asset_path))
               "#{opening_character}#{result}"


### PR DESCRIPTION
config.rb
```
configure :test do
  # http_prefix overwrites asset_host
  set :http_prefix, '/assets/'
  activate :asset_host, :host => '//YOURDOMAIN.cloudfront.net', exts: ['.jpg']
end

```