### PR TITLE
allow to override data in context

### DIFF
--- a/middleman-core/lib/middleman-core/template_renderer.rb
+++ b/middleman-core/lib/middleman-core/template_renderer.rb
@@ -132,7 +132,7 @@ module Middleman
       @app.extensions.add_exposed_to_context(context)
 
       locals.each do |k, _|
-        next unless context.respond_to?(k) && ![:current_path, :paginate, :page_articles, :blog_controller, :lang, :locale].include?(k.to_sym)
+        next unless context.respond_to?(k) && ![:current_path, :paginate, :page_articles, :blog_controller, :lang, :locale, :data].include?(k.to_sym)
 
         msg = "Template local `#{k}` tried to overwrite an existing context value. Please rename the key when passing to `locals`"
 


### PR DESCRIPTION
Currently the build fails when liquid tries to override the (empty or not existing?) context value data.

cc: https://github.com/middleman/middleman/issues/2083