### PR TITLE
Update "Port in use"-message for PreviewServer

### DIFF
--- a/middleman-core/lib/middleman-core/preview_server.rb
+++ b/middleman-core/lib/middleman-core/preview_server.rb
@@ -268,7 +268,8 @@ module Middleman
         begin
           ::WEBrick::HTTPServer.new(http_opts)
         rescue Errno::EADDRINUSE
-          $stderr.puts %(== Port "#{http_opts[:Port]}" is in use. This should not have happened. Please start "middleman server" again.)
+          port = http_opts[:Port]
+          $stderr.puts %(== Port #{port} is already in use. This could mean another instance of middleman is already running. Please make sure port #{port} is free and start `middleman server` again, or choose another port by running `middleman server —-port=#{port + 1}` instead.)
         end
       end
 


### PR DESCRIPTION
When starting the preview server while the port is already in use, users
get the following error message:

> Port "4567" is in use. This should not have happened. Please start "middleman server" again.

I see two problems with this message:

1. "This should not have happened" makes this error sound like
   something scary went wrong, while this is something most middleman
   users will run into sooner or later.
2. "Please start "middleman server" again." isn't the best advise, since
   trying to start it again won't solve the issue, as there's either
   another middleman instance running, or some other process is keeping
   the port occupied.

Instead, I'd like to propose this:

> Port 4567 is already in use. This could mean another instance of middleman is already running. Please make sure port 4567 is free and start `middleman server` again, or choose another port by running `middleman server —-port=4568` instead.

This error message mentions that there might be another instance running
(which is quite likely in this situation), and tells the user to make
sure the port is free and try again *or* choose another port. The
suggested alternative port is `http_opts[:Port] + 1`, so it'll use 4568
if the current port is 4567, for lack of a better option.