### PR TITLE
Updated RubyInstaller-Devkit link

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,6 @@ Copyright (c) 2010-2017 Thomas Reynolds. MIT Licensed, see [LICENSE] for details
 [codeclimate]: https://codeclimate.com/github/middleman/middleman
 [gittip]: https://www.gittip.com/middleman/
 [rubyinstaller]: http://rubyinstaller.org/
-[RubyInstaller-Devkit]: http://rubyinstaller.org/add-ons/devkit/
+[RubyInstaller-Devkit]: https://rubyinstaller.org/add-ons/devkit.html
 [rubydoc]: http://rubydoc.info/github/middleman/middleman
 [LICENSE]: https://github.com/middleman/middleman/blob/master/LICENSE.md


### PR DESCRIPTION
The RubyInstaller-Devkit link has changed. Updated it.