### PR TITLE
Compat with latest rails/activesupport < 5.2

### DIFF
--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency('dotenv')
 
   # Helpers
-  s.add_dependency('activesupport', ['>= 4.2', '< 5.1'])
+  s.add_dependency('activesupport', ['>= 4.2', '< 5.2'])
   s.add_dependency('padrino-helpers', ['~> 0.13.0'])
   s.add_dependency("addressable", ["~> 2.3"])
   s.add_dependency('memoist', ['~> 0.14'])


### PR DESCRIPTION
Currently failing with `activesupport 5.1.1` on travis: https://travis-ci.org/amplified-work/middleman/jobs/243873944

I'm interested in guidance on this issue. There is a single failure with liquid templates:

```
Feature: Support liquid partials

The use of "create_dir" is deprecated. Use "create_directory" instead
== Preferring use of LibSass
  Scenario: Rendering liquid                    # features/liquid.feature:3
    Given the Server is running at "liquid-app" # lib/middleman-core/step_definitions/server_steps.rb:65
Template local `data` tried to overwrite an existing context value. Please rename the key when passing to `locals`
    When I go to "/liquid_master.html"          # lib/middleman-core/step_definitions/server_steps.rb:74
    Then I should see "Greetings"               # lib/middleman-core/step_definitions/server_steps.rb:90
      expected "Liquid error (line 1): internal" to include "Greetings" (RSpec::Expectations::ExpectationNotMetError)
      ./lib/middleman-core/step_definitions/server_steps.rb:91:in `/^I should see "([^\"]*)"$/'
      features/liquid.feature:6:in `Then I should see "Greetings"'

Failing Scenarios:
cucumber features/liquid.feature:3 # Scenario: Rendering liquid

1 scenario (1 failed)
3 steps (1 failed, 2 passed)
0m0.448s
```
And 4 related to minify_javascript:
```
cucumber features/minify_javascript.feature:4 # Scenario: Rendering inline js with the feature disabled
cucumber features/minify_javascript.feature:42 # Scenario: Rendering inline js with a passthrough minifier
cucumber features/minify_javascript.feature:89 # Scenario: Rendering inline JS with a passthrough minifier using activate-style compressor
cucumber features/minify_javascript.feature:123 # Scenario: Rendering inline js with the feature enabled
```
Any pointers welcome :rocket: 