### PR TITLE
Processor lanes

### DIFF
--- a/middleman-core/lib/middleman-core/builder.rb
+++ b/middleman-core/lib/middleman-core/builder.rb
@@ -149,7 +149,7 @@ module Middleman
           offset = end_r
           ranges << range
         end
-        outputs = ranges.in_threads(threads).map do |range|
+        outputs = Parallel.map(ranges, in_threads: threads) do |range|
           puts range.to_s
           resources[range].map(&method(:output_resource))
         end


### PR DESCRIPTION
The idea of this PR is to reduce the amounts of times the mutex is hit to just the number of spawned processes.

In the current implementation, the mutex is hit every time a resource is rendered, which given a lengthy job is not that important, however many websites have multiple resources of insignificant render time.

The potential downside of this is uneven processing when a portion of the resources are more expensive than the rest.

My website is too small (~100 resources) to give me a significant metric, however I created a test of 1000 html.erb files and it seemed to save a couple of seconds off the total time

I would like to ask if some could try this patch and report back their findings.

Thanks.

TODO:
- [ ] Rebase/squash the commits