### PR TITLE
Depend on therubyracer 0.12.3 or higher

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem 'phantomjs', '~> 2.1.1.0', require: false
 
 # For less, note there is no compatible JS runtime for windows
 gem 'therubyrhino', '>= 2.0', platforms: :jruby
-gem 'therubyracer', '>= 0.12', platforms: :ruby
+gem 'therubyracer', '~> 0.12.3', platforms: :ruby
 
 # Code Quality
 gem 'rubocop', '~> 0.24', require: false


### PR DESCRIPTION
therubyracer needed a patch to be compatible with Ruby 2.4.1. When
trying to initialize a middleman project on a machine running Ruby
2.4.1, chances are high that the installation will fail due to
therubyracer.

Fixes #2110