### PR TITLE
Support chained sass (and less) files

### DIFF
--- a/middleman-core/features/chained_templates.feature
+++ b/middleman-core/features/chained_templates.feature
@@ -7,6 +7,13 @@ Feature: Templates should be chainable
     Then I should see "Title</h1>"
     And I should see "Subtitle</h2>"
     And I should see "Sup</h3>"
+    When I go to "/stylesheets/main.css"
+
+  Scenario: Scss file in Erb
+    Given the Server is running at "chained-app"
+    When I go to "/stylesheets/main.css"
+    Then I should see "color: from_main;"
+    And I should see "background: from_sub;"
 
   Scenario: Build chained template
     Given a successfully built app at "chained-app"

--- a/middleman-core/fixtures/chained-app/source/stylesheets/main.css.scss.erb
+++ b/middleman-core/fixtures/chained-app/source/stylesheets/main.css.scss.erb
@@ -1,0 +1,3 @@
+@import 'sub';
+
+<%= 'body { color: from_main; }' %>

--- a/middleman-core/fixtures/chained-app/source/stylesheets/sub.scss
+++ b/middleman-core/fixtures/chained-app/source/stylesheets/sub.scss
@@ -1,0 +1,1 @@
+body { background: from_sub; }

--- a/middleman-core/lib/middleman-core/template_renderer.rb
+++ b/middleman-core/lib/middleman-core/template_renderer.rb
@@ -183,7 +183,7 @@ module Middleman
           content_renderer = ::Middleman::FileRenderer.new(@app, path)
           content = content_renderer.render(locs, opts, context, &block)
 
-          path = File.basename(path, File.extname(path))
+          path = path.sub(/\.[^.]*\z/, '')
         rescue LocalJumpError
           raise "Tried to render a layout (calls yield) at #{path} like it was a template. Non-default layouts need to be in #{@app.config[:source]}/#{@app.config[:layouts_dir]}."
         end


### PR DESCRIPTION
When handling chained templates, middleman used to remove the path and kept only the file's basename. Template engines which support imports (e.g. less or sass), use the file's path to find files to include. Since the path was removed, imports were not working for chained templates.

This commit changes middleman to keep the full path to the template file and adds a test case, which illustrates the desired behavior.