### PR TITLE
remove fast_blank dependency

### DIFF
--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.add_dependency('rack', ['>= 1.4.5', '< 3'])
   s.add_dependency('tilt', ['~> 2.0'])
   s.add_dependency('erubis')
-  s.add_dependency('fast_blank')
   s.add_dependency('parallel')
   s.add_dependency('servolux')
   s.add_dependency('dotenv')


### PR DESCRIPTION
- remove fast_blank as it blocks Middleman from being used with JRuby