### PR TITLE
chmod before closing file to fix compatibility with JRuby

### DIFF
--- a/middleman-core/lib/middleman-core/builder.rb
+++ b/middleman-core/lib/middleman-core/builder.rb
@@ -184,8 +184,8 @@ module Middleman
                           ])
       file.binmode
       file.write(contents)
-      file.close
       File.chmod(0o644, file)
+      file.close
       file
     end
 


### PR DESCRIPTION
JRuby cannot chmod a closed file. MRI can do it either way. Therefore, put chmod statement before statement to close file.

Here's the error from JRuby this patch addresses:

```
closed stream
org/jruby/RubyFile.java:601:in `chmod'
middleman-core/lib/middleman-core/builder.rb:188:in `write_tempfile'
```