### PR TITLE
Remove dependency that is no longer useful

### DIFF
--- a/middleman-core/lib/middleman-core/util/data.rb
+++ b/middleman-core/lib/middleman-core/util/data.rb
@@ -1,7 +1,6 @@
 require 'yaml'
 require 'json'
 require 'pathname'
-require 'backports/2.1.0/array/to_h'
 require 'hashie'
 require 'memoist'
 

--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -58,5 +58,4 @@ Gem::Specification.new do |s|
   # Hash stuff
   s.add_dependency('hashie', ['~> 3.4'])
   s.add_dependency('hamster', ['~> 3.0'])
-  s.add_dependency('backports', ['~> 3.6'])
 end


### PR DESCRIPTION
I'm really glad that `backports` was helpful to you.

Now that you only support Ruby 2.2+, that particular backport is no longer needed.

Thanks for middleman btw, I've used it before and hope to use it again soon if I can find the time to migrate again my blog.