### PR TITLE
Add LD-JSON to MinifyJavascript content types allowed to be compressed

### DIFF
--- a/middleman-core/lib/middleman-core/extensions/minify_javascript.rb
+++ b/middleman-core/lib/middleman-core/extensions/minify_javascript.rb
@@ -10,7 +10,7 @@ class Middleman::Extensions::MinifyJavascript < ::Middleman::Extension
     require 'uglifier'
     ::Uglifier.new
   }, 'Set the JS compressor to use.'
-  option :content_types, %w(application/javascript), 'Content types of resources that contain JS'
+  option :content_types, %w(application/javascript application/ld+json), 'Content types of resources that contain JS'
   option :inline_content_types, %w(text/html text/php), 'Content types of resources that contain inline JS'
 
   def ready


### PR DESCRIPTION
As LD-JSON spec is basically a JSON in a <script> tag, the uglifier can compress them as a normal javascript.