### PR TITLE
Resolve Haml 5 warnings

### DIFF
--- a/middleman-core/lib/middleman-core/renderers/haml.rb
+++ b/middleman-core/lib/middleman-core/renderers/haml.rb
@@ -30,6 +30,10 @@ module Middleman
 
       def evaluate(scope, locals, &block)
         options = {}.merge!(@options).merge!(filename: eval_file, line: line, context: @context || scope)
+        if options.include?(:outvar)
+          options[:buffer] = options.delete(:outvar)
+          options[:save_buffer] = true
+        end
         @engine = ::Haml::Engine.new(data, options)
         output = @engine.render(scope, locals, &block)
 
@@ -44,6 +48,9 @@ module Middleman
 
         ::Haml::Options.defaults[:context] = nil
         ::Haml::Options.send :attr_accessor, :context
+        if defined?(::Haml::TempleEngine)
+          ::Haml::TempleEngine.define_options context: nil
+        end
 
         # rubocop:disable NestedMethodDefinition
         [::Haml::Filters::Sass, ::Haml::Filters::Scss, ::Haml::Filters::Markdown].each do |f|


### PR DESCRIPTION
Fix https://github.com/middleman/middleman/issues/2087

Haml 5 now uses Temple. Thus we need to follow [Temple's way to support Tilt](https://github.com/judofyr/temple/blob/v0.8.0/lib/temple/templates/tilt.rb#L26-L29).

I had the same modification in Tilt https://github.com/rtomayko/tilt/pull/317, but middleman overrides the method to be not functional. So I applied the same fix and also retrieved `:context` option which is added by middleman.