### PR TITLE
Disable Travis CI email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,5 @@ env:
     - TEST=true
 script: bundle exec rake test
 notifications:
+  email: false
   slack: middleman:JW9OvXmn1m3XrSERe8866nBR


### PR DESCRIPTION
The PR status indicator is enough; sending emails for every broken build is repetitive and unnecessary.