### PR TITLE
Use EnhancedHash for partial locals

### DIFF
--- a/middleman-core/features/partials.feature
+++ b/middleman-core/features/partials.feature
@@ -37,7 +37,7 @@ Feature: Provide Sane Defaults for Partial Behavior
   Scenario: Partials can be passed locals
     Given the Server is running at "partials-app"
     When I go to "/locals.html"
-    Then I should see "Local var is bar"
+    Then I should see "Local vars are 'foo', 'bar' and 'baz'"
 
   Scenario: Partial and Layout use different engines
     Given the Server is running at "different-engine-partial"

--- a/middleman-core/fixtures/partials-app/source/_locals.erb
+++ b/middleman-core/fixtures/partials-app/source/_locals.erb
@@ -1,1 +1,1 @@
-Local var is <%= foo %>
+Local vars are '<%= locals['foo'] %>', '<%= locals[:bar] %>' and '<%= baz %>'

--- a/middleman-core/fixtures/partials-app/source/locals.html.erb
+++ b/middleman-core/fixtures/partials-app/source/locals.html.erb
@@ -1,1 +1,1 @@
-<%= partial 'locals', locals: { foo: 'bar' } %>
+<%= partial 'locals', locals: { foo: 'foo', 'bar' => 'bar', 'baz': 'baz' } %>

--- a/middleman-core/lib/middleman-core/core_extensions/default_helpers.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/default_helpers.rb
@@ -279,7 +279,7 @@ class Middleman::CoreExtensions::DefaultHelpers < ::Middleman::Extension
     end
 
     def partial(template, options={}, &block)
-      including_parent_locals = {}
+      including_parent_locals = Middleman::Util::EnhancedHash.new
       including_parent_locals.merge!(@locs || {})
       including_parent_locals.merge!(options[:locals] || {})
 


### PR DESCRIPTION
Since upgrading Middleman past 4.1.0, the partial function has been overwritten in the Middleman::CoreExtensions::DefaultHelpers class to include parent locals (https://github.com/middleman/middleman/commit/95537967316577520ad4a665835edf5d4cd64f48).

However, this has altered the default partial functionality inherited from Padrino. The hash that is now passed through to Padrino is a simple Ruby Hash, but before, it could be a Middleman::Util::EnhancedHash when metadata was passed into locals.

This is problematic as partials could use both Ruby's Hash object and a page's metadata (the Middleman::Util::EnhancedHash object) for locals. With the v4.1.0 implementation, Middleman::Util::EnhancedHash keys are stringified when merged with a Hash, meaning that sometimes we can access locals only as strings, and sometimes only symbols.

Take the example below:
```
[1] pry(#<Middleman::ConfigContext>)> options = { locals: Middleman::Util::EnhancedHash.new(greeting: 'Hello') }
=> {:locals=>{"greeting"=>"Hello"}}
[2] pry(#<Middleman::ConfigContext>)> including_parent_locals = {}
=> {}
[3] pry(#<Middleman::ConfigContext>)> including_parent_locals.merge!(options[:locals])
=> {"greeting"=>"Hello"}
[4] pry(#<Middleman::ConfigContext>)> including_parent_locals['greeting']
=> "Hello"
[5] pry(#<Middleman::ConfigContext>)> including_parent_locals[:greeting]
=> nil
[6] pry(#<Middleman::ConfigContext>)> including_parent_locals.greeting
NoMethodError: undefined method `greeting' for {"greeting"=>"Hello"}:Hash
from (pry):6:in `evaluate_configuration!'
[7] pry(#<Middleman::ConfigContext>)> including_parent_locals.class
=> Hash
```

However, constructing `including_parent_locals` with the EnhancedHash will restore the pre-v4.1.0 functionality:


```
[1] pry(#<Middleman::ConfigContext>)> options = { locals: Middleman::Util::EnhancedHash.new(greeting: 'Hello') }
=> {:locals=>{"greeting"=>"Hello"}}
[2] pry(#<Middleman::ConfigContext>)> including_parent_locals = Middleman::Util::EnhancedHash.new  
=> {}
[3] pry(#<Middleman::ConfigContext>)> including_parent_locals.merge!(options[:locals])
=> {"greeting"=>"Hello"}
[4] pry(#<Middleman::ConfigContext>)> including_parent_locals['greeting']
=> "Hello"
[5] pry(#<Middleman::ConfigContext>)> including_parent_locals[:greeting]
=> "Hello"
[6] pry(#<Middleman::ConfigContext>)> including_parent_locals.greeting
=> "Hello"
[7] pry(#<Middleman::ConfigContext>)> including_parent_locals.class
=> Middleman::Util::EnhancedHash
```

Related issue/comment: https://github.com/middleman/middleman/issues/1981#issuecomment-361017407