### PR TITLE
Update version of rubies on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ before_script:
   - bundle update
 rvm:
   - ruby-head
-  - 2.5.0
-  - 2.4.3
-  - 2.3.6
-  - 2.2.9
+  - 2.5.1
+  - 2.4.4
+  - 2.3.7
+  - 2.2.10
 os:
   - linux
   # - osx


### PR DESCRIPTION
Use latest version on Travis CI.

https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-5-1-released/
https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-4-4-released/
https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-3-7-released/
https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-2-10-released/