### PR TITLE
Add Errno::ENETUNREACH to exception list in BasicNetworkResolver

### DIFF
--- a/middleman-core/lib/middleman-core/dns_resolver/basic_network_resolver.rb
+++ b/middleman-core/lib/middleman-core/dns_resolver/basic_network_resolver.rb
@@ -21,7 +21,7 @@ module Middleman
       #   Array of Names
       def getnames(ip)
         resolver.getnames(ip.to_s).map(&:to_s)
-      rescue Resolv::ResolvError, Errno::EADDRNOTAVAIL
+      rescue Resolv::ResolvError, Errno::EADDRNOTAVAIL, Errno::ENETUNREACH
         []
       end
 
@@ -34,7 +34,7 @@ module Middleman
       #   Array of ipaddresses
       def getaddresses(name)
         resolver.getaddresses(name.to_s).map(&:to_s)
-      rescue Resolv::ResolvError, Errno::EADDRNOTAVAIL
+      rescue Resolv::ResolvError, Errno::EADDRNOTAVAIL, Errno::ENETUNREACH
         []
       end
 


### PR DESCRIPTION
Fixes issue #1621 for the master branch. It was fixed in pull request  #1625 for the middleman:v3-stable branch but this change did not make it to the master branch.