### PR TITLE
i18n was accidently duplicating requests for extension-based templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 master
 ===
 
+* i18n was accidently duplicating requests for extension-based template (file.es.html)
+
 # 4.3.0.rc.3
 
 * Fix Internal Server Error from `__middleman` meta page in dev. (#2187)

--- a/middleman-core/lib/middleman-core/core_extensions/i18n.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/i18n.rb
@@ -177,7 +177,14 @@ class Middleman::CoreExtensions::Internationalization < ::Middleman::Extension
 
       result = parse_locale_extension(resource.path)
       ext_locale, path, page_id = result
-      new_resources << build_resource(path, resource.path, page_id, ext_locale)
+
+      new_resource = build_resource(path, resource.path, page_id, ext_locale)
+
+      # extension resources replace original i18n attempt.
+      exists = new_resources.find { |r| r.path == new_resource.path }
+      new_resources.delete(exists) if exists
+
+      new_resources << new_resource
 
       resource.ignore!
     end


### PR DESCRIPTION
I noticed when building the docs site that extension-based templates (page.jp.html) were being requested twice. This makes i18n prefer the extension over the extensionless form.