### PR TITLE
Fix rakefile

### DIFF
--- a/middleman-cli/lib/middleman-cli/templates/extension/Rakefile
+++ b/middleman-cli/lib/middleman-cli/templates/extension/Rakefile
@@ -4,7 +4,7 @@ Bundler::GemHelper.install_tasks
 require 'cucumber/rake/task'
 
 Cucumber::Rake::Task.new(:cucumber, 'Run features that should pass') do |t|
-  t.cucumber_opts = '--fail-fast --color --tags 'not @wip' --strict'
+  t.cucumber_opts = '--fail-fast --color --tags "not @wip" --strict'
 end
 
 require 'rake/clean'


### PR DESCRIPTION
I could be wrong, but:

```sh
jsoref$ middleman extension foo; cd foo; curl -O https://raw.githubusercontent.com/middleman/middleman/master/middleman-cli/lib/middleman-cli/templates/extension/Rakefile; sed -i.0 -e 's/# s/s/' *.gemspec; rake
js after_configuration
      create  foo/.gitignore
      create  foo/Rakefile
      create  foo/foo.gemspec
      create  foo/Gemfile
      create  foo/lib/foo.rb
      create  foo/lib/foo/extension.rb
      create  foo/features/support/env.rb
      create  foo/fixtures
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   299  100   299    0     0   3301      0 --:--:-- --:--:-- --:--:--  3322
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
rake aborted!
SyntaxError: /private/tmp/foo/Rakefile:7: syntax error, unexpected keyword_not, expecting keyword_end
...--fail-fast --color --tags 'not @wip' --strict'
...                            ^~~
/Users/jsoref/.rvm/gems/ruby-2.5.1/gems/rake-12.3.1/exe/rake:27:in `<top (required)>'
/Users/jsoref/.rvm/gems/ruby-2.5.1/bin/ruby_executable_hooks:24:in `eval'
/Users/jsoref/.rvm/gems/ruby-2.5.1/bin/ruby_executable_hooks:24:in `<main>'
(See full trace by running task with --trace)
```