### PR TITLE
Use name for extension

### DIFF
--- a/middleman-cli/lib/middleman-cli/templates/extension/lib/lib.rb
+++ b/middleman-cli/lib/middleman-cli/templates/extension/lib/lib.rb
@@ -1,6 +1,6 @@
 require "middleman-core"
 
 Middleman::Extensions.register :<%= name %> do
-  require "my-extension/extension"
+  require "<%= name %>/extension"
   MyExtension
 end


### PR DESCRIPTION
Otherwise, you get the wrong file reference:
```sh
$ middleman extension foo; cat foo/lib/foo.rb
js after_configuration
      create  foo/.gitignore
      create  foo/Rakefile
      create  foo/foo.gemspec
      create  foo/Gemfile
      create  foo/lib/foo.rb
      create  foo/lib/foo/extension.rb
      create  foo/features/support/env.rb
      create  foo/fixtures
require "middleman-core"

Middleman::Extensions.register :foo do
  require "my-extension/extension"
  MyExtension
end```