### PR TITLE
Address security vulnerability due to i18n 0.7.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ PATH
       fastimage (~> 2.0)
       hamster (~> 3.0)
       hashie (~> 3.4)
-      i18n (~> 0.7)
+      i18n (~> 0.8)
       listen (~> 3.0)
       memoist (~> 0.14)
       padrino-helpers (~> 0.13.0)
@@ -71,7 +71,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.2)
     contracts (0.16.0)
     cucumber (3.1.2)
       builder (>= 2.1.2)

--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_dependency('listen', ['~> 3.0'])
 
   # i18n
-  s.add_dependency('i18n', ['~> 0.7'])
+  s.add_dependency('i18n', ['~> 0.8'])
 
   # Automatic Image Sizes
   s.add_dependency('fastimage', ['~> 2.0'])


### PR DESCRIPTION
### Why
The previous version of i18n has a critical vulnerability that has been addressed in a subsequent release.

```
Name: i18n
Version: 0.7.0
Advisory: CVE-2014-10077
Criticality: Unknown
URL: https://github.com/svenfuchs/i18n/pull/289
Title: i18n Gem for Ruby lib/i18n/core_ext/hash.rb Hash#slice() Function Hash Handling DoS
Solution: upgrade to >= 0.8.0
```

### What
This PR updates i18n to 0.8.0 to address this security vulnerability.