### PR TITLE
bumped i18n version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ PATH
       fastimage (~> 2.0)
       hamster (~> 3.0)
       hashie (~> 3.4)
-      i18n (~> 0.7)
+      i18n (~> 0.8)
       listen (~> 3.0)
       memoist (~> 0.14)
       padrino-helpers (~> 0.13.0)
@@ -266,4 +266,4 @@ DEPENDENCIES
   yard (~> 0.9.11)
 
 BUNDLED WITH
-   1.16.6
+   1.17.1

--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_dependency('listen', ['~> 3.0'])
 
   # i18n
-  s.add_dependency('i18n', ['~> 0.7'])
+  s.add_dependency('i18n', ['~> 0.8'])
 
   # Automatic Image Sizes
   s.add_dependency('fastimage', ['~> 2.0'])


### PR DESCRIPTION
This is to fix the issue that I opened here:
https://github.com/middleman/middleman/issues/2217
Just bumping i18n version to fix the security vulnerability in 0.7