### PR TITLE
Remove bundler version constraint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
       activesupport (>= 4.2, < 5.2)
       addressable (~> 2.3)
       backports (~> 3.11)
-      bundler (~> 1.1)
+      bundler
       contracts (~> 0.16.0)
       dotenv
       erubis

--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.3.0'
 
   # Core
-  s.add_dependency('bundler', ['~> 1.1'])
+  s.add_dependency('bundler')
   s.add_dependency('rack', ['>= 1.4.5', '< 3'])
   s.add_dependency('tilt', ['~> 2.0'])
   s.add_dependency('erubis')


### PR DESCRIPTION
Hey! 👋 

I'm the release manager for Bundler and I'm preparing for the upcoming Bundler 2 release. I noticed that `middleman-core` has Bundler locked to `~> 1.1`. This should be removed so that people who only have Bundler 2 installed can install your gem.

You don't have to worry about making sure your `Gemfile.lock` loads with the correct version of Bundler, it will take care of that itself.

Thanks! 