### PR TITLE
CI: Add Ruby 2.6.0 + update rubocop, nokogiri

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 cache: bundler
 rvm:
   - ruby-head
+  - 2.6.0
   - 2.5.3
   - 2.4.5
   - 2.3.8

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem 'mini_racer', '~> 0.2.4', platforms: :ruby
 gem 'therubyrhino', '>= 2.0', platforms: :jruby
 
 # Code Quality
-gem 'rubocop', '~> 0.59', require: false
+gem 'rubocop', '~> 0.61.1', require: false
 gem 'simplecov', '~> 0.10', require: false
 
 # Middleman itself

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2018.0812)
-    mini_portile2 (2.3.0)
+    mini_portile2 (2.4.0)
     mini_racer (0.2.4)
       libv8 (>= 6.3)
     minitest (5.11.3)
@@ -132,8 +132,8 @@ GEM
     multi_test (0.1.2)
     mustermann (1.0.3)
     nio4r (2.3.1)
-    nokogiri (1.8.5)
-      mini_portile2 (~> 2.3.0)
+    nokogiri (1.9.1)
+      mini_portile2 (~> 2.4.0)
     oj (3.7.1)
     padrino-helpers (0.13.3.4)
       i18n (~> 0.6, >= 0.6.7)
@@ -179,7 +179,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rubocop (0.60.0)
+    rubocop (0.61.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)
@@ -229,7 +229,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.19)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (1.4.0)
+    unicode-display_width (1.4.1)
     xpath (2.1.0)
       nokogiri (~> 1.3)
     yard (0.9.16)
@@ -256,7 +256,7 @@ DEPENDENCIES
   rake (~> 12.3)
   redcarpet (>= 3.1)
   rspec (~> 3.0)
-  rubocop (~> 0.59)
+  rubocop (~> 0.61.1)
   rubydns (~> 1.0.1)
   sassc (~> 2.0)
   simplecov (~> 0.10)
@@ -267,4 +267,4 @@ DEPENDENCIES
   yard (~> 0.9.11)
 
 BUNDLED WITH
-   1.17.1
+   1.17.3


### PR DESCRIPTION
This PR adds Ruby 2.6.0, current latest, to CI.

**Update**: The 2.6.0 build wasn't green, so I updated to the latest RuboCop, which had fixed some issues relating to safe_yaml in Psych on 2.6.0. Then, when I tried to install locally, Nokogiri was pinned at an earlier version

- [Nokogiri CHANGELOG](https://www.nokogiri.org/CHANGELOG.html)
- [RuboCop CHANGELOG](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md)

**Update 2**: Yay, now 2.6.0 is green. 🥗 

The only failure in the allowed section of the CI matrix is 2.4.5, on failing to choose a locale. This, I don't understand. Help?