### PR TITLE
Travis: remove deprecated CI option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: false
 cache: bundler
 rvm:
   - ruby-head


### PR DESCRIPTION
This PR removes a Travis option which no longer does anything.

See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration