### PR TITLE
Cherry-pick pull request #1640 to 4.2-stable (Missing Requires)

### DIFF
--- a/middleman-core/lib/middleman-core/core_extensions/default_helpers.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/default_helpers.rb
@@ -1,4 +1,11 @@
 require 'padrino-helpers'
+require 'padrino-helpers/output_helpers'
+require 'padrino-helpers/asset_tag_helpers'
+require 'padrino-helpers/form_helpers'
+require 'padrino-helpers/format_helpers'
+require 'padrino-helpers/number_helpers'
+require 'padrino-helpers/output_helpers'
+require 'padrino-helpers/render_helpers'
 require 'middleman-core/contracts'
 
 # Don't fail on invalid locale, that's not what our current

--- a/middleman-core/lib/middleman-core/meta_pages/sitemap_resource.rb
+++ b/middleman-core/lib/middleman-core/meta_pages/sitemap_resource.rb
@@ -1,4 +1,6 @@
 require 'padrino-helpers'
+require 'padrino-helpers/output_helpers'
+require 'padrino-helpers/tag_helpers'
 
 module Middleman
   module MetaPages


### PR DESCRIPTION
Hello, I was having the same issue as #1601 on Middleman 4.2.1, Windows 10, Ruby 2.3.3. Cherry-picking the changes from #1640 solved the problem on 4.2.1 as well.