### PR TITLE
Add --bail option to fail upon first error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 master
 ===
 
+* Add `--bail` to fail a build upon the first error and show the error messages. (#2246)
 * Update activesupport to 5.x and padrino to 0.14.x
 * Only SassC from now on.
 * Add `--dry-run` to run a build, but skip outputting to disk.

--- a/middleman-cli/lib/middleman-cli/build.rb
+++ b/middleman-cli/lib/middleman-cli/build.rb
@@ -28,6 +28,10 @@ module Middleman::Cli
                  type: :boolean,
                  default: false,
                  desc: 'Print debug messages'
+    class_option :bail,
+                 type: :boolean,
+                 default: false,
+                 desc: 'Fail out on the first error and print error messages'
     class_option :instrument,
                  type: :boolean,
                  default: false,
@@ -136,7 +140,9 @@ module Middleman::Cli
       case event_type
       when :error
         say_status :error, target, :red
-        shell.say extra, :red if options['verbose']
+        shell.say extra, :red if options['verbose'] || options['bail']
+
+        raise 'Build error' if options['bail']
       when :deleted
         say_status :remove, target, :green
       when :created


### PR DESCRIPTION
When a failure happens in the build step, it's often difficult to debug
with `--verbose` on because the error may have occurred in the middle of
the output.  This option now fails upon first error and shows the error
message to make it easier to diagnose and fix problems.

Closes #1924