### PR TITLE
Feature: Add an option to create asset hashes without using the original filenames as prefix

### DIFF
--- a/middleman-core/features/asset_hash.feature
+++ b/middleman-core/features/asset_hash.feature
@@ -306,3 +306,17 @@ Feature: Assets get file hashes appended to them and references to them are upda
       | javascripts/application.js.map |
 
     And the file "javascripts/application-myprefix-4553338c.js" should contain "//# sourceMappingURL=application.js-myprefix-22cc2b5f.map"
+
+  Scenario: Filenames can be removed by option
+    Given a successfully built app at "asset-hash-remove-filename"
+    When I cd to "build"
+    Then the following files should exist:
+      | index.html |
+      | javascripts/4553338c.js |
+      | javascripts/22cc2b5f.map |
+      | index.html |
+    And the following files should not exist:
+      | javascripts/application.js |
+      | javascripts/application.js.map |
+
+    And the file "javascripts/4553338c.js" should contain "//# sourceMappingURL=22cc2b5f.map"

--- a/middleman-core/fixtures/asset-hash-remove-filename/config.rb
+++ b/middleman-core/fixtures/asset-hash-remove-filename/config.rb
@@ -1,5 +1,7 @@
 activate :asset_hash,
-         remove_filename: true
+  rename_proc: -> (path, basename, digest, extension, options) {
+    "#{path}#{digest}#{extension}"
+  }
 
 activate :relative_assets
 

--- a/middleman-core/fixtures/asset-hash-remove-filename/config.rb
+++ b/middleman-core/fixtures/asset-hash-remove-filename/config.rb
@@ -1,0 +1,6 @@
+activate :asset_hash,
+         remove_filename: true
+
+activate :relative_assets
+
+activate :directory_indexes

--- a/middleman-core/fixtures/asset-hash-remove-filename/config.rb
+++ b/middleman-core/fixtures/asset-hash-remove-filename/config.rb
@@ -1,7 +1,7 @@
 activate :asset_hash,
-  rename_proc: -> (path, basename, digest, extension, options) {
-    "#{path}#{digest}#{extension}"
-  }
+         rename_proc: lambda do |path, _basename, digest, extension, _options|
+           "#{path}#{digest}#{extension}"
+         end
 
 activate :relative_assets
 

--- a/middleman-core/fixtures/asset-hash-remove-filename/source/index.html.erb
+++ b/middleman-core/fixtures/asset-hash-remove-filename/source/index.html.erb
@@ -1,0 +1,6 @@
+<% content_for :head do %>
+  <title>The Middleman!</title>
+<% end %>
+
+<h1>Testing the sitemap hashing</h1>
+<br /><br /><br />

--- a/middleman-core/fixtures/asset-hash-remove-filename/source/javascripts/application.js
+++ b/middleman-core/fixtures/asset-hash-remove-filename/source/javascripts/application.js
@@ -1,0 +1,2 @@
+function foo(){var message="HEY THERE FRIEND!";var para=document.createElement("p");para.innerHTML=message;var body=document.getElementsByTagName("body")[0];body.insertBefore(para,body.firstChild)}window.onload=foo;
+//# sourceMappingURL=application.js.map

--- a/middleman-core/fixtures/asset-hash-remove-filename/source/javascripts/application.js.map
+++ b/middleman-core/fixtures/asset-hash-remove-filename/source/javascripts/application.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["source/javascripts/application.js"],"names":["foo","message","para","document","createElement","innerHTML","body","getElementsByTagName","insertBefore","firstChild","window","onload"],"mappings":"AAAA,QAASA,OACP,GAAIC,SAAU,mBACd,IAAIC,MAAOC,SAASC,cAAc,IAClCF,MAAKG,UAAYJ,OACb,IAAIK,MAAOH,SAASI,qBAAqB,QAAQ,EAC/CD,MAAKE,aAAaN,KAAMI,KAAKG,YAGpCC,OAAOC,OAASX"}

--- a/middleman-core/fixtures/asset-hash-remove-filename/source/layout.erb
+++ b/middleman-core/fixtures/asset-hash-remove-filename/source/layout.erb
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+
+    <%= javascript_include_tag "application" %>
+    <%= yield_content :head %>
+  </head>
+
+  <body class="<%= page_classes %>">
+
+    <div id="main" role="main">
+      <%= yield %>
+    </div>
+
+  </body>
+</html>

--- a/middleman-core/lib/middleman-core/extensions/asset_hash.rb
+++ b/middleman-core/lib/middleman-core/extensions/asset_hash.rb
@@ -6,7 +6,9 @@ class Middleman::Extensions::AssetHash < ::Middleman::Extension
   option :ignore, [], 'Regexes of filenames to skip adding asset hashes to'
   option :rewrite_ignore, [], 'Regexes of filenames to skip processing for path rewrites'
   option :prefix, '', 'Prefix for hash'
-  option :remove_filename, false, 'Remove the filename of the asset, naming it with the hash only'
+  option :rename_proc, proc { |path, basename, digest, extension, options|
+    "#{path}#{basename}-#{options.prefix}#{digest}#{extension}"
+  }, 'Accepts path parameters and returns path name'
 
   def initialize(app, options_hash = ::Middleman::EMPTY_HASH, &block)
     super
@@ -92,8 +94,7 @@ class Middleman::Extensions::AssetHash < ::Middleman::Extension
 
     resource_list.update!(resource, :destination_path) do
       path, basename, extension = split_path(resource.destination_path)
-      basename = '' if options.remove_filename
-      resource.destination_path = "#{path}#{basename}#{'-' unless basename.empty?}#{options.prefix}#{digest}#{extension}"
+      resource.destination_path = options.rename_proc.call(path, basename, digest, extension, options)
     end
   end
 

--- a/middleman-core/lib/middleman-core/extensions/asset_hash.rb
+++ b/middleman-core/lib/middleman-core/extensions/asset_hash.rb
@@ -92,8 +92,8 @@ class Middleman::Extensions::AssetHash < ::Middleman::Extension
 
     resource_list.update!(resource, :destination_path) do
       path, basename, extension = split_path(resource.destination_path)
-      basename = "" if options.remove_filename
-      resource.destination_path = "#{path}#{basename}#{"-" unless basename.empty?}#{options.prefix}#{digest}#{extension}"
+      basename = '' if options.remove_filename
+      resource.destination_path = "#{path}#{basename}#{'-' unless basename.empty?}#{options.prefix}#{digest}#{extension}"
     end
   end
 
@@ -105,11 +105,12 @@ class Middleman::Extensions::AssetHash < ::Middleman::Extension
   end
 
   private
+
   # Splits resource path into path, basename and extension
   # (e.g. "/images/landscape.png" => ["/images/", "landscape", ".png]
   def split_path(filepath)
     basename = File.basename(filepath, extension = File.extname(filepath))
-    path = filepath.chomp(basename+extension)
+    path = filepath.chomp(basename + extension)
     [path, basename, extension]
   end
 end


### PR DESCRIPTION
Hi. So I added a feature I would like to have. Using the `remove_filename` option on `asset_hash` now creates assets without prefixing the filenames.

With `remove_filename: false` (default): `javascripts/application-4553338c.js`
With `remove_filename: true`: `javascripts/4553338c.js`

If you need any changes, tests or additional documentation, please just comment. Thank you for this great piece of software!