### PR TITLE
Reimplement the i18n lookup table

### DIFF
--- a/middleman-core/features/i18n_link_to.feature
+++ b/middleman-core/features/i18n_link_to.feature
@@ -230,3 +230,26 @@ Feature: i18n Paths
     Then I should see "Page Lang: Spanish"
     Then I should see 'Current: /es/article.html'
     Then I should see 'Other: /article.html'
+
+  Scenario: url_for can link to the current page in a different language with localized templates
+    Given a fixture app "empty-app"
+    And a file named "source/localizable/index.de.html.erb" with:
+      """
+      Deutsch. Die Englische Version finden Sie unter "<%= url_for current_page, locale: :en %>"
+      """
+    And a file named "source/localizable/index.en.html.erb" with:
+      """
+      English. The German version can be found at "<%= url_for current_page, locale: :de %>"
+      """
+    And a file named "config.rb" with:
+      """
+      # FIXME: Auto-discover does not work if there are no locale files.
+      activate :i18n, mount_at_root: :en, :locales => [:en, :de]
+      """
+    Given the Server is running at "empty-app"
+    When I go to "/index.html"
+    Then I should see "English"
+    Then I should see '"/de/"'
+    When I go to "/de/index.html"
+    Then I should see "Deutsch"
+    Then I should see '"/"'

--- a/middleman-core/lib/middleman-core/core_extensions/i18n.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/i18n.rb
@@ -143,7 +143,9 @@ class Middleman::CoreExtensions::Internationalization < ::Middleman::Extension
     new_resources = []
 
     file_extension_resources = resource_list.select do |resource|
-      parse_locale_extension(resource.path)
+      # Ignore resources which are outside of the localizable directory
+      File.fnmatch?(File.join(options[:templates_dir], '**'), resource.path) &&
+        parse_locale_extension(resource.path)
     end
 
     localizable_folder_resources = resource_list.select do |resource|
@@ -194,16 +196,56 @@ class Middleman::CoreExtensions::Internationalization < ::Middleman::Extension
       end
     end
 
-    @lookup = new_resources.each_with_object({}) do |desc, sum|
-      abs_path = desc.source_path.sub(options[:templates_dir], '')
+    # This generates a lookup hash that maps the real path (as seen by the web
+    # page user) to the paths of the localized versions. The lookup is later
+    # used by `url_for '/some/page.html', :locale => :en` and other url
+    # helpers.
+    #
+    # For example (given :mount_at_root => :es) and localized paths:
+    #
+    # @lookup['/en/magic/stuff.html'] = {:en => '/en/magic/stuff.html', :de => '/de/magisches/zeug.html', :es => '/magico/cosas.html'}
+    # @lookup['/de/index.html'] = {:en => '/en/index.html', :de => '/de/index.html', :es => '/index.html'}
+    # @lookup['/en/index.html'] = {:en => '/en/index.html', :de => '/de/index.html', :es => '/index.html'}
+    # @lookup['/index.html'] = {:en => '/en/index.html', :de => '/de/index.html', :es => '/index.html'}
+    #
+    # We do this by grouping by the source paths with the locales removed. All
+    # the localized pages with the same content in different languages get the
+    # same key.
+    #
+    @source_path_group = new_resources.group_by do |resource|
+      # Try to get source path without extension
+      _locale, path, _page_id = parse_locale_extension(resource.source_path)
 
-      # Process templates with locale suffix
-      locales.each do |locale|
-        abs_path = abs_path.sub(".#{locale}.", '.')
+      # If that fails, there is no extension, so we use the original path. We
+      # can not use resource.path here, because .path may be translated, so the
+      # file names do not match up.
+      path ||= resource.source_path
+
+      # This will contain the localizable/ directory, but that does not matter,
+      # because it will be contained in both alternatives above, so the
+      # grouping key will be correct.
+      path
+    end
+
+    # Then we walk this grouped hash and generate the lookup table as given
+    # above.
+    @lookup = {}
+    @source_path_group.each do |_path, resources|
+      # For each group we generate a list of the paths the user really sees
+      # (e.g. ['/en/index.html', '/de/index.html', '/index.html'])
+      exposed_paths = resources.map(&:path)
+
+      # We also generate a map with the same infos, but with the locales as keys.
+      # e.g. {:en => '/en/index.html', :de => '/de/index.html', :es => '/index.html'}
+      locale_map = resources.each_with_object({}) do |resource, map|
+        map[resource.locale] = '/' + resource.path
       end
 
-      sum[abs_path] ||= {}
-      sum[abs_path][desc.locale] = '/' + desc.path
+      # Then we add those to the lookup table, so every path has a
+      # cross-reference to any other path in other locales.
+      exposed_paths.each do |path|
+        @lookup['/' + path] = locale_map
+      end
     end
 
     new_resources.each do |r|


### PR DESCRIPTION
I have found middleman to be quite fragile when working with i18n pages. For example `link_to "This page in German", current_page, locale: :de` often just links to the same English version, for example with i18n paths.

This is due to a buggy implementation of the lookup tables used for the paths. I debugged the issue, added tests and a fix that should prove to be more robust in the field. It also seems to be faster (on my machine).