### PR TITLE
Update YARD @param name

### DIFF
--- a/middleman-cli/lib/middleman-cli/build.rb
+++ b/middleman-cli/lib/middleman-cli/build.rb
@@ -133,7 +133,7 @@ module Middleman::Cli
 
     # Handles incoming events from the builder.
     # @param [Symbol] event_type The type of event.
-    # @param [String] contents The event contents.
+    # @param [String] target The event contents.
     # @param [String] extra The extra information.
     # @return [void]
     def on_event(event_type, target, extra = nil)


### PR DESCRIPTION
This PR updates a YARD comment to avoid a warning like:

```
lib/middleman-cli/build.rb:103: [UnknownParam] @param tag has unknown parameter name: contents
```