### PR TITLE
Drop unknown YARD parameter

### DIFF
--- a/middleman-cli/lib/middleman-cli/extension.rb
+++ b/middleman-cli/lib/middleman-cli/extension.rb
@@ -24,7 +24,6 @@ module Middleman::Cli
     class_option :git, type: :boolean, default: true
 
     # The extension task
-    # @param [String] name
     def extension
       copy_file 'extension/gitignore', File.join(name, '.gitignore') unless options[:'skip-git']
       template 'extension/Rakefile', File.join(name, 'Rakefile')


### PR DESCRIPTION
This PR avoids a YARD warning:

```
lib/middleman-cli/extension.rb:27: [UnknownParam] @param tag has unknown parameter name: name
```