### PR TITLE
Remove test files from gemspec

### DIFF
--- a/middleman-cli/lib/middleman-cli/templates/extension/gemspec
+++ b/middleman-cli/lib/middleman-cli/templates/extension/gemspec
@@ -11,8 +11,7 @@ Gem::Specification.new do |s|
   # s.summary     = %q{A short summary of your extension}
   # s.description = %q{A longer description of your extension}
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.files       = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(fixtures|features|spec)/}) }
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   

--- a/middleman-cli/middleman-cli.gemspec
+++ b/middleman-cli/middleman-cli.gemspec
@@ -13,8 +13,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Hand-crafted frontend development'
   s.description = 'A static site generator. Provides dozens of templating languages (Haml, Sass, Slim, CoffeeScript, and more). Makes minification, compression, cache busting, Yaml data (and more) an easy part of your development cycle.'
 
-  s.files        = `git ls-files -z`.split("\0")
-  s.test_files   = `git ls-files -z -- {fixtures,features}/*`.split("\0")
+  s.files       = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(fixtures|features|spec)/}) }
   s.executable   = 'middleman'
   s.require_path = 'lib'
   s.required_ruby_version = '>= 2.3.0'

--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -13,8 +13,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Hand-crafted frontend development'
   s.description = 'A static site generator. Provides dozens of templating languages (Haml, Sass, Slim, CoffeeScript, and more). Makes minification, compression, cache busting, Yaml data (and more) an easy part of your development cycle.'
 
-  s.files        = `git ls-files -z`.split("\0")
-  s.test_files   = `git ls-files -z -- {fixtures,features}/*`.split("\0")
+  s.files       = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(fixtures|features|spec)/}) }
   s.require_path = 'lib'
   s.required_ruby_version = '>= 2.3.0'
 


### PR DESCRIPTION
Middleman includes specs and fixtures in a gem.
It seems they don't really serve any useful purpose https://github.com/rubygems/rubygems/issues/735 and for example excluded from [bundler generated gems](https://github.com/bundler/bundler/blob/master/lib/bundler/templates/newgem/newgem.gemspec.tt#L24-L26).

If excluded they significantly reduce size of the gems
Before
<img width="1440" alt="Screen Shot 2019-05-14 at 20 47 51" src="https://user-images.githubusercontent.com/8058230/57717327-0c937480-768c-11e9-94f9-c9f8881f9bec.png">
<img width="1410" alt="Screen Shot 2019-05-14 at 20 58 52" src="https://user-images.githubusercontent.com/8058230/57717333-1026fb80-768c-11e9-9fa7-c099120f24b0.png">
After
<img width="1260" alt="изображение" src="https://user-images.githubusercontent.com/8058230/57717381-32207e00-768c-11e9-9436-d3b22b7d032f.png">
<img width="1203" alt="Screen Shot 2019-05-14 at 20 58 47" src="https://user-images.githubusercontent.com/8058230/57717351-1ddc8100-768c-11e9-8729-6df5d088c825.png">


