### PR TITLE
Create deps.yml when --only-changed is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # master
 
+- Always write `deps.yml` if `--track-dependencies` is set and the file doesn't exist
+
 # 5.0.0.rc.1
 
 - Support NO_COLOR: https://no-color.org

--- a/middleman-core/spec/middleman-core/dependencies_spec.rb
+++ b/middleman-core/spec/middleman-core/dependencies_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+require 'middleman-core/dependencies'
+
+describe ::Middleman::Dependencies do
+  describe '.load_and_deserialize' do
+    let(:config) { { data_collection_depth: 1 } }
+    let(:app) { double(:app, config: config) }
+
+    context 'when the file is missing' do
+      before do
+        allow(File).to receive(:exist?).and_return(false)
+      end
+
+      it 'raises MissingDepsYAML' do
+        expect { described_class.load_and_deserialize(app) }
+          .to raise_error(described_class::MissingDepsYAML)
+      end
+    end
+
+    context 'when the file is present' do
+      let(:data) { { 'data_depth' => 1 } }
+
+      before do
+        allow(File).to receive(:exist?).and_return(true)
+        allow(described_class).to receive(:parse_yaml).and_return(data)
+      end
+
+      context 'when the data is invalid' do
+        let(:data) { 1 }
+
+        it 'raises InvalidDepsYAML' do
+          expect { described_class.load_and_deserialize(app) }
+            .to raise_error(described_class::InvalidDepsYAML)
+        end
+      end
+
+      context 'when the depth is different to that in the config' do
+        let(:config) { { data_collection_depth: 0 } }
+
+        it 'raises ChangedDepth' do
+          expect { described_class.load_and_deserialize(app) }
+            .to raise_error(described_class::ChangedDepth)
+        end
+      end
+
+      context 'when global files have been invalidated' do
+        before do
+          allow(described_class).to receive(:invalidated_global).and_return([1])
+        end
+
+        it 'raises InvalidatedGlobalFiles' do
+          expect { described_class.load_and_deserialize(app) }
+            .to raise_error(described_class::InvalidatedGlobalFiles)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This allows you to always run with --track-dependencies --only-changed,
and if deps.yml is missing, it will write a new one.

It also fixes a small issue where other types of failure in loading
deps.yml were always treated as a general corruption, because the errors
inherited from StandardError through RuntimeError, so they were
re-raised as the less-specific InvalidDepsYAML.

Closes https://github.com/middleman/middleman/issues/2262.