### PR TITLE
Conform generated gemspec to `bundle gem` style

### DIFF
--- a/middleman-cli/lib/middleman-cli/extension.rb
+++ b/middleman-cli/lib/middleman-cli/extension.rb
@@ -25,9 +25,14 @@ module Middleman::Cli
 
     # The extension task
     def extension
+      config = {
+        git_username: git_username,
+        git_email: git_email
+      }
+
       copy_file 'extension/gitignore', File.join(name, '.gitignore') unless options[:'skip-git']
       template 'extension/Rakefile', File.join(name, 'Rakefile')
-      template 'extension/gemspec', File.join(name, "#{name}.gemspec")
+      template 'extension/gemspec', File.join(name, "#{name}.gemspec"), config
       template 'extension/Gemfile', File.join(name, 'Gemfile')
       template 'extension/lib/lib.rb', File.join(name, 'lib', "#{name}.rb")
       template 'extension/lib/lib/extension.rb', File.join(name, 'lib', name, 'extension.rb')
@@ -37,5 +42,20 @@ module Middleman::Cli
 
     # Add to CLI
     Base.register(self, 'extension', 'extension [options]', 'Create a new Middleman extension')
+
+    private
+
+    def git_exist?
+      @git_exist = !`which git`.empty? unless defined?(@git_exist)
+      @git_exist
+    end
+
+    def git_username
+      git_exist? ? `git config user.name`.chomp : ''
+    end
+
+    def git_email
+      git_exist? ? `git config user.email`.chomp : ''
+    end
   end
 end

--- a/middleman-cli/lib/middleman-cli/templates/extension/gemspec
+++ b/middleman-cli/lib/middleman-cli/templates/extension/gemspec
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|

--- a/middleman-cli/lib/middleman-cli/templates/extension/gemspec
+++ b/middleman-cli/lib/middleman-cli/templates/extension/gemspec
@@ -4,8 +4,8 @@ Gem::Specification.new do |s|
   s.name        = "<%= name %>"
   s.version     = "0.0.1"
   s.platform    = Gem::Platform::RUBY
-  # s.authors     = ["Your Name"]
-  # s.email       = ["email@example.com"]
+  s.authors     = ["<%= config[:git_username] %>"]
+  s.email       = ["<%= config[:git_email] %>"]
   s.homepage    = "TODO: Put your gem's website or public repo URL here."
   s.summary     = %q{TODO: A short summary of your extension}
   s.description = %q{TODO: A longer description of your extension}

--- a/middleman-cli/lib/middleman-cli/templates/extension/gemspec
+++ b/middleman-cli/lib/middleman-cli/templates/extension/gemspec
@@ -6,9 +6,9 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   # s.authors     = ["Your Name"]
   # s.email       = ["email@example.com"]
-  # s.homepage    = "http://example.com"
-  # s.summary     = %q{A short summary of your extension}
-  # s.description = %q{A longer description of your extension}
+  s.homepage    = "TODO: Put your gem's website or public repo URL here."
+  s.summary     = %q{TODO: A short summary of your extension}
+  s.description = %q{TODO: A longer description of your extension}
 
   s.files       = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(fixtures|features|spec)/}) }
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
## Motivation
In executing `$ bundle gem`, gemspec contains git `user.name` and `user.email` automatically. 
And place `TODO` to the field to must update. It's very useful.

## Changes
- remove obsoleteness magic comment
    - 	`# -*- encoding: utf-8 -*-`
- authors and email from git config
- uncomment and add `TODO` to homepage, summary, and description