### PR TITLE
Fix failing spec when run as individually

### DIFF
--- a/middleman-core/lib/middleman-core/core_extensions/data/proxies/base.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/data/proxies/base.rb
@@ -63,6 +63,9 @@ module Middleman
           end
 
           def wrap_data(key, data)
+            require_relative 'hash'
+            require_relative 'array'
+
             if @depth >= @data_collection_depth
               log_access(:__full_access__)
               ::Middleman::Util.recursively_enhance(data)

--- a/middleman-core/lib/middleman-core/dns_resolver.rb
+++ b/middleman-core/lib/middleman-core/dns_resolver.rb
@@ -1,6 +1,7 @@
 require 'resolv'
 require 'middleman-core/dns_resolver/network_resolver'
 require 'middleman-core/dns_resolver/hosts_resolver'
+require 'middleman-core/util/empty_hash'
 
 module Middleman
   # This resolves IP address to names and vice versa


### PR DESCRIPTION
## Step to reproduce
```shell
$ cd middleman-core
$ bundle exec rspec spec/middleman-core/dns_resolver_spec.rb
```
![Screenshot from 2019-10-16 01-19-59](https://user-images.githubusercontent.com/4487291/66850117-19a5ee00-efb3-11e9-93ce-3fb085a6c287.png)


```shell
$ cd middleman-core
$ bundle exec rspec spec/middleman-core/data_proxy_spec.rb
```
![Screenshot from 2019-10-16 01-19-21](https://user-images.githubusercontent.com/4487291/66850067-03982d80-efb3-11e9-927f-2dc41fc6d16f.png)

##  Why failed?
### `spec/middleman-core/dns_resolver_spec.rb`
```
1) Middleman::DnsResolver#names_for when hosts resolver can resolve name should not receive getnames(*(any args)) 0 times
   Failure/Error:
     def initialize(options_hash = ::Middleman::EMPTY_HASH)
       # using the splat operator works around a non-existing HOSTSRC variable
       # using nil as input does not work, but `*[]` does and then Resolv::Hosts
       # uses its defaults
       @resolver = options_hash.fetch(:resolver, Resolv::Hosts.new(*hosts_file))
     end

   NameError:
     uninitialized constant Middleman::EMPTY_HASH
   # ./lib/middleman-core/dns_resolver/hosts_resolver.rb:11:in `initialize'
   # ./lib/middleman-core/dns_resolver.rb:32:in `new'
   # ./lib/middleman-core/dns_resolver.rb:32:in `initialize'
   # ./spec/middleman-core/dns_resolver_spec.rb:6:in `new'
   # ./spec/middleman-core/dns_resolver_spec.rb:6:in `block (2 levels) in <top (required)>'
   # ./spec/middleman-core/dns_resolver_spec.rb:32:in `block (4 levels) in <top (required)>'
```

### `spec/middleman-core/data_proxy_spec.rb`
```
1) Middleman::CoreExtensions::Data::Proxies::HashProxy#data_proxy logs sub array access slices
   Failure/Error: ArrayProxy.new(key, data, @data_collection_depth, self)

   NameError:
     uninitialized constant Middleman::CoreExtensions::Data::Proxies::BaseProxy::ArrayProxy
   # ./lib/middleman-core/core_extensions/data/proxies/base.rb:72:in `wrap_data'
   # ./lib/middleman-core/core_extensions/data/proxies/hash.rb:13:in `[]'
   # ./lib/middleman-core/core_extensions/data/proxies/hash.rb:22:in `method_missing'
   # ./spec/middleman-core/data_proxy_spec.rb:102:in `block (3 levels) in <top (required)>'
```

---

So I supplied missing `require` to fix failing spec when run as individually.