### PR TITLE
Run test on Windows by AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,24 @@
+cache:
+  - vendor/bundle
+
+environment:
+  matrix:
+    - RUBY_VERSION: 26-x64
+    - RUBY_VERSION: 25-x64
+init:
+  - git config --global core.autocrlf true
+
+install:
+  - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+  - bundle config --local path vendor/bundle
+  - bundle install
+
+build: off
+
+before_test:
+  - ruby -v
+  - gem -v
+  - bundle -v
+
+test_script:
+  - bundle exec rake

--- a/gem_rake_helper.rb
+++ b/gem_rake_helper.rb
@@ -17,7 +17,11 @@ end
 
 require 'cucumber/rake/task'
 Cucumber::Rake::Task.new do |t|
-  exempt_tags = ["--tags 'not @wip'"]
+  exempt_tags = if Gem.win_platform?
+                  ["--tags 'not(@wip or @skip-windows)'"]
+                else
+                  ["--tags 'not @wip'"]
+                end
   t.cucumber_opts = "--fail-fast --require features --color #{exempt_tags.join(' ')} --strict"
 end
 

--- a/middleman-cli/features/preview_server-hook.feature
+++ b/middleman-cli/features/preview_server-hook.feature
@@ -1,3 +1,4 @@
+@skip-windows
 Feature: Run preview server before hook
 
   Scenario: When run

--- a/middleman-cli/features/preview_server.feature
+++ b/middleman-cli/features/preview_server.feature
@@ -1,3 +1,4 @@
+@skip-windows
 Feature: Run the preview server
 
   As a software developer

--- a/middleman-core/features/automatic_directory_matcher.feature
+++ b/middleman-core/features/automatic_directory_matcher.feature
@@ -1,3 +1,4 @@
+@skip-windows
 Feature: Map special characters to automatically put files in a directory
   
   Scenario: Building files with special character escape

--- a/middleman-core/features/coffee-script.feature
+++ b/middleman-core/features/coffee-script.feature
@@ -1,3 +1,4 @@
+@skip-windows
 Feature: Support coffee-script
   In order to offer an alternative when writing JavaScript
 

--- a/middleman-core/features/sass-assets-paths.feature
+++ b/middleman-core/features/sass-assets-paths.feature
@@ -1,3 +1,4 @@
+@skip-windows
 Feature: Support SASS assets paths
  In order to import common shared assets when writing Sass
 

--- a/middleman-core/features/scss-support.feature
+++ b/middleman-core/features/scss-support.feature
@@ -11,6 +11,7 @@ Feature: Support SCSS Syntax
    When I go to "/stylesheets/layout.css"
    Then I should see "html"
 
+@skip-windows
  Scenario: Rendering scss errors
    Given the Server is running at "scss-app"
    When I go to "/stylesheets/error.css"

--- a/middleman-core/features/slim.feature
+++ b/middleman-core/features/slim.feature
@@ -28,6 +28,7 @@ Feature: Support slim templating language
     Then I should see "Content for main:Content Main"
     Then I should see "Content for B:Content B"
 
+  @skip-windows
   Scenario: Rendering Scss in a Slim filter
     Given an empty app
     And a file named "config.rb" with:

--- a/middleman-core/features/stylus.feature
+++ b/middleman-core/features/stylus.feature
@@ -1,3 +1,4 @@
+@skip-windows
 Feature: Stylus Updates and Partials
   Scenario: The preview server should update stylesheets when Stylus changes
     Given the Server is running at "stylus-preview-app"

--- a/middleman-core/spec/support/given.rb
+++ b/middleman-core/spec/support/given.rb
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 module Given
   ROOT = File.expand_path('../..', __dir__)
   TMP  = File.join(ROOT, 'tmp')
@@ -6,7 +8,8 @@ module Given
     def fixture(name)
       cleanup!
 
-      `rsync -av #{File.join(ROOT, 'fixtures', name)}/ #{TMP}/`
+      FileUtils.cp_r(File.join(ROOT, 'fixtures', name), TMP)
+
       Dir.chdir TMP
       ENV['MM_ROOT'] = TMP
     end
@@ -32,7 +35,8 @@ module Given
 
     def cleanup!
       Dir.chdir ROOT
-      `rm -rf #{TMP}` if File.exist? TMP
+
+      FileUtils.remove_entry_secure(TMP) if File.exist? TMP
     end
   end
 end


### PR DESCRIPTION
## Purpose
Middleman supports using on Windows. That's described in README.

But the test suite is checked only Linux platform by Travis CI.
So, I add appveyor.yml to run the test on Windows for check Middleman behavior on windows.
![Screenshot from 2019-10-17 23-19-43](https://user-images.githubusercontent.com/4487291/67017366-9f9d7280-f134-11e9-96ea-f87871d1c3fe.png)
https://ci.appveyor.com/project/unasuke/middleman

## Why not GitHub Actions?
Yes, yes. I tried GitHub Actions at first. But it's still a public beta, cannot complete the test suite as correctly.

- https://github.com/unasuke/middleman/commits/github_action
- https://github.com/unasuke/middleman/runs/263654211

![Screenshot from 2019-10-17 23-21-09](https://user-images.githubusercontent.com/4487291/67017498-d7a4b580-f134-11e9-932b-d150fa38f1fb.png)
