### PR TITLE
URI.decode/encode is obsoleted. Use WEBrick::HTTPUtils.escape/unescape

### DIFF
--- a/middleman-core/lib/middleman-core/rack.rb
+++ b/middleman-core/lib/middleman-core/rack.rb
@@ -8,6 +8,8 @@ require 'middleman-core/util'
 require 'middleman-core/logger'
 require 'middleman-core/template_renderer'
 
+require 'webrick'
+
 # CSSPIE HTC File
 ::Rack::Mime::MIME_TYPES['.htc'] = 'text/x-component'
 
@@ -86,7 +88,7 @@ module Middleman
     def process_request(env, req, res)
       start_time = Time.now
 
-      request_path = URI.decode(env['PATH_INFO'].dup)
+      request_path = WEBrick::HTTPUtils.unescape(env['PATH_INFO'].dup)
       request_path.force_encoding('UTF-8') if request_path.respond_to? :force_encoding
       request_path = ::Middleman::Util.full_path(request_path, @middleman)
       full_request_path = File.join(env['SCRIPT_NAME'], request_path) # Path including rack mount

--- a/middleman-core/lib/middleman-core/step_definitions/server_steps.rb
+++ b/middleman-core/lib/middleman-core/step_definitions/server_steps.rb
@@ -1,6 +1,7 @@
 require 'middleman-core/rack'
 require 'rspec/expectations'
 require 'capybara/cucumber'
+require 'webrick'
 
 Given /^a clean server$/ do
   @initialize_commands = []
@@ -74,11 +75,11 @@ Given /^a template named "([^\"]*)" with:$/ do |name, string|
 end
 
 When /^I go to "([^\"]*)"$/ do |url|
-  visit(URI.encode(url).to_s)
+  visit(WEBrick::HTTPUtils.escape(url))
 end
 
 Then /^going to "([^\"]*)" should not raise an exception$/ do |url|
-  expect { visit(URI.encode(url).to_s) }.to_not raise_exception
+  expect { visit(WEBrick::HTTPUtils.escape(url)) }.to_not raise_exception
 end
 
 Then /^the content type should be "([^\"]*)"$/ do |expected|

--- a/middleman-core/lib/middleman-core/util/paths.rb
+++ b/middleman-core/lib/middleman-core/util/paths.rb
@@ -1,10 +1,10 @@
 # Core Pathname library used for traversal
 require 'pathname'
-require 'uri'
 require 'addressable/uri'
 require 'memoist'
 require 'tilt'
 require 'set'
+require 'webrick'
 
 require 'middleman-core/contracts'
 
@@ -35,7 +35,7 @@ module Middleman
       return path unless path.is_a?(String)
 
       # The tr call works around a bug in Ruby's Unicode handling
-      ::URI.decode(path).sub(%r{^/}, '').tr('', '')
+      WEBrick::HTTPUtils.unescape(path).sub(%r{^/}, '').tr('', '')
     end
     memoize :normalize_path
 


### PR DESCRIPTION
URI.escape/unescape is obsoleted.
This methods are following RFC 2396.
However, RFC 2396 was obsoleted by RFC 3986.

* https://tools.ietf.org/html/rfc2396
* https://tools.ietf.org/html/rfc3986

Ruby core team says "Instead, use CGI.escape, URI.encode_www_form or URI.encode_www_form_component" but those methods are incompatible between URI.escape/unescape.

So, I choose WEBrick::HTTPUtils.escape/unescape instead, its compatible with URI.escape/unescape.

We need take off this obsoleted rfc dependent behavior in the future.

It shows many warning messages in Ruby 2.7.