### PR TITLE
Replace aruba's deprecated method to the new method

### DIFF
--- a/middleman-core/lib/middleman-core/step_definitions/commandline_steps.rb
+++ b/middleman-core/lib/middleman-core/step_definitions/commandline_steps.rb
@@ -14,8 +14,8 @@ When /^I stop (?:middleman|all commands) if the output( of the last command)? co
 rescue ChildProcess::TimeoutError, TimeoutError
   @interactive.terminate
 ensure
-  announcer.stdout @interactive.stdout
-  announcer.stderr @interactive.stderr
+  aruba.announcer.stdout @interactive.stdout
+  aruba.announcer.stderr @interactive.stderr
 end
 
 # Make it just a long running process

--- a/middleman-core/lib/middleman-core/step_definitions/commandline_steps.rb
+++ b/middleman-core/lib/middleman-core/step_definitions/commandline_steps.rb
@@ -47,7 +47,7 @@ Given /I start a dns server with:/ do |string|
     )
   )
 
-  set_environment_variable 'PATH', File.expand_path(File.join(current_dir, 'bin')) + ':' + ENV['PATH']
+  set_environment_variable 'PATH', File.expand_path(File.join(expand_path('.'), 'bin')) + ':' + ENV['PATH']
   write_file db_file, string
 
   @dns_server = run_command("dns_server.rb #{db_file} #{port}", timeout: 120)
@@ -66,7 +66,7 @@ Given /I start a mdns server with:/ do |string|
     )
   )
 
-  set_environment_variable 'PATH', File.expand_path(File.join(current_dir, 'bin')) + ':' + ENV['PATH']
+  set_environment_variable 'PATH', File.expand_path(File.join(expand_path('.'), 'bin')) + ':' + ENV['PATH']
   write_file db_file, string
 
   @mdns_server = run_command("dns_server.rb #{db_file} #{port}", timeout: 120)

--- a/middleman-core/lib/middleman-core/step_definitions/commandline_steps.rb
+++ b/middleman-core/lib/middleman-core/step_definitions/commandline_steps.rb
@@ -20,7 +20,7 @@ end
 
 # Make it just a long running process
 Given /`(.*?)` is running in background/ do |cmd|
-  run(cmd, 120)
+  run_command(cmd, timeout: 120)
 end
 
 Given /I have a local hosts file with:/ do |string|
@@ -50,7 +50,7 @@ Given /I start a dns server with:/ do |string|
   set_env 'PATH', File.expand_path(File.join(current_dir, 'bin')) + ':' + ENV['PATH']
   write_file db_file, string
 
-  @dns_server = run("dns_server.rb #{db_file} #{port}", 120)
+  @dns_server = run_command("dns_server.rb #{db_file} #{port}", timeout: 120)
 end
 
 Given /I start a mdns server with:/ do |string|
@@ -69,7 +69,7 @@ Given /I start a mdns server with:/ do |string|
   set_env 'PATH', File.expand_path(File.join(current_dir, 'bin')) + ':' + ENV['PATH']
   write_file db_file, string
 
-  @mdns_server = run("dns_server.rb #{db_file} #{port}", 120)
+  @mdns_server = run_command("dns_server.rb #{db_file} #{port}", timeout: 120)
 end
 
 Given /I start a mdns server for the local hostname/ do

--- a/middleman-core/lib/middleman-core/step_definitions/commandline_steps.rb
+++ b/middleman-core/lib/middleman-core/step_definitions/commandline_steps.rb
@@ -47,7 +47,7 @@ Given /I start a dns server with:/ do |string|
     )
   )
 
-  set_env 'PATH', File.expand_path(File.join(current_dir, 'bin')) + ':' + ENV['PATH']
+  set_environment_variable 'PATH', File.expand_path(File.join(current_dir, 'bin')) + ':' + ENV['PATH']
   write_file db_file, string
 
   @dns_server = run_command("dns_server.rb #{db_file} #{port}", timeout: 120)
@@ -66,7 +66,7 @@ Given /I start a mdns server with:/ do |string|
     )
   )
 
-  set_env 'PATH', File.expand_path(File.join(current_dir, 'bin')) + ':' + ENV['PATH']
+  set_environment_variable 'PATH', File.expand_path(File.join(current_dir, 'bin')) + ':' + ENV['PATH']
   write_file db_file, string
 
   @mdns_server = run_command("dns_server.rb #{db_file} #{port}", timeout: 120)


### PR DESCRIPTION
Those four APIs are now deprecated.
So I replaced to the new APIs.

1. `#run`
    -  https://github.com/cucumber/aruba/commit/507b353b678b
1. `#set_env`
    - https://github.com/cucumber/aruba/commit/663991ec7
1. `#current_dir`
    - https://github.com/cucumber/aruba/commit/802c4ec242
1. `#announcer`
    - https://github.com/cucumber/aruba/commit/7f8a155c89