### PR TITLE
Remove Backports

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,6 @@ PATH
     middleman-core (5.0.0.rc.1)
       activesupport (~> 5.2)
       addressable (~> 2.3)
-      backports (~> 3.11)
       bundler
       contracts (~> 0.16.0)
       dotenv

--- a/middleman-cli/features/support/env.rb
+++ b/middleman-cli/features/support/env.rb
@@ -1,6 +1,5 @@
 ENV['TEST'] = 'true'
 
-require 'backports/latest'
 require 'active_support/all'
 
 require 'sassc'

--- a/middleman-core/features/support/env.rb
+++ b/middleman-core/features/support/env.rb
@@ -1,6 +1,5 @@
 ENV['TEST'] = 'true'
 
-require 'backports/latest'
 require 'active_support/all'
 
 require 'sassc'

--- a/middleman-core/lib/middleman-core.rb
+++ b/middleman-core/lib/middleman-core.rb
@@ -2,7 +2,6 @@
 libdir = __dir__
 $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 
-require 'backports/latest'
 require 'active_support/all'
 
 # Top-level Middleman namespace

--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |s|
   s.add_dependency('padrino-helpers', ['~> 0.14.4'])
   s.add_dependency('addressable', ['~> 2.3'])
   s.add_dependency('memoist', ['~> 0.14'])
-  s.add_dependency('backports', ['~> 3.11'])
 
   # Watcher
   s.add_dependency('listen', ['~> 3.0'])

--- a/middleman-core/spec/spec_helper.rb
+++ b/middleman-core/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-require 'backports/latest'
 require 'active_support/all'
 
 require 'simplecov'


### PR DESCRIPTION
## Motivation

This resolves #2314 by removing Backports altogether.

## Changes
- Removed dependency on Backports.

## Notes

I ran all tests with Ruby 2.5.0 and they passed, so I would think Backports might not be needed anymore after all. If you know of places where it might be needed, we should add tests for that and import the needed backport explicitly.