### PR TITLE
Reset Content-Length header when rewriting bodies

### DIFF
--- a/middleman-core/lib/middleman-core/core_extensions/inline_url_rewriter.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/inline_url_rewriter.rb
@@ -123,6 +123,11 @@ module Middleman
             end
           end
 
+          # Rewriting might have changed Content-Length, so we need
+          # to reset it to the actual result. The rewritten result is
+          # always a String, not an Array or Enumerable.
+          headers['Content-Length'] = rewritten.bytesize.to_s
+
           ::Rack::Response.new(
             rewritten,
             status,


### PR DESCRIPTION
When rewriting the body output the string length might change, so after applying rewrites we need to forcibly reset the `Content-Length` header to the actual value.

Note that no tests are present since

a) Tests are pretty minimal for the 4.x branch
b) The 4.x branch is no longer mainline

Closes #2309