### PR TITLE
Delete erroneous documentation of server? / build?

### DIFF
--- a/middleman-core/lib/middleman-core/application.rb
+++ b/middleman-core/lib/middleman-core/application.rb
@@ -359,14 +359,14 @@ module Middleman
     end
 
     # Whether we're in server mode
-    # @return [Boolean] If we're in dev mode
+    # @return [Boolean]
     Contract Bool
     def server?
       mode?(:server)
     end
 
     # Whether we're in build mode
-    # @return [Boolean] If we're in dev mode
+    # @return [Boolean]
     Contract Bool
     def build?
       mode?(:build)


### PR DESCRIPTION
Return value documentation was incorrect. As other Boolean return values are not explicitly documented, I just deleted it.