### PR TITLE
Remove reference to unused reload_paths option

### DIFF
--- a/middleman-cli/lib/middleman-cli/server.rb
+++ b/middleman-cli/lib/middleman-cli/server.rb
@@ -45,7 +45,6 @@ module Middleman::Cli
       params = {
         debug: options['verbose'],
         instrumenting: options['instrument'],
-        reload_paths: options['reload_paths'],
         daemon: options['daemon']
       }
 


### PR DESCRIPTION
The option was removed in bedf235ff68998c0fd87f7531c860f82381312c2. However, it wasn't deleted from the params hash, so a nil value is always being passed in.