### PR TITLE
Loosen activesupport dependence for security fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
   remote: middleman-core
   specs:
     middleman-core (4.3.6)
-      activesupport (>= 4.2, < 5.1)
+      activesupport (>= 4.2, < 6.0)
       addressable (~> 2.3)
       backports (~> 3.6)
       bundler
@@ -34,7 +34,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.0.7.2)
+    activesupport (5.2.4.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)

--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency('dotenv')
 
   # Helpers
-  s.add_dependency('activesupport', ['>= 4.2', '< 5.1'])
+  s.add_dependency('activesupport', ['>= 4.2', '< 6.0'])
   s.add_dependency('padrino-helpers', ['~> 0.13.0'])
   s.add_dependency("addressable", ["~> 2.3"])
   s.add_dependency('memoist', ['~> 0.14'])


### PR DESCRIPTION
### What
Change the maximum version of `activesupport` required to be any `5.x` version, bringing the dependency back inline prior to it being restricted in commit ea2115f3f87d6e881fe9517dc65735c96735faf3.

### Why
There is a vulnerability reported in `activesupport` that is fixed in version `5.2.4.3`, which `middleman-core` does not allow to be used due to its `< 5.1` version requirement. The vulnerability is [`CVE-2020-8165`].

Prior to commit ea2115f3f87d6e881fe9517dc65735c96735faf3 any `5.x` version was allowed because the dependency was defined as `~> 5.0`, however in that commit that intended to loosen the minimum dependency it appears the maximum dependency was tightened. There is no explanation in the commit or its related PR #1976 about this so it could have been an accident.

Fix #2326

[`CVE-2020-8165`]: https://github.com/advisories/GHSA-2p68-f74v-9wc6