### PR TITLE
Test building of redirects

### DIFF
--- a/middleman-core/features/redirects.feature
+++ b/middleman-core/features/redirects.feature
@@ -60,3 +60,7 @@ Feature: Meta redirects
     And the Server is running at "large-build-app"
     When I go to "/hello.html"
     Then I should see 'hello.html to world.html'
+
+  Scenario: Build a redirect
+    Given a successfully built app at "redirect-app"
+    Then the file "build/external.html" should contain '<meta http-equiv=refresh content="0; url=http://example.com"'

--- a/middleman-core/fixtures/redirect-app/config.rb
+++ b/middleman-core/fixtures/redirect-app/config.rb
@@ -1,0 +1,1 @@
+redirect 'external.html', to: 'http://example.com'

--- a/middleman-core/lib/middleman-core/builder.rb
+++ b/middleman-core/lib/middleman-core/builder.rb
@@ -365,20 +365,23 @@ module Middleman
             export_file!(output_file, resource.file_descriptor[:full_path], true)
           else
             content = resource.render({}, {})
+            if resource.file_descriptor.nil?
+              edge = nil
+            else
+              self_vertex = ::Middleman::Dependencies::FileVertex.from_resource(resource)
 
-            self_vertex = ::Middleman::Dependencies::FileVertex.from_resource(resource)
-
-            edge = if serialize_deps
-                     {
-                       self_vertex: self_vertex.serialize,
-                       depends_on: resource.vertices.map(&:serialize)
-                     }
-                   else
-                     ::Middleman::Dependencies::Edge.new(
-                       self_vertex,
-                       resource.vertices << self_vertex
-                     )
-                   end
+              edge = if serialize_deps
+                       {
+                         self_vertex: self_vertex.serialize,
+                         depends_on: resource.vertices.map(&:serialize)
+                       }
+                     else
+                       ::Middleman::Dependencies::Edge.new(
+                         self_vertex,
+                         resource.vertices << self_vertex
+                       )
+                     end
+            end
 
             export_file!(output_file, binary_encode(content))
           end


### PR DESCRIPTION
This is currently broken in master. Before looking further into it myself, I wonder if anyone else who is more familiar with the codebase can take a quick look, and see if it is something obvious?

Regarding my implementation of the test, I noticed that while the redirect feature makes use of the step

```
And a file named "config.rb" with:
"""
redirect "hello.html", to: "world.html"
"""
```

It seems impossible to make use of this when building an an app, so I created a new fixture. Given that I have this fixture, does it make sense to convert the rest of the scenarios to use it (i.e., is a using fixtures preferred over using the  `a file named "config.rb" with:` step)?