### PR TITLE
Remove an unused constant

### DIFF
--- a/middleman-core/lib/middleman-core/sources.rb
+++ b/middleman-core/lib/middleman-core/sources.rb
@@ -27,9 +27,6 @@ module Middleman
     # Types which could cause output to change.
     OUTPUT_TYPES = %i[source locales data].freeze
 
-    # Types which require a reload to eval ruby
-    CODE_TYPES = [:reload].freeze
-
     Matcher = Or[Regexp, RespondTo[:call]]
 
     # A reference to the current app.


### PR DESCRIPTION
It was added in 0e620a1ba194d11b0bb2a90535e05f6d87ec1b12, but never used.