### PR TITLE
Require padrino-helpers as they are used in file

### DIFF
--- a/middleman-core/lib/middleman-core/extensions/gzip.rb
+++ b/middleman-core/lib/middleman-core/extensions/gzip.rb
@@ -1,3 +1,5 @@
+require 'padrino-helpers'
+
 # This extension Gzips assets and pages when building.
 # Gzipped assets and pages can be served directly by Apache or
 # Nginx with the proper configuration, and pre-zipping means that we


### PR DESCRIPTION
Without this, running `cucumber features/i18n_preview.feature` would fail.