### PR TITLE
Reference contribution guidelines in README

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -35,12 +35,26 @@ Ideally, a bug report should include a pull request with failing specs.
 1. [Fork the repository.][fork]
 2. Create a topic [branch]. `git checkout -b local_topic_branch`
 3. Add specs for your unimplemented feature or bug fix.
-4. Run `bundle exec rake test`. If your specs pass, return to step 3.
+4. [Run the tests](#running-the-tests). If your specs pass, return to step 3.
 5. Implement your feature or bug fix.
-6. Run `bundle exec rake test`. If your specs fail, return to step 5.
+6. Run the tests. If your specs fail, return to step 5.
 7. Add, commit, and push your changes. To push your topic branch use `git push -u origin local_topic_branch`.
 8. [Submit a pull request.][pr]
 
 [fork]: http://help.github.com/fork-a-repo/
 [branch]: https://help.github.com/articles/fork-a-repo#create-branches
 [pr]: http://help.github.com/send-pull-requests/
+
+## Testing
+
+Internally, we test Middleman using a combination of [Cucumber][cucumber] and [RSpec][rspec]. Cucumber is used for specifying behavior a high level, whereas RSpec is used for testing components in isolation.
+
+### Running the tests
+
+1. Checkout Repository: `git clone https://github.com/middleman/middleman.git`
+2. Install Bundler: `gem install bundler`
+3. Run `bundle install` inside the project root to install the gem dependencies.
+4. Run test cases: `bundle exec rake test`
+
+[cucumber]: https://cucumber.io/
+[rspec]: https://rspec.info/

--- a/README.md
+++ b/README.md
@@ -69,18 +69,9 @@ Additionally, up-to-date generated code documentation is available on [RubyDoc]
 
 The official community forum is available at: http://forum.middlemanapp.com
 
-## Bug Reports
+## Contributing to Middleman
 
-Github Issues are used for managing bug reports and feature requests. If you run into issues, please search the issues and submit new problems: https://github.com/middleman/middleman/issues
-
-The best way to get quick responses to your issues and swift fixes to your bugs is to submit detailed bug reports, include test cases and respond to developer questions in a timely manner. Even better, if you know Ruby, you can submit [Pull Requests](https://help.github.com/articles/using-pull-requests) containing Cucumber Features which describe how your feature should work or exploit the bug you are submitting.
-
-## How to Run Cucumber Tests
-
-1. Checkout Repository: `git clone https://github.com/middleman/middleman.git`
-2. Install Bundler: `gem install bundler`
-3. Run `bundle install` inside the project root to install the gem dependencies.
-4. Run test cases: `bundle exec rake test`
+Contributions are welcomed! To get started, please see our [contribution guidelines](https://github.com/middleman/middleman/blob/master/.github/CONTRIBUTING.md), which include information on [submitting bug reports](https://github.com/middleman/middleman/blob/master/.github/CONTRIBUTING.md#submitting-an-issue), and [running the tests](https://github.com/middleman/middleman/blob/master/.github/CONTRIBUTING.md#testing).
 
 ## Donate
 


### PR DESCRIPTION
Information is duplicated between the two. I think it is simpler to keep the README focused on a Middleman user's perspective, whereas CONTRIBUTING.md can focus on a contributor's perspective.

My motivation for this is that I'd like to later add more extensive documentation about testing Middleman from a contributor's perspective, but doing this in the README seemed like it would bloat it too much.