### PR TITLE
Use travis-ci's rvm aliases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: ruby
 cache: bundler
 rvm:
   - ruby-head
-  - 2.7.0
-  - 2.6.3
-  - 2.5.5
+  - 2.7
+  - 2.6
+  - 2.5
 os:
   - linux
 matrix:


### PR DESCRIPTION
This way, we don't need to upgrade our .travis.yml when a new minor version is released.