### PR TITLE
Remove tag for ruby less than 2.1

### DIFF
--- a/middleman-cli/features/preview_server.feature
+++ b/middleman-cli/features/preview_server.feature
@@ -471,7 +471,6 @@ Feature: Run the preview server
     Inspect your site configuration at "http://www.example.com:4567/__middleman", "http://127.0.0.1:4567/__middleman"
     """
 
-  @ruby-2.1
   @wip
   Scenario: Start the server with server name "host.local" and the link local name server is used to resolve the server name
 
@@ -504,7 +503,6 @@ Feature: Run the preview server
     Inspect your site configuration at "http://host.local:4567/__middleman", "http://127.0.0.1:4567/__middleman"
     """
 
-  @ruby-2.1
   @wip
   Scenario: Start the server with server name "host" and the link local name server is used to resolve the server name
 

--- a/middleman-core/lib/middleman-core/step_definitions/commandline_steps.rb
+++ b/middleman-core/lib/middleman-core/step_definitions/commandline_steps.rb
@@ -80,7 +80,3 @@ end
 After do
   all_commands.each(&:terminate)
 end
-
-Before '@ruby-2.1' do
-  skip_this_scenario if RUBY_VERSION < '2.1'
-end


### PR DESCRIPTION
Minimum Ruby version is currently 2.5, so this is no longer relevant.