### PR TITLE
Trigger a reload for the preview server when data changes

### DIFF
--- a/middleman-cli/features/preview_server.feature
+++ b/middleman-cli/features/preview_server.feature
@@ -553,3 +553,26 @@ Feature: Run the preview server
       """
       The Middleman is reloading
       """
+
+  Scenario: Server reloads when data changes
+    When I run `middleman server --verbose` interactively
+    And a file named "data/people.yml" with:
+      """
+      - Tom
+      """
+    And I wait for the output to contain:
+      """
+      The Middleman is running
+      """
+    When a file named "data/people.yml" with:
+      """
+      - Bob
+      """
+    And I stop middleman if the output contains:
+      """
+      The Middleman is reloading
+      """
+    Then the output should contain:
+      """
+      The Middleman is reloading
+      """

--- a/middleman-core/lib/middleman-core/core_extensions/data.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/data.rb
@@ -46,9 +46,11 @@ module Middleman
 
         Contract Any
         def after_configuration
-          return unless @original_data_dir != app.config[:data_dir]
+          @watcher.update_path(app.config[:data_dir]) if @original_data_dir != app.config[:data_dir]
 
-          @watcher.update_path(app.config[:data_dir])
+          app.files.watch :reload,
+                          path: File.expand_path(@watcher.directory, app.root),
+                          only: DATA_FILE_MATCHER
         end
       end
     end


### PR DESCRIPTION
Resolves #2329. Without this, proxy pages that were passed data as a local weren't being loaded when the data changed.