### PR TITLE
Cleanup of how fixtures customize a fixture 

### DIFF
--- a/middleman-core/features/asset_hash.feature
+++ b/middleman-core/features/asset_hash.feature
@@ -117,7 +117,7 @@ Feature: Assets get file hashes appended to them and references to them are upda
       activate :directory_indexes
       activate :asset_host, host: 'https://middlemanapp.com'
       """
-    Given the Server is running at "asset-hash-host-app"
+    Given the Server is running
     When I go to "/"
     Then I should see 'href="https://middlemanapp.com/stylesheets/site-7474cadd.css"'
     Then I should see 'href="https://middlemanapp.com/stylesheets/fragment-2902933e.css"'
@@ -149,7 +149,7 @@ Feature: Assets get file hashes appended to them and references to them are upda
       activate :directory_indexes
       activate :asset_hash
       """
-    Given the Server is running at "asset-hash-host-app"
+    Given the Server is running
     When I go to "/"
     Then I should see 'href="https://middlemanapp.com/stylesheets/site-7474cadd.css"'
     Then I should see 'href="https://middlemanapp.com/stylesheets/fragment-2902933e.css"'

--- a/middleman-core/features/automatic_image_sizes.feature
+++ b/middleman-core/features/automatic_image_sizes.feature
@@ -6,7 +6,7 @@ Feature: Automatically detect and insert image dimensions into tags
     And a file named "config.rb" with:
       """
       """
-    And the Server is running at "automatic-image-size-app"
+    And the Server is running
     When I go to "/auto-image-sizes.html"
     Then I should not see "width="
     And I should not see "height="
@@ -20,7 +20,7 @@ Feature: Automatically detect and insert image dimensions into tags
       """
       activate :automatic_image_sizes
       """
-    And the Server is running at "automatic-image-size-app"
+    And the Server is running
     When I go to "/auto-image-sizes.html"
     Then I should see 'width="1"'
     And I should see 'height="1"'

--- a/middleman-core/features/cache_buster.feature
+++ b/middleman-core/features/cache_buster.feature
@@ -1,12 +1,12 @@
 Feature: Generate mtime-based query string for busting browser caches
   In order to display the most recent content for IE & CDNs and appease YSlow
-    
+
   Scenario: Rendering css with the feature disabled
     Given "cache_buster" feature is "disabled"
     And the Server is running at "cache-buster-app"
     When I go to "/stylesheets/relative_assets.css"
     Then I should see 'blank.gif"'
-    
+
   Scenario: Rendering html with the feature disabled
     Given "cache_buster" feature is "disabled"
     And the Server is running at "cache-buster-app"
@@ -49,7 +49,7 @@ Feature: Generate mtime-based query string for busting browser caches
         '/cache-buster.html',
       ]
       """
-    And the Server is running at "cache-buster-app"
+    And the Server is running
     When I go to "/cache-buster.html"
     Then I should see 'site.css"'
     Then I should see 'empty-with-include.js"'

--- a/middleman-core/features/collections.feature
+++ b/middleman-core/features/collections.feature
@@ -69,7 +69,7 @@ Feature: Collections
 
       First Tag: <%= collection(:first_tag) %>
       """
-    Given the Server is running at "collections-app"
+    Given the Server is running
     When I go to "index.html"
     Then I should see 'Article1: Blog1 Newer Article'
     And I should see 'Article1: Blog1 Another Article'
@@ -101,7 +101,7 @@ Feature: Collections
         Article: <%= article.data.title || article.file_descriptor[:relative_path] %>
       <% end %>
       """
-    Given the Server is running at "collections-app"
+    Given the Server is running
     When I go to "index.html"
     Then I should not see "Article: index.html.erb"
     Then I should see 'Article: Blog2 Newer Article'
@@ -166,7 +166,7 @@ Feature: Collections
       - "/blog1/2011-01-01-new-article.html"
       - "/blog2/2011-01-02-another-article.html"
       """
-    Given the Server is running at "collections-app"
+    Given the Server is running
     When I go to "0-ok.html"
     Then I should see 'Newer Article Content'
     When I go to "1-ok.html"
@@ -186,7 +186,7 @@ Feature: Collections
       - "/blog1/2011-01-01-new-article.html"
       - "/blog2/2011-01-02-another-article.html"
       """
-    Given the Server is running at "collections-app"
+    Given the Server is running
     When I go to "0.html"
     Then I should see 'Newer Article Content'
     When I go to "1.html"
@@ -243,7 +243,7 @@ Feature: Collections
       """
       Test1
       """
-    Given the Server is running at "collections-app"
+    Given the Server is running
     When I go to "test1.html"
     Then I should see 'Test1'
     When I go to "test2.html"

--- a/middleman-core/features/content_type.feature
+++ b/middleman-core/features/content_type.feature
@@ -23,7 +23,7 @@ Feature: Setting the right content type for files
     proxy "bar", "index.html", content_type: 'text/custom'
     proxy "foo", "README" # auto-delegate to target content type
     """
-    And the Server is running at "content-type-app"
+    And the Server is running
     When I go to "/README"
     Then the content type should be "text/awesome"
     When I go to "/bar"
@@ -40,7 +40,6 @@ Feature: Setting the right content type for files
     """
     mime_type('.js', 'application/x-javascript')
     """
-    And the Server is running at "content-type-app"
+    And the Server is running
     When I go to "/javascripts/app.js"
     Then the content type should be "application/x-javascript"
-

--- a/middleman-core/features/custom_layouts.feature
+++ b/middleman-core/features/custom_layouts.feature
@@ -7,7 +7,7 @@ Feature: Custom layouts
       """
       page '/custom-layout.html', layout: :custom
       """
-    And the Server is running at "custom-layout-app2"
+    And the Server is running
     When I go to "/custom-layout.html"
     Then I should see "Custom Layout"
 
@@ -21,7 +21,7 @@ Feature: Custom layouts
         proxy "/test/#{who}.html", "/custom-layout.html"
       end
       """
-    And the Server is running at "custom-layout-app2"
+    And the Server is running
     When I go to "/test/me.html"
     Then I should see "Custom Layout"
     When I go to "/test/you.html"
@@ -33,7 +33,7 @@ Feature: Custom layouts
       """
       page '/custom-layout-dir/', layout: :custom
       """
-    And the Server is running at "custom-layout-app2"
+    And the Server is running
     When I go to "/custom-layout-dir"
     Then I should see "Custom Layout"
     When I go to "/custom-layout-dir/"
@@ -47,7 +47,7 @@ Feature: Custom layouts
       """
       page '/custom-layout-dir', layout: :custom
       """
-    And the Server is running at "custom-layout-app2"
+    And the Server is running
     When I go to "/custom-layout-dir"
     Then I should see "Custom Layout"
     When I go to "/custom-layout-dir/"
@@ -61,7 +61,7 @@ Feature: Custom layouts
       """
       page '/custom-layout-dir/index.html', layout: :custom
       """
-    And the Server is running at "custom-layout-app2"
+    And the Server is running
     When I go to "/custom-layout-dir"
     Then I should see "Custom Layout"
     When I go to "/custom-layout-dir/"

--- a/middleman-core/features/default-layout.feature
+++ b/middleman-core/features/default-layout.feature
@@ -50,7 +50,7 @@ Feature: Describe which files get layouts
 
       <test>Hi</test>
       """
-    And the Server is running at "empty_app"
+    And the Server is running
 
   Scenario: Normal Template
     When I go to "/index.html"
@@ -87,4 +87,3 @@ Feature: Describe which files get layouts
     When I go to "/test.xml"
     Then I should see "<test>Hi</test>"
     And I should see "<title>Second Layout</title>"
-

--- a/middleman-core/features/directory_index.feature
+++ b/middleman-core/features/directory_index.feature
@@ -67,7 +67,7 @@ Feature: Directory Index
     relative_link_to: <%= link_to "Relative", "../needs_index.html" %>
     link_to_with_spaces: <%= link_to "Spaces", "../evil%20spaces.html" %>
     """
-    And the Server is running at "indexable-app"
+    And the Server is running
     When I go to "/link_to/"
     Then I should see 'link_to: <a href="/needs_index/">Needs Index</a>'
     Then I should see 'explicit_link_to: <a href="/needs_index/">Explicit</a>'

--- a/middleman-core/features/encoding_option.feature
+++ b/middleman-core/features/encoding_option.feature
@@ -19,7 +19,7 @@ Feature: encoding option
       ::Rack::Mime::MIME_TYPES['.htm'] = 'text/html; charset=iso-8859-1'
       ::Rack::Mime::MIME_TYPES['.map'] = 'application/json; charset=iso-8859-1'
       """
-    Given the Server is running at "i-8859-1-app"
+    Given the Server is running
 
     When I go to "/index.html"
     Then the "Content-Type" header should contain "text/html"

--- a/middleman-core/features/encoding_option.feature
+++ b/middleman-core/features/encoding_option.feature
@@ -2,7 +2,6 @@
 Feature: encoding option
 
   Scenario: No encoding set
-    Given a fixture app "clean-app"
     Given the Server is running at "clean-app"
 
     When I go to "/index.html"

--- a/middleman-core/features/endpoints.feature
+++ b/middleman-core/features/endpoints.feature
@@ -12,6 +12,6 @@ Feature: Generic block based pages
     """
     Hi
     """
-    And the Server is running at "empty_app"
+    And the Server is running
     When I go to "/hello.html"
     Then I should see "world"

--- a/middleman-core/features/former_padrino_helpers.feature
+++ b/middleman-core/features/former_padrino_helpers.feature
@@ -17,11 +17,9 @@ Feature: Built-in macro view helpers
     """
     set :http_prefix, "/foo"
     """
-    And the Server is running at "padrino-helpers-app"
+    And the Server is running
     When I go to "/former_padrino_test.html"
     And I should see 'src="/foo/images/test2.png"'
     And I should see 'src="/foo/images/100px.png"'
     And I should see 'src="/foo/javascripts/test1.js"'
     And I should see 'href="/foo/stylesheets/test1.css"'
-
-                

--- a/middleman-core/features/helpers_form_tag.feature
+++ b/middleman-core/features/helpers_form_tag.feature
@@ -17,7 +17,7 @@ Feature: form_tag helper
     relative: <% form_tag "../needs_index.html#relative", relative: true do %>
     <% end %>
     """
-    And the Server is running at "indexable-app"
+    And the Server is running
     When I go to "/form_tag.html"
     Then I should see 'action="needs_index.html#absolute"'
     Then I should see 'action="needs_index.html#relative"'

--- a/middleman-core/features/helpers_link_to.feature
+++ b/middleman-core/features/helpers_link_to.feature
@@ -19,7 +19,7 @@ Feature: link_to helper
     """
     <%= link_to "test", "http://google.com/test.html" %>
     """
-    And the Server is running at "link-to-app"
+    And the Server is running
     When I go to "/link_to_absolute.html"
     Then I should see '<a href="http://google.com/test.html">test</a>'
 
@@ -52,7 +52,7 @@ Feature: link_to helper
     absolute spaces: <%= link_to "Spaces Index", "/evil spaces.html", relative: true %>
     relative spaces: <%= link_to "Spaces Relative", "../evil spaces.html", relative: true %>
     """
-    And the Server is running at "indexable-app"
+    And the Server is running
     When I go to "/link_to.html"
     Then I should see 'absolute: <a href="needs_index.html">Needs Index</a>'
     Then I should see 'relative: <a href="needs_index.html">Relative</a>'
@@ -115,7 +115,7 @@ Feature: link_to helper
     absolute: <%= link_to "Needs Index", "/needs_index.html" %>
     relative: <%= link_to "Relative", "../needs_index.html" %>
     """
-    And the Server is running at "indexable-app"
+    And the Server is running
     When I go to "/link_to.html"
     Then I should see 'absolute: <a href="needs_index.html">Needs Index</a>'
     Then I should see 'relative: <a href="/needs_index.html">Relative</a>'
@@ -150,7 +150,7 @@ Feature: link_to helper
     """
     <%= link_to "Needs Index", sitemap.by_path("/needs_index.html") %>
     """
-    And the Server is running at "indexable-app"
+    And the Server is running
     When I go to "/link_to/"
     Then I should see '<a href="/needs_index/">Needs Index</a>'
 
@@ -176,7 +176,7 @@ Feature: link_to helper
     <%= link_to "Needs Index Query", "/needs_index.html?foo" %>
     <%= link_to "Needs Index Query and Anchor", "/needs_index.html?foo#foo" %>
     """
-    And the Server is running at "indexable-app"
+    And the Server is running
     When I go to "/link_to/"
     Then I should see '<a href="/needs_index/#foo">Needs Index Anchor</a>'
     Then I should see '<a href="/needs_index/?foo">Needs Index Query</a>'

--- a/middleman-core/features/helpers_select_tag.feature
+++ b/middleman-core/features/helpers_select_tag.feature
@@ -7,7 +7,7 @@ Feature: select_tag helper
     """
     options as array: <%= select_tag :colors, options: ["red", "blue", "blorange"], include_blank: "Choose a color" %>
     """
-    And the Server is running at "indexable-app"
+    And the Server is running
     When I go to "/select_tag.html"
     Then I should see '<select name="colors"'
     Then I should see '<option value="">Choose a color</option>'

--- a/middleman-core/features/helpers_url_for.feature
+++ b/middleman-core/features/helpers_url_for.feature
@@ -13,7 +13,7 @@ Feature: url_for helper
     absolute: <%= url_for "/needs_index.html", relative: true %>
     relative: <%= url_for "../needs_index.html", relative: true %>
     """
-    And the Server is running at "indexable-app"
+    And the Server is running
     When I go to "/url_for.html"
     Then I should see 'absolute: needs_index.html'
     Then I should see 'relative: needs_index.html'
@@ -47,7 +47,7 @@ Feature: url_for helper
         "<%= url_for(item) %>"
     <% end %>
     """
-    And the Server is running at "indexable-app"
+    And the Server is running
     When I go to "/url_for.html"
     Then I should see '"url_for/sub.html"'
     Then I should not see "/url_for/sub.html"
@@ -72,7 +72,7 @@ Feature: url_for helper
     absolute: <%= url_for "/needs_index.html" %>
     relative: <%= url_for "../needs_index.html" %>
     """
-    And the Server is running at "indexable-app"
+    And the Server is running
     When I go to "/url_for.html"
     Then I should see 'absolute: needs_index.html'
     Then I should see 'relative: /needs_index.html'
@@ -80,7 +80,7 @@ Feature: url_for helper
     When I go to "/url_for/sub.html"
     Then I should see 'absolute: ../needs_index.html'
     Then I should see 'relative: ../needs_index.html'
-  
+
   Scenario: url_for knows about directory indexes
     Given a fixture app "indexable-app"
     And a file named "source/url_for.html.erb" with:
@@ -93,7 +93,7 @@ Feature: url_for helper
     absolute: <%= url_for "/needs_index.html", relative: true %>
     relative: <%= url_for "../needs_index.html", relative: true %>
     """
-    And the Server is running at "indexable-app"
+    And the Server is running
     When I go to "/url_for/"
     Then I should see 'absolute: ../needs_index/'
     Then I should see 'relative: ../needs_index/'
@@ -107,7 +107,7 @@ Feature: url_for helper
     """
     "<%= url_for sitemap.by_path("/needs_index.html") %>"
     """
-    And the Server is running at "indexable-app"
+    And the Server is running
     When I go to "/url_for/"
     Then I should see '"/needs_index/"'
 
@@ -121,7 +121,7 @@ Feature: url_for helper
     """
     <%= url_for "/needs_index.html" %>
     """
-    And the Server is running at "indexable-app"
+    And the Server is running
     When I go to "/url_for.html"
     Then I should see '/foo/needs_index.html'
 
@@ -133,7 +133,7 @@ Feature: url_for helper
     Needs Index Query <%= url_for "/needs_index.html?foo" %>
     Needs Index Query and Anchor <%= url_for "/needs_index.html?foo#foo" %>
     """
-    And the Server is running at "indexable-app"
+    And the Server is running
     When I go to "/url_for/"
     Then I should see 'Needs Index Anchor /needs_index/#foo'
     Then I should see 'Needs Index Query /needs_index/?foo'
@@ -146,7 +146,7 @@ Feature: url_for helper
     Needs Index String <%= url_for "/needs_index.html", query: "foo" %>
     Needs Index Hash <%= url_for "/needs_index.html", query: { foo: :bar } %>
     """
-    And the Server is running at "indexable-app"
+    And the Server is running
     When I go to "/url_for/"
     Then I should see 'Needs Index String /needs_index/?foo'
     Then I should see 'Needs Index Hash /needs_index/?foo=bar'

--- a/middleman-core/features/i18n_link_to.feature
+++ b/middleman-core/features/i18n_link_to.feature
@@ -57,7 +57,7 @@ Feature: i18n Paths
       set :strip_index_file, false
       activate :i18n, mount_at_root: :en
       """
-    Given the Server is running at "empty-app"
+    Given the Server is running
     When I go to "/hello.html"
     Then I should see "Page: Hello"
     Then I should see '<a href="/index.html" class="current">Current Home</a>'
@@ -133,7 +133,7 @@ Feature: i18n Paths
       activate :i18n, mount_at_root: :en
       activate :relative_assets
       """
-    Given the Server is running at "empty-app"
+    Given the Server is running
     When I go to "/index.html"
     Then I should see "assets/css/main.css"
     When I go to "/hello.html"
@@ -211,7 +211,7 @@ Feature: i18n Paths
       """
       activate :i18n, mount_at_root: :en
       """
-    Given the Server is running at "empty-app"
+    Given the Server is running
     When I go to "/hello.html"
     Then I should see "Page: Hello"
     Then I should see 'Current: /hello.html'
@@ -250,7 +250,7 @@ Feature: i18n Paths
       # FIXME: Auto-discover does not work if there are no locale files.
       activate :i18n, mount_at_root: :en, :locales => [:en, :de]
       """
-    Given the Server is running at "empty-app"
+    Given the Server is running
     When I go to "/index.html"
     Then I should see "English"
     Then I should see '"/de/"'

--- a/middleman-core/features/i18n_mixed_sources.feature
+++ b/middleman-core/features/i18n_mixed_sources.feature
@@ -1,11 +1,6 @@
 Feature: i18n merging path trees
 
   Scenario: Mixing localized and non-localized sources and merging the path trees (see issue #1709)
-    Given a fixture app "i18n-test-app"
-    And a file named "config.rb" with:
-      """
-      activate :i18n, mount_at_root: :en, langs: [:en, :es]
-      """
     Given the Server is running at "i18n-mixed-sources"
 
     When I go to "/"

--- a/middleman-core/features/i18n_partials.feature
+++ b/middleman-core/features/i18n_partials.feature
@@ -6,7 +6,7 @@ Feature: i18n Partials
       """
       activate :i18n
       """
-    Given the Server is running at "i18n-test-app"
+    Given the Server is running
     When I go to "/partials/index.html"
     Then I should see "Country: USA"
     Then I should see "State: District of Columbia"

--- a/middleman-core/features/i18n_preview.feature
+++ b/middleman-core/features/i18n_preview.feature
@@ -7,7 +7,7 @@ Feature: i18n Preview
       """
       activate :i18n
       """
-    Given the Server is running at "i18n-test-app"
+    Given the Server is running
     When I go to "/"
     Then I should see "Howdy"
     When I go to "/hello.html"
@@ -43,7 +43,7 @@ Feature: i18n Preview
       """
       activate :i18n
       """
-    Given the Server is running at "i18n-test-app"
+    Given the Server is running
     And the file "locales/en.yml" has the contents
       """
       ---
@@ -73,7 +73,7 @@ Feature: i18n Preview
       """
       activate :i18n, path: "/lang_:locale/"
       """
-    Given the Server is running at "i18n-test-app"
+    Given the Server is running
     When I go to "/"
     Then I should see "Howdy"
     When I go to "/hello.html"
@@ -92,7 +92,7 @@ Feature: i18n Preview
       """
       activate :i18n, templates_dir: "lang_data"
       """
-    Given the Server is running at "i18n-alt-root-app"
+    Given the Server is running
     When I go to "/"
     Then I should see "Howdy"
     When I go to "/hello.html"
@@ -110,7 +110,7 @@ Feature: i18n Preview
       """
       activate :i18n, lang_map: { en: :english, es: :spanish }
       """
-    Given the Server is running at "i18n-test-app"
+    Given the Server is running
     When I go to "/"
     Then I should see "Howdy"
     When I go to "/hello.html"
@@ -128,7 +128,7 @@ Feature: i18n Preview
       """
       activate :i18n, mount_at_root: :es
       """
-    Given the Server is running at "i18n-test-app"
+    Given the Server is running
     When I go to "/en/index.html"
     Then I should see "Howdy"
     When I go to "/en/hello.html"
@@ -156,7 +156,7 @@ Feature: i18n Preview
       """
       activate :i18n, langs: :es
       """
-    Given the Server is running at "i18n-test-app"
+    Given the Server is running
     When I go to "/en/index.html"
     Then I should see "File Not Found"
     When I go to "/en/hello.html"
@@ -179,7 +179,7 @@ Feature: i18n Preview
       """
       activate :i18n, mount_at_root: false
       """
-    Given the Server is running at "i18n-test-app"
+    Given the Server is running
     When I go to "/en/index.html"
     Then I should see "Howdy"
     When I go to "/en/hello.html"
@@ -199,7 +199,7 @@ Feature: i18n Preview
       """
       activate :i18n, langs: [:en]
       """
-    Given the Server is running at "i18n-test-app"
+    Given the Server is running
     When I go to "/"
     Then I should see "Howdy"
     When I go to "/hello.html"
@@ -218,7 +218,7 @@ Feature: i18n Preview
       activate :i18n
       activate :relative_assets
       """
-    Given the Server is running at "i18n-test-app"
+    Given the Server is running
     When I go to "/"
     Then I should see '"stylesheets/site.css"'
     When I go to "/hello.html"
@@ -234,7 +234,7 @@ Feature: i18n Preview
       """
       activate :i18n, mount_at_root: :es
       """
-    Given the Server is running at "i18n-default-app"
+    Given the Server is running
     When I go to "/en/"
     Then I should see "Default locale: es"
     Then I should see "Current locale: en"
@@ -247,7 +247,7 @@ Feature: i18n Preview
       """
       activate :i18n
       """
-    Given the Server is running at "i18n-nested-app"
+    Given the Server is running
     When I go to "/"
     Then I should see "Howdy"
     Then I should see "More"
@@ -268,7 +268,7 @@ Feature: i18n Preview
         end
       end
       """
-    Given the Server is running at "i18n-default-app"
+    Given the Server is running
     When I go to "/name.html"
     Then I should see "File Not Found"
     When I go to "/en/people/tom.html"

--- a/middleman-core/features/ignore_already_minified.feature
+++ b/middleman-core/features/ignore_already_minified.feature
@@ -19,10 +19,10 @@ Feature: CSS and JavaScripts which are minify shouldn't be re-minified
       9,
       10 ];
       """
-    And the Server is running at "empty_app"
+    And the Server is running
     When I go to "/javascripts/test.min.js"
     Then I should see "10" lines
-    
+
   Scenario: CSS files containing ".min" should not be re-compressed
     Given an empty app
     And a file named "config.rb" with:
@@ -39,9 +39,9 @@ Feature: CSS and JavaScripts which are minify shouldn't be re-minified
         six: 6;
         seven: 7;
         eight: 8;
-        nine: 9; 
+        nine: 9;
         ten: 10; }
       """
-    And the Server is running at "empty_app"
+    And the Server is running
     When I go to "/stylesheets/test.min.css"
     Then I should see "10" lines

--- a/middleman-core/features/markdown_kramdown.feature
+++ b/middleman-core/features/markdown_kramdown.feature
@@ -8,7 +8,7 @@ Feature: Markdown (Kramdown) support
       set :markdown_engine, :kramdown
       set :markdown, smartypants: true
       """
-    Given the Server is running at "markdown-app"
+    Given the Server is running
     When I go to "/smarty_pants.html"
     Then I should see "“Hello”"
 
@@ -28,7 +28,7 @@ Feature: Markdown (Kramdown) support
 
       [mail@mail.com](mailto:mail@mail.com)
       """
-    Given the Server is running at "markdown-app"
+    Given the Server is running
     When I go to "/link_and_image/"
     Then I should see "/smarty_pants/"
     Then I should see 'width="1"'
@@ -49,7 +49,7 @@ Feature: Markdown (Kramdown) support
       [A link](/smarty_pants.html)
       [A second link](/smarty_pants.html){: anchor="test-anchor"}
       """
-    Given the Server is running at "markdown-app"
+    Given the Server is running
     When I go to "/links/"
     Then I should see "/smarty_pants/"
     And I should see "/smarty_pants/#test-anchor"

--- a/middleman-core/features/markdown_kramdown_in_haml.feature
+++ b/middleman-core/features/markdown_kramdown_in_haml.feature
@@ -15,7 +15,7 @@ Feature: Markdown support in Haml (Kramdown)
 
         paragraph
       """
-    Given the Server is running at "markdown-in-haml-app"
+    Given the Server is running
     When I go to "/markdown_filter/"
     Then I should see ">H1</h1>"
     Then I should see "<p>paragraph</p>"
@@ -35,7 +35,7 @@ Feature: Markdown support in Haml (Kramdown)
 
         ![image](blank.gif){: srcset="image_2x.jpg 2x"}
       """
-    Given the Server is running at "markdown-in-haml-app"
+    Given the Server is running
     When I go to "/link_and_image/"
     Then I should see "/link_target/"
     Then I should see "/images/image_2x.jpg 2x"

--- a/middleman-core/features/markdown_kramdown_in_slim.feature
+++ b/middleman-core/features/markdown_kramdown_in_slim.feature
@@ -15,7 +15,7 @@ Feature: Markdown support in Slim (Kramdown)
 
         paragraph
       """
-    Given the Server is running at "markdown-in-slim-app"
+    Given the Server is running
     When I go to "/markdown_filter/"
     Then I should see ">H1</h1>"
     Then I should see "<p>paragraph</p>"
@@ -35,7 +35,7 @@ Feature: Markdown support in Slim (Kramdown)
 
         ![image](blank.gif){: srcset="image_2x.jpg 2x"}
       """
-    Given the Server is running at "markdown-in-slim-app"
+    Given the Server is running
     When I go to "/link_and_image/"
     Then I should see "/link_target/"
     Then I should see "/images/image_2x.jpg 2x"

--- a/middleman-core/features/markdown_redcarpet.feature
+++ b/middleman-core/features/markdown_redcarpet.feature
@@ -16,7 +16,7 @@ Feature: Markdown (Redcarpet) support
                      lax_spacing: true
 
       """
-    Given the Server is running at "markdown-app"
+    Given the Server is running
     When I go to "/no_intra_emphasis.html"
     Then I should not see "<em>"
     When I go to "/tables.html"
@@ -45,7 +45,7 @@ Feature: Markdown (Redcarpet) support
                      highlight: true,
                      disable_indented_code_blocks: true
       """
-    Given the Server is running at "markdown-app"
+    Given the Server is running
     When I go to "/underline.html"
     Then I should see "<u>underlined</u>"
     When I go to "/highlighted.html"
@@ -60,7 +60,7 @@ Feature: Markdown (Redcarpet) support
       set :markdown_engine, :redcarpet
       set :markdown, smartypants: true
       """
-    Given the Server is running at "markdown-app"
+    Given the Server is running
     When I go to "/smarty_pants.html"
     Then I should see "&ldquo;"
 
@@ -78,7 +78,7 @@ Feature: Markdown (Redcarpet) support
                      prettify: true
 
       """
-    Given the Server is running at "markdown-app"
+    Given the Server is running
     When I go to "/filter_html.html"
     Then I should not see "<em>"
     When I go to "/img.html"
@@ -108,7 +108,7 @@ Feature: Markdown (Redcarpet) support
       """
       [A link](/foo.html)
       """
-    Given the Server is running at "markdown-app"
+    Given the Server is running
     When I go to "/link.html"
     Then I should see 'target="_blank"'
 
@@ -120,7 +120,7 @@ Feature: Markdown (Redcarpet) support
       set :markdown, xhtml: true,
                      hard_wrap: true
       """
-    Given the Server is running at "markdown-app"
+    Given the Server is running
     When I go to "/hard_wrap.html"
     Then I should see "<br/>"
 
@@ -131,7 +131,7 @@ Feature: Markdown (Redcarpet) support
       set :markdown_engine, :redcarpet
       set :markdown, smartypants: true
       """
-    Given the Server is running at "markdown-frontmatter-options-app"
+    Given the Server is running
     When I go to "/smarty_pants-default.html"
     Then I should see "&ldquo;"
     When I go to "/smarty_pants-on.html"
@@ -159,7 +159,7 @@ Feature: Markdown (Redcarpet) support
 
       ![image](blank.gif)
       """
-    Given the Server is running at "markdown-app"
+    Given the Server is running
     When I go to "/link_and_image/"
     Then I should see "/smarty_pants/"
     Then I should see 'width="1"'

--- a/middleman-core/features/markdown_redcarpet_in_haml.feature
+++ b/middleman-core/features/markdown_redcarpet_in_haml.feature
@@ -15,7 +15,7 @@ Feature: Markdown support in Haml
 
         paragraph
       """
-    Given the Server is running at "markdown-in-haml-app"
+    Given the Server is running
     When I go to "/markdown_filter/"
     Then I should see ">H1</h1>"
     Then I should see "<p>paragraph</p>"
@@ -35,7 +35,7 @@ Feature: Markdown support in Haml
 
         ![image](blank.gif)
       """
-    Given the Server is running at "markdown-in-haml-app"
+    Given the Server is running
     When I go to "/link_and_image/"
     Then I should see "/link_target/"
     Then I should see 'src="/images/blank.gif"'

--- a/middleman-core/features/markdown_redcarpet_in_slim.feature
+++ b/middleman-core/features/markdown_redcarpet_in_slim.feature
@@ -15,7 +15,7 @@ Feature: Markdown support in Slim
 
         paragraph
       """
-    Given the Server is running at "markdown-in-slim-app"
+    Given the Server is running
     When I go to "/markdown_filter/"
     Then I should see ">H1</h1>"
     Then I should see "<p>paragraph</p>"
@@ -35,7 +35,7 @@ Feature: Markdown support in Slim
 
         ![image](blank.gif)
       """
-    Given the Server is running at "markdown-in-slim-app"
+    Given the Server is running
     When I go to "/link_and_image/"
     Then I should see "/link_target/"
     Then I should see 'src="/images/blank.gif"'

--- a/middleman-core/features/minify_css.feature
+++ b/middleman-core/features/minify_css.feature
@@ -7,7 +7,7 @@ Feature: Minify CSS
       """
       config[:sass_source_maps] = false
       """
-    And the Server is running at "minify-css-app"
+    And the Server is running
     When I go to "/stylesheets/site.css"
     Then I should see "7" lines
     And I should see "only screen and (device-width"
@@ -20,7 +20,7 @@ Feature: Minify CSS
 
       activate :minify_css
       """
-    And the Server is running at "minify-css-app"
+    And the Server is running
     When I go to "/stylesheets/site.css"
     Then I should see "1" lines
     And I should see "only screen and (device-width"
@@ -38,7 +38,7 @@ Feature: Minify CSS
       activate :minify_css
       proxy '/css-proxy', '/stylesheets/site.css', ignore: true
       """
-    And the Server is running at "minify-css-app"
+    And the Server is running
     When I go to "/css-proxy"
     Then I should see "1" lines
     And I should see "only screen and (device-width"
@@ -57,7 +57,7 @@ Feature: Minify CSS
 
       activate :minify_css, compressor: ::PassThrough
       """
-    And the Server is running at "passthrough-app"
+    And the Server is running
     When I go to "/stylesheets/site.css"
     Then I should see "5" lines
 
@@ -67,7 +67,7 @@ Feature: Minify CSS
       """
       config[:sass_source_maps] = false
       """
-    And the Server is running at "minify-css-app"
+    And the Server is running
     When I go to "/inline-css.html"
     Then I should see:
     """
@@ -95,7 +95,7 @@ Feature: Minify CSS
 
       page "/inline-css.html", layout: false
       """
-    And the Server is running at "passthrough-app"
+    And the Server is running
     When I go to "/inline-css.html"
     Then I should see:
     """
@@ -122,7 +122,7 @@ Feature: Minify CSS
 
       page "/inline-css.html", layout: false
       """
-    And the Server is running at "passthrough-app"
+    And the Server is running
     When I go to "/inline-css.html"
     Then I should see:
     """
@@ -139,7 +139,7 @@ Feature: Minify CSS
 
       activate :minify_css, inline: true
       """
-    And the Server is running at "minify-css-app"
+    And the Server is running
     When I go to "/inline-css.html"
     Then I should see:
     """
@@ -156,7 +156,7 @@ Feature: Minify CSS
 
       activate :minify_css, inline: true
       """
-    And the Server is running at "minify-css-app"
+    And the Server is running
     When I go to "/inline-css.php"
     Then I should see:
     """
@@ -176,7 +176,7 @@ Feature: Minify CSS
       activate :minify_css, inline: true
       proxy '/inline-css-proxy', '/inline-css.html', ignore: true
       """
-    And the Server is running at "minify-css-app"
+    And the Server is running
     When I go to "/inline-css-proxy"
     Then I should see:
     """
@@ -197,7 +197,7 @@ Feature: Minify CSS
                             inline: true,
                             inline_content_types: ['text/html']
       """
-    And the Server is running at "minify-css-app"
+    And the Server is running
     When I go to "/stylesheets/site.xcss"
     Then I should see "1" lines
     And I should see "only screen and (device-width"

--- a/middleman-core/features/minify_javascript.feature
+++ b/middleman-core/features/minify_javascript.feature
@@ -6,7 +6,7 @@ Feature: Minify JavaScript
     And a file named "config.rb" with:
       """
       """
-    And the Server is running at "minify-js-app"
+    And the Server is running
     When I go to "/inline-js.html"
     Then I should see:
     """
@@ -53,7 +53,7 @@ Feature: Minify JavaScript
 
       page "/inline-js.html", layout: false
       """
-    And the Server is running at "passthrough-app"
+    And the Server is running
     When I go to "/inline-js.html"
     Then I should see:
     """
@@ -100,7 +100,7 @@ Feature: Minify JavaScript
 
       page "/inline-js.html", layout: false
       """
-    And the Server is running at "passthrough-app"
+    And the Server is running
     When I go to "/inline-js.html"
     Then I should see:
     """
@@ -126,7 +126,7 @@ Feature: Minify JavaScript
       """
       activate :minify_javascript, inline: true
       """
-    And the Server is running at "minify-js-app"
+    And the Server is running
     When I go to "/inline-js.html"
     Then I should see:
     """
@@ -152,7 +152,7 @@ Feature: Minify JavaScript
       """
       activate :minify_javascript, inline: true
       """
-    And the Server is running at "minify-js-app"
+    And the Server is running
     When I go to "/inline-js.php"
     Then I should see:
     """
@@ -178,7 +178,7 @@ Feature: Minify JavaScript
       activate :minify_javascript, inline: true
       proxy '/inline-js-proxy', '/inline-js.html', ignore: true
       """
-    And the Server is running at "minify-js-app"
+    And the Server is running
     When I go to "/inline-js-proxy"
     Then I should see "14" lines
 
@@ -188,7 +188,7 @@ Feature: Minify JavaScript
       """
       activate :minify_javascript
       """
-    And the Server is running at "minify-js-app"
+    And the Server is running
     When I go to "/javascripts/js_test.js"
     Then I should see "1" lines
     When I go to "/more-js/other.js"
@@ -201,7 +201,7 @@ Feature: Minify JavaScript
       activate :minify_javascript
       proxy '/js-proxy', '/javascripts/js_test.js', ignore: true
       """
-    And the Server is running at "minify-js-app"
+    And the Server is running
     When I go to "/js-proxy"
     Then I should see "1" lines
 
@@ -216,7 +216,7 @@ Feature: Minify JavaScript
       """
       activate :minify_javascript, inline: true
       """
-    And the Server is running at "minify-js-app"
+    And the Server is running
     When I go to "/inline-coffeescript.html"
     Then I should see "3" lines
 
@@ -226,7 +226,7 @@ Feature: Minify JavaScript
       """
       activate :minify_javascript
       """
-    And the Server is running at "minify-js-app"
+    And the Server is running
     When I go to "/javascripts/coffee_test.js"
     Then I should see "1" lines
 
@@ -244,7 +244,7 @@ Feature: Minify JavaScript
 
       page "/inline-coffeescript.html", layout: false
       """
-    And the Server is running at "passthrough-app"
+    And the Server is running
     When I go to "/inline-coffeescript.html"
     Then I should see "13" lines
 
@@ -260,6 +260,6 @@ Feature: Minify JavaScript
 
       activate :minify_javascript, compressor: ::PassThrough
       """
-    And the Server is running at "passthrough-app"
+    And the Server is running
     When I go to "/javascripts/coffee_test.js"
     Then I should see "11" lines

--- a/middleman-core/features/minify_javascript.feature
+++ b/middleman-core/features/minify_javascript.feature
@@ -206,7 +206,7 @@ Feature: Minify JavaScript
     Then I should see "1" lines
 
   Scenario: Rendering external js with a passthrough minifier
-    And the Server is running at "passthrough-app"
+    Given the Server is running at "passthrough-app"
     When I go to "/javascripts/js_test.js"
     Then I should see "8" lines
 
@@ -263,4 +263,3 @@ Feature: Minify JavaScript
     And the Server is running at "passthrough-app"
     When I go to "/javascripts/coffee_test.js"
     Then I should see "11" lines
-

--- a/middleman-core/features/move_files.feature
+++ b/middleman-core/features/move_files.feature
@@ -6,7 +6,7 @@ Feature: Move files
     """
     move_file "/static.html", "/static2.html"
     """
-    And the Server is running at "large-build-app"
+    And the Server is running
     When I go to "/static.html"
     Then I should see 'Not Found'
     When I go to "/static2.html"
@@ -19,7 +19,7 @@ Feature: Move files
     activate :directory_indexes
     move_file "/static.html", "/static2.html"
     """
-    And the Server is running at "large-build-app"
+    And the Server is running
     When I go to "/static.html"
     Then I should see 'Not Found'
     When I go to "/static/index.html"
@@ -34,11 +34,10 @@ Feature: Move files
     activate :directory_indexes
     move_file "/static/index.html", "/static2.html"
     """
-    And the Server is running at "large-build-app"
+    And the Server is running
     When I go to "/static.html"
     Then I should see 'Not Found'
     When I go to "/static/index.html"
     Then I should see 'Not Found'
     When I go to "/static2.html"
     Then I should see 'Static, no code!'
-

--- a/middleman-core/features/page-id.feature
+++ b/middleman-core/features/page-id.feature
@@ -38,7 +38,7 @@ Feature: Page IDs
   Scenario: Override page ID derivation with a proc
     Given a fixture app "page-id-app"
     And app "page-id-app" is using config "proc"
-    And the Server is running at "page-id-app"
+    And the Server is running
 
     When I go to "/index.html"
     Then I should see "I am: index.html-foo"

--- a/middleman-core/features/redirects.feature
+++ b/middleman-core/features/redirects.feature
@@ -6,7 +6,7 @@ Feature: Meta redirects
     """
     redirect "hello.html", to: "world.html"
     """
-    And the Server is running at "large-build-app"
+    And the Server is running
     When I go to "/hello.html"
     Then I should see '<link rel="canonical" href="world.html"'
     Then I should see '<meta http-equiv=refresh content="0; url=world.html"'
@@ -17,7 +17,7 @@ Feature: Meta redirects
     """
     redirect "hello.html", to: "http://example.com"
     """
-    And the Server is running at "large-build-app"
+    And the Server is running
     When I go to "/hello.html"
     Then I should see '<meta http-equiv=refresh content="0; url=http://example.com"'
 
@@ -31,7 +31,7 @@ Feature: Meta redirects
       redirect "hello.html", to: r
     end
     """
-    And the Server is running at "large-build-app"
+    And the Server is running
     When I go to "/hello.html"
     Then I should see '<meta http-equiv=refresh content="0; url=/static.html"'
 
@@ -43,7 +43,7 @@ Feature: Meta redirects
     redirect "hello.html", to: "link_test.html"
     redirect "hello2.html", to: "services/index.html"
     """
-    And the Server is running at "large-build-app"
+    And the Server is running
     When I go to "/hello/index.html"
     Then I should see '<meta http-equiv=refresh content="0; url=/link_test/"'
     When I go to "/hello2/index.html"
@@ -57,7 +57,7 @@ Feature: Meta redirects
       "#{from} to #{to}"
     end
     """
-    And the Server is running at "large-build-app"
+    And the Server is running
     When I go to "/hello.html"
     Then I should see 'hello.html to world.html'
 

--- a/middleman-core/features/relative_assets.feature
+++ b/middleman-core/features/relative_assets.feature
@@ -118,7 +118,7 @@ Feature: Relative Assets
       """
       <%= image_tag '/img/blank.gif' %>
       """
-    And the Server is running at "relative-assets-app"
+    And the Server is running
     When I go to "/sub/image_tag.html"
     Then I should see '<img src="../img/blank.gif"'
 
@@ -129,7 +129,7 @@ Feature: Relative Assets
       """
       <%= image_tag "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" %>
       """
-    And the Server is running at "relative-assets-app"
+    And the Server is running
     When I go to "/sub/image_tag.html"
     Then I should see '<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" />'
 
@@ -141,7 +141,7 @@ Feature: Relative Assets
         '/stylesheets/fonts.css',
       ]
       """
-    And the Server is running at "relative-assets-app"
+    And the Server is running
     When I go to "/stylesheets/relative_assets.css"
     Then I should see 'url("../images/blank.gif'
     When I go to "/stylesheets/fonts.css"

--- a/middleman-core/features/relative_assets_helpers_only.feature
+++ b/middleman-core/features/relative_assets_helpers_only.feature
@@ -37,7 +37,7 @@ Feature: Relative Assets (Helpers Only)
         font-style: normal;
       }
       """
-    And the Server is running at "relative-assets-app"
+    And the Server is running
     When I go to "/stylesheets/relative_assets_helper.css"
     Then I should see 'url("../images/blank.gif'
     And I should see 'url("../images/blank2.gif'
@@ -56,7 +56,7 @@ Feature: Relative Assets (Helpers Only)
       activate :directory_indexes
       activate :relative_assets, helpers_only: true
       """
-    And the Server is running at "relative-assets-app"
+    And the Server is running
     When I go to "/relative_image/index.html"
     Then I should see "../stylesheets/relative_assets.css"
 
@@ -70,7 +70,7 @@ Feature: Relative Assets (Helpers Only)
       """
       <%= image_tag '/img/blank.gif' %>
       """
-    And the Server is running at "relative-assets-app"
+    And the Server is running
     When I go to "/sub/image_tag.html"
     Then I should see '<img src="../img/blank.gif"'
 
@@ -84,7 +84,7 @@ Feature: Relative Assets (Helpers Only)
       """
       <%= image_tag "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" %>
       """
-    And the Server is running at "relative-assets-app"
+    And the Server is running
     When I go to "/sub/image_tag.html"
     Then I should see '<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" />'
 
@@ -116,7 +116,7 @@ Feature: Relative Assets (Helpers Only)
         font-style: normal;
       }
       """
-    And the Server is running at "relative-assets-app"
+    And the Server is running
     When I go to "/stylesheets/relative_assets_helper.css"
     Then I should see 'url("../images/blank.gif'
     When I go to "/stylesheets/fonts3.css"

--- a/middleman-core/features/sass_in_slim.feature
+++ b/middleman-core/features/sass_in_slim.feature
@@ -13,7 +13,7 @@ Feature: Sass/SCSS support in Slim
         .sass
           margin: 0
       """
-    Given the Server is running at "sass-in-slim-app"
+    Given the Server is running
     When I go to "/sass_filter/"
     Then I should see "text/css"
     Then I should see ".sass"
@@ -33,7 +33,7 @@ Feature: Sass/SCSS support in Slim
           margin: 0;
         }
       """
-    Given the Server is running at "sass-in-slim-app"
+    Given the Server is running
     When I go to "/scss_filter/"
     Then I should see "text/css"
     Then I should see ".scss"

--- a/middleman-core/features/slim.feature
+++ b/middleman-core/features/slim.feature
@@ -16,7 +16,7 @@ Feature: Support slim templating language
         body
           h1 Welcome to Slim
       """
-    And the Server is running at "empty_app"
+    And the Server is running
     When I go to "/slim.html"
     Then I should see "<h1>Welcome to Slim</h1>"
 
@@ -72,7 +72,7 @@ Feature: Support slim templating language
         body
           h1 Welcome to Slim
       """
-    And the Server is running at "empty_app"
+    And the Server is running
     When I go to "/scss.html"
     Then I should see "html,body,div"
     When I go to "/sass.html"


### PR DESCRIPTION
I noticed that sometimes the same fixture was being referenced twice in a given scenario. Something like the following.

```
Given a fixture app "empty-app"
# additional customization
And the Server is running at "empty-app"
```

This is equivalent to

```
Given a fixture app "empty-app"
# additional customization
Given a fixture app "empty-app"
And the Server is running
```

So it can just be replaced with

```
Given a fixture app "empty-app"
# additional customization
And the Server is running
```

This avoids pointless duplication of the fixture name.