### PR TITLE
Fix linking of external urls when i18n is enabled

### DIFF
--- a/middleman-core/features/i18n_link_to.feature
+++ b/middleman-core/features/i18n_link_to.feature
@@ -257,3 +257,13 @@ Feature: i18n Paths
     When I go to "/de/index.html"
     Then I should see "Deutsch"
     Then I should see '"/"'
+
+  Scenario: link_to is i18n aware and leaves absolute URLs unchanged
+    Given a fixture app "i18n-default-app"
+    And a file named "source/localizable/index.html.erb" with:
+      """
+      <%= link_to "Example", "https://www.example.org/" %>
+      """
+    And the Server is running
+    When I go to "/index.html"
+    Then I should see '<a href="https://www.example.org/">Example</a>'

--- a/middleman-core/fixtures/i18n-default-app/config.rb
+++ b/middleman-core/fixtures/i18n-default-app/config.rb
@@ -1,0 +1,1 @@
+activate :i18n

--- a/middleman-core/lib/middleman-core/core_extensions/i18n.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/i18n.rb
@@ -261,6 +261,8 @@ class Middleman::CoreExtensions::Internationalization < ::Middleman::Extension
   Contract String, Symbol => Maybe[String]
   def localized_path(path, locale)
     lookup = ::Middleman::Util.parse_uri(path)
+    return path if lookup.host
+
     lookup.path << app.config[:index_file] if lookup.path&.end_with?('/')
 
     if @lookup[lookup.path] && @lookup[lookup.path][locale]


### PR DESCRIPTION
The Internationalization extension is redefining url_for to localize url paths. However, this redefinition was also acting on external urls, causing them to sometimes have an "/index.html" appended to them.

This path uses the presence of a host in the parsed URI object to determine whether or not a URL is "external". This is the same method for determining this as is already used in the base url_for.