### PR TITLE
Remove unneeded code

### DIFF
--- a/middleman-core/lib/middleman-core/core_extensions/default_helpers.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/default_helpers.rb
@@ -1,10 +1,6 @@
 require 'padrino-helpers'
 require 'middleman-core/contracts'
 
-# Don't fail on invalid locale, that's not what our current
-# users expect.
-::I18n.enforce_available_locales = false
-
 class Padrino::Helpers::OutputHelpers::ErbHandler
   # Force Erb capture not to use safebuffer
   def capture_from_template(*args, &block)


### PR DESCRIPTION
This was from e9968680338100bf9f6f2d96c3c1d129a083c49f, when i18n was being explicitly required by all Middleman apps. The same code is already part of `Middleman::CoreExtensions::Internationalization`, so it looks like when that extension was extracted, deleting it here was forgotten.