### PR TITLE
Move i18n test cleanup code to After block

### DIFF
--- a/middleman-core/lib/middleman-core/core_extensions/i18n.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/i18n.rb
@@ -24,17 +24,6 @@ class Middleman::CoreExtensions::Internationalization < ::Middleman::Extension
     # Don't fail on invalid locale, that's not what our current
     # users expect.
     ::I18n.enforce_available_locales = false
-
-    # This is for making the tests work - since the tests
-    # don't completely reload middleman, I18n.load_path can get
-    # polluted with paths from other test app directories that don't
-    # exist anymore.
-    return unless ENV['TEST']
-
-    app.after_configuration_eval do
-      ::I18n.load_path.delete_if { |path| path =~ %r{tmp/aruba} }
-      ::I18n.reload!
-    end
   end
 
   def after_configuration

--- a/middleman-core/lib/middleman-core/step_definitions.rb
+++ b/middleman-core/lib/middleman-core/step_definitions.rb
@@ -19,3 +19,14 @@ World(ArubaMonkeypatch)
 Before do
   @aruba_timeout_seconds = RUBY_PLATFORM == 'java' ? 120 : 60
 end
+
+# This is for making the tests work - since the tests
+# don't completely reload middleman, I18n.load_path can get
+# polluted with paths from other test app directories that don't
+# exist anymore.
+After do
+  if defined?(I18n)
+    I18n.load_path.delete_if { |path| path =~ %r{tmp/aruba} }
+    I18n.reload!
+  end
+end


### PR DESCRIPTION
Avoiding having test specific code in the extension simplifies it, and eliminates the possibility it would create a bug in a real Middleman app.

Using `defined?(I18n)` is not strictly required, as the I18n module is currently always present, as it is loaded via requiring 'active_support/all'. However, as that's not immediately apparent, and could theoretically change in the future, I thought it was better to have.