### PR TITLE
Update kramdown to avoid CVE-2020-14001 in v4

### DIFF
--- a/middleman/middleman.gemspec
+++ b/middleman/middleman.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |s|
   s.add_dependency('middleman-cli', Middleman::VERSION)
   s.add_dependency('haml', ['>= 4.0.5'])
   s.add_dependency('coffee-script', ['~> 2.2'])
-  s.add_dependency('kramdown', ['~> 1.2'])
+  s.add_dependency('kramdown', ['>= 2.3.0'])
 end


### PR DESCRIPTION
Proposal to update kramdown dependency for security reason in v4 middleman: https://github.com/advisories/GHSA-mqm2-cgpr-p4m6