### PR TITLE
Update version of kramdown to ~> 2.3 to address CVE-2020-14001

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'pry-stack_explorer'
 # Optional middleman dependencies, included for tests
 gem 'coffee-script', '~> 2.2', require: false
 gem 'haml', '>= 4.0.5', require: false
-gem 'kramdown', '~> 1.2', require: false
+gem 'kramdown', '~> 2.3', require: false
 gem 'liquid', '>= 3.0', require: false
 gem 'redcarpet', '>= 3.1', require: false
 gem 'sassc', '~> 2.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,7 +110,8 @@ GEM
       concurrent-ruby (~> 1.0)
     interception (0.5)
     jaro_winkler (1.5.4)
-    kramdown (1.17.0)
+    kramdown (2.3.0)
+      rexml
     lazy_priority_queue (0.1.1)
     libv8 (7.3.492.27.1)
     liquid (4.0.3)
@@ -163,6 +164,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redcarpet (3.5.0)
+    rexml (3.2.4)
     rgl (0.5.6)
       lazy_priority_queue (~> 0.1.0)
       stream (~> 0.5.2)
@@ -241,7 +243,7 @@ DEPENDENCIES
   coffee-script (~> 2.2)
   cucumber (~> 3.0)
   haml (>= 4.0.5)
-  kramdown (~> 1.2)
+  kramdown (~> 2.3)
   liquid (>= 3.0)
   middleman-cli!
   middleman-core!

--- a/middleman/middleman.gemspec
+++ b/middleman/middleman.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |s|
   s.add_dependency('middleman-cli', Middleman::VERSION)
   s.add_dependency('haml', ['>= 4.0.5'])
   s.add_dependency('coffee-script', ['~> 2.2'])
-  s.add_dependency('kramdown', ['~> 1.2'])
+  s.add_dependency('kramdown', ['~> 2.3'])
 end


### PR DESCRIPTION
Update to version of kramdown to address high severity vulnerability CVE-2020-14001