### PR TITLE
Replace URI.escape with WEBrick::HTTPUtils.escape

### DIFF
--- a/middleman-core/lib/middleman-core/builder.rb
+++ b/middleman-core/lib/middleman-core/builder.rb
@@ -229,7 +229,7 @@ module Middleman
           if resource.binary?
             export_file!(output_file, resource.file_descriptor[:full_path])
           else
-            response = @rack.get(::URI.escape(resource.request_path))
+            response = @rack.get(::WEBrick::HTTPUtils.escape(resource.request_path))
 
             # If we get a response, save it to a tempfile.
             if response.status == 200

--- a/middleman-core/lib/middleman-core/extensions/asset_hash.rb
+++ b/middleman-core/lib/middleman-core/extensions/asset_hash.rb
@@ -87,7 +87,7 @@ class Middleman::Extensions::AssetHash < ::Middleman::Extension
     else
       # Render through the Rack interface so middleware and mounted apps get a shot
       response = @rack_client.get(
-        ::URI.escape(resource.destination_path),
+        ::WEBrick::HTTPUtils.escape(resource.destination_path),
         'bypass_inline_url_rewriter_asset_hash' => 'true'
       )
 


### PR DESCRIPTION
Fixes `warning: URI.escape is obsolete` warnings.

Similar to #2312 and the fix 7c155c2