### PR TITLE
Add an option to modify asset_path in AssetHost extension

### DIFF
--- a/middleman-core/features/asset_host.feature
+++ b/middleman-core/features/asset_host.feature
@@ -14,6 +14,7 @@ Feature: Alternate between multiple asset hosts
     Then I should not see content matching %r{http://assets1.example.com//}
     Then I should see content matching %r{<a href="https://github.com/angular/angular.js">Angular.js</a>}
     Then I should see content matching %r{'//www.example.com/script.js'}
+    Then I should see content matching %r{blank0.gif}
     When I go to "/stylesheets/asset_host.css"
     Then I should see content matching %r{http://assets1.example.com/}
     Then I should not see content matching %r{http://assets1.example.com//}
@@ -53,3 +54,23 @@ Feature: Alternate between multiple asset hosts
     Then I should see content matching %r{http://assets1.example.com/}
     When I go to "/stylesheets/asset_host.css"
     Then I should not see content matching %r{http://assets1.example.com/}
+
+  Scenario: Host is rewritten with a proc
+    Given a fixture app "asset-host-app"
+    And a file named "config.rb" with:
+      """
+      activate :asset_host, host: "http://assets1.example.com", asset_path_rewriter: Proc.new { |full_asset_path|
+        full_asset_path.upcase
+      }
+      """
+    And the Server is running
+    When I go to "/asset_host.html"
+    Then I should see content matching %r{http://assets1.example.com/}
+    Then I should see content matching %r{BLANK0.GIF}
+    Then I should not see content matching %r{blank0.gif}
+    When I go to "/stylesheets/asset_host.css"
+    Then I should see content matching %r{http://assets1.example.com/}
+    Then I should not see content matching %r{http://assets1.example.com//}
+    When I go to "/javascripts/asset_host.js"
+    Then I should not see content matching %r{http://assets1.example.com/}
+ 

--- a/middleman-core/lib/middleman-core/extensions/asset_host.rb
+++ b/middleman-core/lib/middleman-core/extensions/asset_host.rb
@@ -6,6 +6,7 @@ class Middleman::Extensions::AssetHost < ::Middleman::Extension
   option :sources, %w(.css .htm .html .js .php .xhtml), 'List of extensions that are searched for bustable assets.'
   option :ignore, [], 'Regexes of filenames to skip adding query strings to'
   option :rewrite_ignore, [], 'Regexes of filenames to skip processing for host rewrites'
+  option :asset_path_rewriter, nil, 'Proc to modify the asset path before the host is added'
 
   def initialize(app, options_hash={}, &block)
     super
@@ -27,6 +28,12 @@ class Middleman::Extensions::AssetHost < ::Middleman::Extension
       dirpath.join(asset_path).to_s
     else
       asset_path
+    end
+
+    full_asset_path = if options[:asset_path_rewriter].is_a?(Proc)
+      options[:asset_path_rewriter].call(full_asset_path)
+    else
+      full_asset_path
     end
 
     asset_prefix = if options[:host].is_a?(Proc)


### PR DESCRIPTION
👋 Hello!

This adds an option for a proc called `asset_path_rewriter` to the extension. 

I was hoping to add this option for the AssetHost extension because our CDN can rewrite file names to remove special characters.