### PR TITLE
Reduce dependabot frequency

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,11 @@
+# Create Pull-Requests for NPM updates automatically
+# https://dependabot.com/docs/config-file/
+
+version: 1
+update_configs:
+  # Keep package.json (& lockfiles) up to date.
+  # Security updates will be created immediately,
+  # other updates monthly, to cut down on repo noise.
+  - package_manager: "ruby:bundler"
+    directory: "/"
+    update_schedule: "monthly"


### PR DESCRIPTION
Avoid too much noise in commit list, hides relevant commits in a heap of (mostly) irrelevant ones.