### PR TITLE
Ruby 3.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: xenial
 cache: bundler
 rvm:
   - ruby-head
+  - 3.0
   - 2.7
   - 2.6
   - 2.5

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'rspec', '~> 3.10', require: false
 # Pry tools
 gem 'pry'
 gem 'pry-rescue'
-gem 'pry-stack_explorer'
+gem 'pry-stack_explorer', require: false
 
 # Optional middleman dependencies, included for tests
 gem 'coffee-script', '~> 2.2', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,7 @@ PATH
       tilt (~> 2.0.9)
       toml
       uglifier (~> 4.1)
+      webrick
 
 GEM
   remote: https://rubygems.org/
@@ -254,6 +255,7 @@ GEM
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.7.0)
+    webrick (1.7.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yard (0.9.25)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,7 @@ GEM
       timers (~> 4.1)
     async-dns (1.2.5)
       async-io (~> 1.15)
-    async-io (1.30.0)
+    async-io (1.30.1)
       async (~> 1.14)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
@@ -294,4 +294,4 @@ DEPENDENCIES
   yard (~> 0.9.11)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency('dotenv')
   s.add_dependency('rgl', ['~> 0.5.3'])
   s.add_dependency('toml')
+  s.add_dependency('webrick')
 
   # Helpers
   s.add_dependency('activesupport', ['>= 5.0.0'])


### PR DESCRIPTION
Add dependency on WEBrick in Ruby 3.0 and above as it has been removed from the stdlib.