### PR TITLE
CI: Workaround YAML gotcha in Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, macos]
-        ruby-version: [3.0, 2.7]
+        ruby-version: ['3.0', 2.7]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby


### PR DESCRIPTION
To avoid unexpectedly stop testing Ruby 3.0 when Ruby 3.1 is released.

See https://github.com/actions/runner/issues/849

At https://github.com/middleman/middleman/runs/1631689419?check_suite_focus=true#step:3:3 we can see that the setup-ruby action ran with just 3 as the input:

```
Run ruby/setup-ruby@v1
  with:
    ruby-version: 3
```

If we quote the version it works as expected, example at https://github.com/ruby/setup-ruby/runs/1617122299?check_suite_focus=true#step:3:3

```
Run ./
  with:
    ruby-version: 3.0
```