### PR TITLE
CI: No need to run bundle install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
-    - name: Install dependencies
-      run: bundle install
     - name: Runs linter
       run: bundle exec rake rubocop
     - name: Runs tests


### PR DESCRIPTION
https://github.com/ruby/setup-ruby runs `bundle install`

We can see that the step takes 0 seconds at https://github.com/middleman/middleman/runs/1631653509?check_suite_focus=true