### PR TITLE
Require Rack needed by Padrino helpers like mail_to

### DIFF
--- a/middleman-core/lib/middleman-core/core_extensions/default_helpers.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/default_helpers.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'rack'
 require 'padrino-helpers'
 require 'middleman-core/contracts'
 


### PR DESCRIPTION
closes GH-2436