### PR TITLE
Update middleman.gemspec to rely on webrick explicitly

### DIFF
--- a/middleman/middleman.gemspec
+++ b/middleman/middleman.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |s|
   s.add_dependency('haml', ['>= 4.0.5'])
   s.add_dependency('coffee-script', ['~> 2.2'])
   s.add_dependency('kramdown', ['~> 2.3'])
+  s.add_dependency('webrick', ['~> 1.7'])
 end


### PR DESCRIPTION
To solve what's probably the same issue as here: https://github.com/jekyll/jekyll/issues/8523

I've tried roughly this, locally and manually, in order to get middleman to build on ruby 3.0.0.

(I am not really a rubyist. Someone more knowledgeable should definitely double-check this before accepting it.)