### PR TITLE
Allow users to use Active Support 6.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
   remote: middleman-core
   specs:
     middleman-core (4.3.11)
-      activesupport (>= 4.2, < 6.0)
+      activesupport (>= 4.2, < 6.1)
       addressable (~> 2.3)
       backports (~> 3.6)
       bundler (~> 2.0)

--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency('webrick')
 
   # Helpers
-  s.add_dependency('activesupport', ['>= 4.2', '< 6.0'])
+  s.add_dependency('activesupport', ['>= 4.2', '< 6.1'])
   s.add_dependency('padrino-helpers', ['~> 0.13.0'])
   s.add_dependency("addressable", ["~> 2.3"])
   s.add_dependency('memoist', ['~> 0.14'])


### PR DESCRIPTION
We can only use activesupport 6.0.x since activesupport 6.1.0+ requires `i18n >= 1.6, < 2`: https://rubygems.org/gems/activesupport/versions/6.1.0