### PR TITLE
Fix preview server

### DIFF
--- a/middleman-core/lib/middleman-core/preview_server.rb
+++ b/middleman-core/lib/middleman-core/preview_server.rb
@@ -258,7 +258,7 @@ module Middleman
             # use a generated self-signed cert
             http_opts[:SSLCertName] = [
               %w[CN localhost],
-              ['CN', host]
+              ['CN', server_information.server_name]
             ].uniq
             cert, key = create_self_signed_cert(4096, [['CN', server_information.server_name]], server_information.site_addresses, 'Middleman Preview Server')
             http_opts[:SSLCertificate] = cert

--- a/middleman-core/lib/middleman-core/preview_server.rb
+++ b/middleman-core/lib/middleman-core/preview_server.rb
@@ -260,7 +260,7 @@ module Middleman
               %w[CN localhost],
               ['CN', host]
             ].uniq
-            cert, key = create_self_signed_cert(1024, [['CN', server_information.server_name]], server_information.site_addresses, 'Middleman Preview Server')
+            cert, key = create_self_signed_cert(4096, [['CN', server_information.server_name]], server_information.site_addresses, 'Middleman Preview Server')
             http_opts[:SSLCertificate] = cert
             http_opts[:SSLPrivateKey] = key
           end
@@ -309,7 +309,7 @@ module Middleman
         cert.add_extension(aki)
         cert.add_extension ef.create_extension('subjectAltName', aliases.map { |d| "DNS: #{d}" }.join(','))
 
-        cert.sign(rsa, OpenSSL::Digest.new('SHA1'))
+        cert.sign(rsa, OpenSSL::Digest.new('SHA256'))
 
         [cert, rsa]
       end


### PR DESCRIPTION
I tried to use the preview server https. This fails due to an SSL error.

~~~
[2021-07-09 15:48:52] ERROR OpenSSL::SSL::SSLError:
SSL_CTX_use_certificate: ca md too
weak\n\t/usr/local/bundle/gems/webrick-1.7.0/lib/webrick/server.rb:262:in
`initialize'
~~~

Along my way I also fixed a variable which is not set (anymore).