### PR TITLE
fix middleman/ruby process 100% CPU usage problem ( in macOS 11.x Big Sur )

### DIFF
--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -38,7 +38,8 @@ Gem::Specification.new do |s|
   s.add_dependency("padrino-helpers", ["~> 0.12.3"])
 
   # Watcher
-  s.add_dependency("listen", ["~> 3.0.3"])
+  # s.add_dependency("listen", ["~> 3.0.3"])
+  s.add_dependency("listen", ['>= 3.0.5', '< 3.8'])
 
   # i18n
   s.add_dependency("i18n", ["~> 0.7.0"])


### PR DESCRIPTION
## before

<img width="562" alt="before" src="https://user-images.githubusercontent.com/11306350/126879951-f38baf5f-5e71-4111-b087-8dec45141e00.png">

## after

<img width="568" alt="after" src="https://user-images.githubusercontent.com/11306350/126879953-7b5a5b91-13b9-4d7c-b599-9edcbad08494.png">
