### PR TITLE
sitemap/traversal: Use compiled regex for performance improvement

### DIFF
--- a/middleman-core/lib/middleman-core/sitemap/extensions/traversal.rb
+++ b/middleman-core/lib/middleman-core/sitemap/extensions/traversal.rb
@@ -26,9 +26,10 @@ module Middleman
           end
 
           test_expr = parts.join('\\/')
+          test_expr = %r{^#{test_expr}(?:\.[a-zA-Z0-9]+|\/)$}
           # eponymous reverse-lookup
           found = @store.resources.find do |candidate|
-            candidate.path =~ %r{^#{test_expr}(?:\.[a-zA-Z0-9]+|\/)$}
+            candidate.path =~ test_expr
           end
 
           if found


### PR DESCRIPTION
I found when building a large site (Gitlab's Handbook) with a lot of pages, the flame graph was getting stuck quite a bit in the `@store.resources.find` block in `sitemap/extensions/traversal.rb`.

With the change in this MR I was able to decrease the build time from ~3m30s to ~2m20s, a ~33% saving for this specific use case.