### PR TITLE
Typo correction "t̵h̵e̵n̵" "than"

### DIFF
--- a/middleman-core/lib/middleman-core/preview_server.rb
+++ b/middleman-core/lib/middleman-core/preview_server.rb
@@ -194,7 +194,7 @@ module Middleman
 
         unless server_information.port == configured_port
           app.logger.warn format(
-            '== The Middleman uses a different port "%<new_port>s" then the configured one "%<old_port>s" because some other server is listening on that port.',
+            '== The Middleman will use a different port "%<new_port>s" than port "%<old_port>s" as requested, because another server is listening on that port.',
             new_port: server_information.port,
             old_port: configured_port
           )


### PR DESCRIPTION
_Than_ is used in comparisons as a conjunction (as in "she is younger than I am") and as a preposition ("he is taller than me"). _Then_ indicates time. It is used as an adverb ("I lived in Idaho then"), noun ("we'll have to wait until then"), and adjective ("the then-governor").

<img src="https://blog.inkforall.com/wp-content/uploads/2020/10/than-vs-then-1024x683.jpg" width="333"/>