### PR TITLE
Fix HTTPS preview server

### DIFF
--- a/middleman-core/lib/middleman-core/preview_server.rb
+++ b/middleman-core/lib/middleman-core/preview_server.rb
@@ -13,7 +13,7 @@ module Middleman
     class << self
       extend Forwardable
 
-      attr_reader :app, :web_server, :ssl_certificate, :ssl_private_key, :environment, :server_information
+      attr_reader :app, :web_server, :ssl_information, :environment, :server_information
 
       # Start an instance of Middleman::Application
       # @return [void]
@@ -202,8 +202,10 @@ module Middleman
 
         @environment = possible_from_cli(:environment, app.config)
 
-        @ssl_certificate = possible_from_cli(:ssl_certificate, app.config)
-        @ssl_private_key = possible_from_cli(:ssl_private_key, app.config)
+        @ssl_information = {
+          ssl_certificate: possible_from_cli(:ssl_certificate, app.config),
+          ssl_private_key: possible_from_cli(:ssl_private_key, app.config)
+        }
 
         reload_queue = Queue.new
 
@@ -241,6 +243,7 @@ module Middleman
         @web_server = Webrick.new(
           ::Middleman::Rack.new(app).to_app,
           server_information,
+          ssl_information,
           @options[:debug] || false
         )
       end

--- a/middleman-core/lib/middleman-core/preview_server/webrick.rb
+++ b/middleman-core/lib/middleman-core/preview_server/webrick.rb
@@ -7,9 +7,12 @@ require 'webrick/https'
 module Middleman
   class PreviewServer
     class Webrick
-      attr_reader :webrick
+      attr_reader :webrick, :ssl_certificate, :ssl_private_key
 
-      def initialize(rack_app, server_information, is_debug)
+      def initialize(rack_app, server_information, ssl_information, is_debug)
+        @ssl_certificate = ssl_information[:ssl_certificate]
+        @ssl_private_key = ssl_information[:ssl_private_key]
+
         @webrick = setup_webrick(server_information, is_debug)
         webrick.mount '/', ::Rack::Handler::WEBrick, rack_app
       end


### PR DESCRIPTION
### The problem

Middleman crashes when trying to start an HTTPS preview server.

```
…/gems/middleman-2a0ec8f71ad3/middleman-core/lib/middleman-core/preview_server/webrick.rb:40:in `setup_webrick':
undefined local variable or method `ssl_certificate' for #<Middleman::PreviewServer::Webrick:0x…> (NameError)
```

### The cause

When the preview server was refactored in e1b0de9, SSL-related instance variables were left in the original `PreviewServer` class, where the new `PreviewServer::Webrick` can't find them.

### A solution

`PreviewServer::Webrick.new` now accepts an `ssl_information` hash containing the necessary instance variables from the outer `PreviewServer`.