### PR TITLE
Revert "[branch 4.x] Minify JS: migrate from Uglifier to Terser gem to support ES6"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,9 +28,9 @@ PATH
       rack (>= 1.4.5, < 3)
       sassc (~> 2.0)
       servolux
-      terser (~> 1.1)
       tilt (~> 2.0.9)
       toml
+      uglifier (~> 3.0)
       webrick
 
 GEM
@@ -207,8 +207,6 @@ GEM
     temple (0.8.2)
     term-ansicolor (1.7.1)
       tins (~> 1.0)
-    terser (1.1.8)
-      execjs (>= 0.3.0, < 3)
     thor (0.19.4)
     tilt (2.0.10)
     timers (4.0.4)
@@ -219,6 +217,8 @@ GEM
       parslet (>= 1.8.0, < 3.0.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
+    uglifier (3.2.0)
+      execjs (>= 0.3.0, < 3)
     unicode-display_width (2.0.0)
     webrick (1.7.0)
     xpath (2.1.0)

--- a/middleman-core/features/minify_javascript.feature
+++ b/middleman-core/features/minify_javascript.feature
@@ -131,14 +131,14 @@ Feature: Minify Javascript
     Then I should see:
     """
     <script>
-      should(),all.be(),on={one:line};
+      !function(){should(),all.be(),on={one:line}}();
     </script>
     <script>
-      should(),too();
+      !function(){should(),too()}();
     </script>
     <script type='text/javascript'>
       //<!--
-    one,line(),here();
+    !function(){one,line(),here()}();
       //-->
     </script>
     <script type='text/html'>
@@ -159,11 +159,11 @@ Feature: Minify Javascript
     <?='Hello'?>
 
     <script>
-      should(),all.be(),on={one:line};
+      !function(){should(),all.be(),on={one:line}}();
     </script>
     <script type='text/javascript'>
       //<!--
-    one,line(),here();
+    !function(){one,line(),here()}();
       //-->
     </script>
     <script type='text/html'>

--- a/middleman-core/lib/middleman-core/extensions/minify_javascript.rb
+++ b/middleman-core/lib/middleman-core/extensions/minify_javascript.rb
@@ -7,8 +7,8 @@ class Middleman::Extensions::MinifyJavascript < ::Middleman::Extension
   option :inline, false, 'Whether to minify JS inline within HTML files'
   option :ignore, [], 'Patterns to avoid minifying'
   option :compressor, proc {
-    require 'terser'
-    ::Terser.new
+    require 'uglifier'
+    ::Uglifier.new
   }, 'Set the JS compressor to use.'
   option :content_types, %w(application/javascript), 'Content types of resources that contain JS'
   option :inline_content_types, %w(text/html text/php), 'Content types of resources that contain inline JS'

--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -49,7 +49,7 @@ Gem::Specification.new do |s|
   s.add_dependency('sassc', ['~> 2.0'])
 
   # Minify JS
-  s.add_dependency('terser', ['~> 1.1'])
+  s.add_dependency('uglifier', ['~> 3.0'])
   s.add_dependency('execjs', ['~> 2.0'])
 
   # Testing


### PR DESCRIPTION
Reverts middleman/middleman#2531

Deciding to revert for 4.x as the impact on existing projects could be very large. Will instead modify the docs to explain how to enable Terser AND set the default new project template to setup projects with Terser enabled.