### PR TITLE
use YAML.unsafe_load to support Ruby 3.1/Psych 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     name: ubuntu-ruby-${{ matrix.ruby-version }}
     strategy:
       matrix:
-        ruby-version: [3.0, 2.7, 2.6, 2.5]
+        ruby-version: [3.1, 3.0, 2.7, 2.6, 2.5]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/middleman-core/lib/middleman-core/util/data.rb
+++ b/middleman-core/lib/middleman-core/util/data.rb
@@ -120,7 +120,7 @@ module Middleman
       def parse_yaml(content, full_path)
         c = begin
           ::Middleman::Util.instrument 'parse.yaml' do
-            ::YAML.load(content)
+            ::YAML.respond_to?(:unsafe_load) ? ::YAML.unsafe_load(content) : ::YAML.load(content)
           end
         rescue StandardError, ::Psych::SyntaxError => error
           warn "YAML Exception parsing #{full_path}: #{error.message}"


### PR DESCRIPTION
Since `YAML.load` has been changed to an alias of `Psych.safe_load` from Ruby 3.1/Psych 4.0, using Date, Time, etc. cause raise owing to prohibiting of class loading at frontmatter.
https://github.com/ruby/psych/pull/487
To avoid this problem, use `YAML.unsafe_load` if it is definded (`YAML.load` is renamed to `YAML.unsafe_load`).
I think this is better implementation because

- This frontmatter comes from developer's input, so it may be treated as safe input.
- This modification will not break previous behavior of Middleman.

but you can choose passing `permitted_classes` option to `YAML.load` to fix vulnerability.