### PR TITLE
Allow users to use Active Support 7.0 (4.x)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
   remote: middleman-core
   specs:
     middleman-core (4.4.2)
-      activesupport (>= 6.1, < 7.0)
+      activesupport (>= 6.1, < 7.1)
       addressable (~> 2.4)
       backports (~> 3.6)
       bundler (~> 2.0)
@@ -36,7 +36,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.4.1)
+    activesupport (6.1.6.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -243,4 +243,4 @@ DEPENDENCIES
   yard (~> 0.9.20)
 
 BUNDLED WITH
-   2.2.22
+   2.2.33

--- a/middleman-core/lib/middleman-core/util.rb
+++ b/middleman-core/lib/middleman-core/util.rb
@@ -1,5 +1,4 @@
-# For instrumenting
-require 'active_support/notifications'
+require 'active_support/all'
 
 require 'middleman-core/application'
 require 'middleman-core/sources'

--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency('webrick')
 
   # Helpers
-  s.add_dependency('activesupport', ['>= 6.1', '< 7.0'])
+  s.add_dependency('activesupport', ['>= 6.1', '< 7.1'])
   s.add_dependency('padrino-helpers', ['~> 0.15.0'])
   s.add_dependency("addressable", ["~> 2.4"])
   s.add_dependency('memoist', ['~> 0.14'])


### PR DESCRIPTION
- cf. #2462

## Why code change is needed
`require `active_support/all` should be used instead of `require 'active_support/notifications'` to avoid errors in case of use of activesupport 7.0.

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>