### PR TITLE
Use Ruby 3.0.x correctly on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     name: ubuntu-ruby-${{ matrix.ruby-version }}
     strategy:
       matrix:
-        ruby-version: [3.0, 2.7, 2.6, 2.5]
+        ruby-version: ['3.0', 2.7, 2.6, 2.5]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby


### PR DESCRIPTION
As `3.0` is interpreted as `3`, we should use `'3.0'` instead here.

`3.1` is not included in this PR as it was not intended in #2427 and users with Ruby 3.1 can/should use Middleman 5.0.rc.XX.

- Fixes up #2427
- Blocks #2552
- Blocks #2556
- Blocks #2554

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)