### PR TITLE
[4.x] Avoid continue-on-error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
-    continue-on-error: true
     name: ubuntu-ruby-${{ matrix.ruby-version }}
     strategy:
       matrix:


### PR DESCRIPTION
We can track errors on CI with a removal of `continue-on-error: true`.

With #2553 and #2557, all jobs with Ruby 2.5 through 3.0 have been green.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)