### PR TITLE
Allow Middleman::Sitemap::ResourceListContainer to delegate each_with_index

### DIFF
--- a/middleman-core/lib/middleman-core/sitemap/resource_list_container.rb
+++ b/middleman-core/lib/middleman-core/sitemap/resource_list_container.rb
@@ -10,7 +10,7 @@ module Middleman
       extend Forwardable
       include Contracts
 
-      def_delegators :without_ignored, :each, :find, :select, :reject, :map
+      def_delegators :without_ignored, :each, :each_with_index, :find, :select, :reject, :map
 
       Contract Maybe[ArrayOf[Resource]] => Any
       def initialize(initial = nil)


### PR DESCRIPTION
Allow `Middleman::Sitemap::ResourceListContainer` to delegate `each_with_index`.

For example, [middleman-search 0.10.0 gem](https://rubygems.org/gems/middleman-search/versions/0.10.0) uses this delegated method:
https://github.com/manastech/middleman-search/blob/ed9e5254bb554988c755fc40238d9e9f67b20abe/lib/middleman-search/search-index-resource.rb#L80

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>