### PR TITLE
[4.x] Backport 936d19c to middleman core dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
       addressable (~> 2.4)
       backports (~> 3.6)
       bundler (~> 2.0)
-      contracts (~> 0.13.0)
+      contracts (~> 0.13)
       dotenv
       erubis
       execjs (~> 2.0)
@@ -21,7 +21,7 @@ PATH
       hamster (~> 3.0)
       hashie (~> 3.4)
       i18n (~> 1.6.0)
-      listen (~> 3.0.0)
+      listen (~> 3.0)
       memoist (~> 0.14)
       padrino-helpers (~> 0.15.0)
       parallel

--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_dependency('memoist', ['~> 0.14'])
 
   # Watcher
-  s.add_dependency('listen', ['~> 3.0.0'])
+  s.add_dependency('listen', ['~> 3.0'])
 
   # i18n
   s.add_dependency('i18n', ['~> 1.6.0'])
@@ -53,7 +53,7 @@ Gem::Specification.new do |s|
   s.add_dependency('execjs', ['~> 2.0'])
 
   # Testing
-  s.add_dependency('contracts', ['~> 0.13.0'])
+  s.add_dependency('contracts', ['~> 0.13'])
 
   # Hash stuff
   s.add_dependency('hashie', ['~> 3.4'])


### PR DESCRIPTION
Backports 936d19c from master branch to 4.x branch for middleman-core dependency for [listen](https://rubygems.org/gems/listen) `~> 3.0` and [contracts](https://rubygems.org/gems/contracts) `~> 0.13`.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)