### PR TITLE
Lock haml to < 6.0

### DIFF
--- a/middleman/middleman.gemspec
+++ b/middleman/middleman.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('middleman-core', Middleman::VERSION)
   s.add_dependency('middleman-cli', Middleman::VERSION)
-  s.add_dependency('haml', ['>= 4.0.5'])
+  s.add_dependency('haml', ['>= 4.0.5', '< 6.0'])
   s.add_dependency('coffee-script', ['~> 2.2'])
   s.add_dependency('kramdown', ['>= 2.3.0'])
 end


### PR DESCRIPTION
6.0 introduces breaking changes. Lock haml to <6 for now to keep Middleman working. Fixes #2569.