### PR TITLE
Fix 18n fallback when "mount_at_root" is false (4.x)

### DIFF
--- a/middleman-core/features/i18n_builder.feature
+++ b/middleman-core/features/i18n_builder.feature
@@ -123,8 +123,10 @@ Feature: i18n Builder
       | hello.html                                    |
     And the file "en/index.html" should contain "Howdy"
     And the file "en/hello.html" should contain "Hello World"
+    And the file "en/fallback.html" should contain "Fallback"
     And the file "es/index.html" should contain "Como Esta?"
     And the file "es/hola.html" should contain "Hola World"
+    And the file "es/fallback.html" should contain "Fallback"
 
   Scenario: Running localize with the subset config
     Given a fixture app "i18n-test-app"

--- a/middleman-core/fixtures/i18n-test-app/locales/en.yml
+++ b/middleman-core/fixtures/i18n-test-app/locales/en.yml
@@ -2,3 +2,4 @@
 en:
   greetings: "Howdy"
   hi: "Hello"
+  fallback: "Fallback"

--- a/middleman-core/fixtures/i18n-test-app/source/localizable/fallback.html.erb
+++ b/middleman-core/fixtures/i18n-test-app/source/localizable/fallback.html.erb
@@ -1,0 +1,1 @@
+<%= I18n.t(:fallback) %>

--- a/middleman-core/lib/middleman-core/core_extensions/i18n.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/i18n.rb
@@ -236,7 +236,7 @@ class Middleman::CoreExtensions::Internationalization < ::Middleman::Extension
 
     # Reset fallbacks to fall back to our new default
     if ::I18n.respond_to?(:fallbacks)
-      ::I18n.fallbacks = ::I18n::Locale::Fallbacks.new(@mount_at_root)
+      ::I18n.fallbacks = ::I18n::Locale::Fallbacks.new(::I18n.default_locale)
     end
   end
 


### PR DESCRIPTION
Backport of #2602 to the 4.x branch.

Fixes #2596 in the 4.x branch.