### PR TITLE
Use Addressable instead of Webrick for encode/unencode

### DIFF
--- a/middleman-core/lib/middleman-core/builder.rb
+++ b/middleman-core/lib/middleman-core/builder.rb
@@ -1,3 +1,4 @@
+require 'addressable/uri'
 require 'pathname'
 require 'fileutils'
 require 'tempfile'
@@ -229,7 +230,7 @@ module Middleman
           if resource.binary?
             export_file!(output_file, resource.file_descriptor[:full_path])
           else
-            response = @rack.get(::WEBrick::HTTPUtils.escape(resource.request_path))
+            response = @rack.get(Addressable::URI.encode(resource.request_path))
 
             # If we get a response, save it to a tempfile.
             if response.status == 200

--- a/middleman-core/lib/middleman-core/extensions/asset_hash.rb
+++ b/middleman-core/lib/middleman-core/extensions/asset_hash.rb
@@ -1,3 +1,4 @@
+require 'addressable/uri'
 require 'middleman-core/util'
 require 'middleman-core/rack'
 
@@ -87,7 +88,7 @@ class Middleman::Extensions::AssetHash < ::Middleman::Extension
     else
       # Render through the Rack interface so middleware and mounted apps get a shot
       response = @rack_client.get(
-        ::WEBrick::HTTPUtils.escape(resource.destination_path),
+        Addressable::URI.encode(resource.destination_path),
         'bypass_inline_url_rewriter_asset_hash' => 'true'
       )
 

--- a/middleman-core/lib/middleman-core/rack.rb
+++ b/middleman-core/lib/middleman-core/rack.rb
@@ -3,7 +3,7 @@ require 'rack/file'
 require 'rack/lint'
 require 'rack/head'
 require 'rack/utils'
-require 'webrick'
+require 'addressable/uri'
 
 require 'middleman-core/util'
 require 'middleman-core/logger'
@@ -87,7 +87,7 @@ module Middleman
     def process_request(env, req, res)
       start_time = Time.now
 
-      request_path = WEBrick::HTTPUtils.unescape(env['PATH_INFO'].dup)
+      request_path = Addressable::URI.unencode(env['PATH_INFO'].dup)
       if request_path.respond_to? :force_encoding
         request_path.force_encoding('UTF-8')
       end

--- a/middleman-core/lib/middleman-core/step_definitions/server_steps.rb
+++ b/middleman-core/lib/middleman-core/step_definitions/server_steps.rb
@@ -1,7 +1,7 @@
 require 'middleman-core/rack'
 require 'rspec/expectations'
 require 'capybara/cucumber'
-require 'webrick'
+require 'addressable/uri'
 
 Given /^a clean server$/ do
   @initialize_commands = []
@@ -73,11 +73,11 @@ Given /^a template named "([^\"]*)" with:$/ do |name, string|
 end
 
 When /^I go to "([^\"]*)"$/ do |url|
-  visit(WEBrick::HTTPUtils.escape(url))
+  visit(Addressable::URI.encode(url))
 end
 
 Then /^going to "([^\"]*)" should not raise an exception$/ do |url|
-  expect{ visit(WEBrick::HTTPUtils.escape(url)) }.to_not raise_exception
+  expect { visit(Addressable::URI.encode(url)) }.to_not raise_exception
 end
 
 Then /^the content type should be "([^\"]*)"$/ do |expected|

--- a/middleman-core/lib/middleman-core/util/paths.rb
+++ b/middleman-core/lib/middleman-core/util/paths.rb
@@ -4,7 +4,6 @@ require 'uri'
 require 'addressable/uri'
 require 'memoist'
 require 'tilt'
-require 'webrick'
 
 require 'middleman-core/contracts'
 
@@ -34,7 +33,7 @@ module Middleman
     Contract String => String
     def normalize_path(path)
       # The tr call works around a bug in Ruby's Unicode handling
-      WEBrick::HTTPUtils.unescape(path).sub(%r{^/}, '').tr('', '')
+      Addressable::URI.unencode(path).sub(%r{^/}, '').tr('', '')
     end
     memoize :normalize_path
 


### PR DESCRIPTION
This is a backport of 433a4242e411e9f70077aeff5fca51f68b2d0120 from master, but removing the unrelated changes in the Gemfile.lock.

I particularly need this because the use of  `WEBrick::HTTPUtils.unescape` (introduced in 7c155c298a445f1cc2fb0154721cee260ba333a8) is not totally compatible with `URI.decode`, that was used before, because it does not support unicode chars in the URL. 

 `Addressable::URI.unencode`, already in `master`, works as expected. Ir would be great to backport that change to this branch (`4.x`). 