### PR TITLE
Add support for Ruby 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     name: ubuntu-ruby-${{ matrix.ruby-version }}
     strategy:
       matrix:
-        ruby-version: ["3.0", "2.7", "2.6", "2.5"]
+        ruby-version: ["3.1", "3.0", "2.7", "2.6", "2.5"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby

--- a/middleman-cli/.simplecov
+++ b/middleman-cli/.simplecov
@@ -1,4 +1,4 @@
-SimpleCov.start do
+SimpleCov.configure do
   add_filter '/fixtures/'
   add_filter '/features/'
   add_filter '/spec/'

--- a/middleman-core/.simplecov
+++ b/middleman-core/.simplecov
@@ -1,4 +1,4 @@
-SimpleCov.start do
+SimpleCov.configure do
   add_filter '/fixtures/'
   add_filter '/features/'
   add_filter '/spec/'

--- a/middleman/.simplecov
+++ b/middleman/.simplecov
@@ -1,4 +1,4 @@
-SimpleCov.start do
+SimpleCov.configure do
   add_filter '/fixtures/'
   add_filter '/features/'
   add_filter '/spec/'


### PR DESCRIPTION
This PR adds Ruby 3.1 to the continuous integration tests, and fixes issue #2614, so that Middleman will work with Ruby 3.1.

Support for older versions of Ruby is retained; a bit of messing around is needed with the arguments to `YAML.safe_load` but otherwise things work fine.

Closes #2614.