### PR TITLE
Support more types being extracted from YAML

### DIFF
--- a/middleman-core/features/front-matter.feature
+++ b/middleman-core/features/front-matter.feature
@@ -80,6 +80,27 @@ Feature: YAML Front Matter
     When I go to "/front-matter-change.html"
     Then I should see "Hello World"
 
+  Scenario: A template should handle YAML with types
+    Given the Server is running at "frontmatter-app"
+    And the file "source/front-matter-types.html.erb" has the contents
+      """
+      ---
+      date_matter: 2020-01-01
+      time_matter: 2020-12-31 13:14:15 +0000
+      symbol_matter: :a_symbol
+      regexp_matter: !ruby/regexp /a|b/
+      ---
+      Date: <%= current_page.data.date_matter.strftime('%d %m %Y') %>
+      Time: <%= current_page.data.time_matter.strftime('%d %m %Y %H::%M::%S %z') %>
+      Symbol: <%= current_page.data.symbol_matter.is_a? Symbol %>
+      Regexp: <%= "za" =~ current_page.data.regexp_matter %>
+      """
+    When I go to "/front-matter-types.html"
+    Then I should see "Date: 01 01 2020"
+    Then I should see "Time: 31 12 2020 13::14::15 +0000"
+    Then I should see "Symbol: true"
+    Then I should see "Regexp: 1"
+
   Scenario: Rendering raw (template-less) (toml)
     Given the Server is running at "frontmatter-app"
     When I go to "/raw-front-matter-toml.html"

--- a/middleman-core/lib/middleman-core/util/data.rb
+++ b/middleman-core/lib/middleman-core/util/data.rb
@@ -118,7 +118,7 @@ module Middleman
       # @return [Hash]
       Contract String, Pathname => Hash
       def parse_yaml(content, full_path)
-        permitted_classes = [Date, Symbol]
+        permitted_classes = [Date, Time, DateTime, Symbol, Regexp]
         c = begin
           ::Middleman::Util.instrument 'parse.yaml' do
             allowed_parameters = ::YAML.method(:safe_load).parameters


### PR DESCRIPTION
# What

For platforms that use YAML::safe_load we have to say which types are supported otherwise the data is rejected when loaded.  In adding ruby 3.1 support (see #2635) we allowed Date and Symbol classes, however in the 5.x branch we support Date, DateTime, Time, Symbol and Regexp by default (see #2528 - specifically 74b01d768b568fd35d163390ead59ad2a09bddd2).  This commit brings the same set of types into the 4.x branch.

# Why

We use middleman for the [lrug.org](https://github.com/lrug/lrug.org) site and while exploring upgrading to ruby 3.2 everything broke because we have timestamps in the front matter.  The simplest solution (short of us rewriting all our frontmatter) seems to be extending the support already present in 4.x to allow a few more types that YAML will automatically extract if you let it.  The 5.x branch has a wider set of classes, and so we assume that's a safe enough set to use.

# Questions

I added a feature file to provide regression testing for this feature, to make sure that the set of types we support from YAML will continue working if new ruby versions change things up further.  Is that the best way to to this?  Should it be a spec instead?