### PR TITLE
Enable stale bot again (ported from MM v5 branch)

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,22 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 90
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 30
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+  - notstale
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false
+# Ignore issues in a milestone
+exemptMilestones: true
+# Ignore issues with an assignee
+exemptAssignees: true


### PR DESCRIPTION
Ported from MM v5 branch, which was `main` branch some months ago: https://github.com/middleman/middleman/blob/5.x/.github/stale.yml