### PR TITLE
Use contracts ~> 0.17 when ruby version is at least v3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,3 +46,9 @@ gem 'middleman-core', path: 'middleman-core'
 
 # gem 'middleman-compass', github: 'middleman/middleman-compass', require: false
 # gem 'middleman-sprockets', github: 'middleman/middleman-sprockets', require: false
+
+if RUBY_VERSION < '3.0.0'
+  gem 'contracts', '~> 0.13', '< 0.17'
+else
+  gem 'contracts', '~> 0.17'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
       addressable (~> 2.4)
       backports (~> 3.6)
       bundler (~> 2.0)
-      contracts (~> 0.13, < 0.17)
+      contracts (~> 0.13, < 0.18)
       dotenv
       erubis
       execjs (~> 2.0)
@@ -75,7 +75,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.2.3)
-    contracts (0.16.1)
+    contracts (0.17)
     cucumber (3.2.0)
       builder (>= 2.1.2)
       cucumber-core (~> 3.2.0)
@@ -238,6 +238,7 @@ DEPENDENCIES
   byebug
   capybara
   coffee-script (~> 2.2)
+  contracts (~> 0.17)
   cucumber
   haml (~> 4.0)
   kramdown (~> 2.4)

--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -53,7 +53,7 @@ Gem::Specification.new do |s|
   s.add_dependency('execjs', ['~> 2.0'])
 
   # Testing
-  s.add_dependency('contracts', ['~> 0.13', '< 0.17'])
+  s.add_dependency('contracts', ['~> 0.13', '< 0.18'])
 
   # Hash stuff
   s.add_dependency('hashie', ['~> 3.4'])


### PR DESCRIPTION
`contracts` should use v0.17 (now that it is available) when using Ruby version >= 3.0.0, since if using Ruby v2 then `contracts` v0.16 should be used.

Conditionals that was seen in previous commits in the middleman-core Gemfile have been readded in order to install the appropriate `contracts` gem version based on Ruby version used.

If there is anything missing or glaring that I might not be aware of, please point it out!