### PR TITLE
Unlock contracts version restriction

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
       addressable (~> 2.4)
       backports (~> 3.6)
       bundler (~> 2.0)
-      contracts (~> 0.13, < 0.17)
+      contracts
       dotenv
       erubis
       execjs (~> 2.0)
@@ -75,7 +75,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.2.3)
-    contracts (0.16.1)
+    contracts (0.17)
     cucumber (3.2.0)
       builder (>= 2.1.2)
       cucumber-core (~> 3.2.0)

--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -53,7 +53,7 @@ Gem::Specification.new do |s|
   s.add_dependency('execjs', ['~> 2.0'])
 
   # Testing
-  s.add_dependency('contracts', ['~> 0.13', '< 0.17'])
+  s.add_dependency('contracts')
 
   # Hash stuff
   s.add_dependency('hashie', ['~> 3.4'])


### PR DESCRIPTION
This patch simply removes contracts dependency version restriction. Since our codebase now runs on any released contracts versions since #2667.

resolves #2685