### PR TITLE
Relax haml dependency to allow haml 5 and 6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ PATH
       execjs (~> 2.0)
       fast_blank
       fastimage (~> 2.0)
-      haml (~> 4.0)
+      haml (>= 4.0.5)
       hamster (~> 3.0)
       hashie (>= 3.4, < 6.0)
       i18n (>= 1.6, < 1.15)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,9 @@ GEM
     ffi (1.17.1-x86_64-darwin)
     ffi (1.17.1-x86_64-linux-gnu)
     ffi (1.17.1-x86_64-linux-musl)
-    haml (4.0.7)
+    haml (6.3.0)
+      temple (>= 0.8.2)
+      thor
       tilt
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)

--- a/middleman-core/features/minify_javascript.feature
+++ b/middleman-core/features/minify_javascript.feature
@@ -19,23 +19,23 @@ Feature: Minify Javascript
       })();
     </script>
     <script>
-      ;(function() {
-        this;
-        should();
-        too();
-      })();
+    ;(function() {
+      this;
+      should();
+      too();
+    })();
     </script>
     <script type='text/javascript'>
-      //<!--
-      ;(function() {
-        one;
-        line();
-        here();
-      })();
-      //-->
+    //<!--
+    ;(function() {
+      one;
+      line();
+      here();
+    })();
+    //-->
     </script>
     <script type='text/html'>
-      I'm a jQuery {{template}}.
+    I'm a jQuery {{template}}.
     </script>
     """
 
@@ -66,23 +66,23 @@ Feature: Minify Javascript
       })();
     </script>
     <script>
-      ;(function() {
-        this;
-        should();
-        too();
-      })();
+    ;(function() {
+      this;
+      should();
+      too();
+    })();
     </script>
     <script type='text/javascript'>
-      //<!--
-      ;(function() {
-        one;
-        line();
-        here();
-      })();
-      //-->
+    //<!--
+    ;(function() {
+      one;
+      line();
+      here();
+    })();
+    //-->
     </script>
     <script type='text/html'>
-      I'm a jQuery {{template}}.
+    I'm a jQuery {{template}}.
     </script>
     """
 
@@ -108,15 +108,15 @@ Feature: Minify Javascript
       Hello
     </script>
     <script>
-      Hello
+    Hello
     </script>
     <script type='text/javascript'>
-      //<!--
+    //<!--
     Hello
-      //-->
+    //-->
     </script>
     <script type='text/html'>
-      I'm a jQuery {{template}}.
+    I'm a jQuery {{template}}.
     </script>
     """
 
@@ -134,15 +134,15 @@ Feature: Minify Javascript
       should(),all.be(),on={one:line};
     </script>
     <script>
-      should(),too();
+    should(),too();
     </script>
     <script type='text/javascript'>
-      //<!--
+    //<!--
     one,line(),here();
-      //-->
+    //-->
     </script>
     <script type='text/html'>
-      I'm a jQuery {{template}}.
+    I'm a jQuery {{template}}.
     </script>
     """
 

--- a/middleman-core/features/support/env.rb
+++ b/middleman-core/features/support/env.rb
@@ -7,6 +7,14 @@ SimpleCov.root(File.expand_path(File.dirname(__FILE__) + '/../..'))
 
 SimpleCov.start
 
+require "rspec"
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.max_formatted_output_length = nil
+  end
+end
+
 PROJECT_ROOT_PATH = File.dirname(File.dirname(File.dirname(__FILE__)))
 require File.join(PROJECT_ROOT_PATH, 'lib', 'middleman-core')
 require File.join(PROJECT_ROOT_PATH, 'lib', 'middleman-core', 'step_definitions')

--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency('rack', '>= 1.4.5', '< 4')
   s.add_dependency('tilt', ['~> 2.0'])
   s.add_dependency('erubis')
-  s.add_dependency('haml', ['~> 4.0'])
+  s.add_dependency('haml', ['>= 4.0.5'])
   s.add_dependency('coffee-script', ['~> 2.2'])
   s.add_dependency('kramdown', ['~> 2.4'])
   s.add_dependency('fast_blank')


### PR DESCRIPTION
Haml 6 is supported by middleman's main branch, however, it became uninstallable since https://github.com/middleman/middleman/commit/6bf52366abf0ca89549e38b4873b701c66032f44.

Instead, the dependency from `middleman.gemspec` should've been preserved.