### PR TITLE
Support tilt 2.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ PATH
       coffee-script (~> 2.2)
       contracts
       dotenv
-      erubis
+      erubi
       execjs (~> 2.0)
       fast_blank
       fastimage (~> 2.0)
@@ -115,7 +115,7 @@ GEM
     docile (1.4.1)
     dotenv (3.1.7)
     drb (2.2.1)
-    erubis (2.7.0)
+    erubi (1.13.1)
     execjs (2.10.0)
     fast_blank (1.0.1)
     fastimage (2.3.1)

--- a/middleman-core/lib/middleman-core/renderers/erb.rb
+++ b/middleman-core/lib/middleman-core/renderers/erb.rb
@@ -6,7 +6,7 @@ module Middleman
         ::Tilt.prefer(Template, :erb)
       end
 
-      class Template < ::Tilt::ErubisTemplate
+      class Template < ::Tilt::ErubiTemplate
         ##
         # In preamble we need a flag `__in_erb_template` and SafeBuffer for padrino apps.
         #

--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency('bundler', '~> 2.0')
   s.add_dependency('rack', '>= 1.4.5', '< 4')
   s.add_dependency('tilt', ['~> 2.0'])
-  s.add_dependency('erubis')
+  s.add_dependency('erubi')
   s.add_dependency('haml', ['>= 4.0.5'])
   s.add_dependency('coffee-script', ['~> 2.2'])
   s.add_dependency('kramdown', ['~> 2.4'])


### PR DESCRIPTION
Tilt 2.5 removed the erubis template. The maintained template is erubi.

See https://github.com/jeremyevans/tilt/blob/17af3a300ce4bcc79a93901ade7b2e48b6105cbf/docs/TEMPLATES.md#erubi.