### PR TITLE
Fix tilt 2.5 deprecations

### DIFF
--- a/middleman-core/lib/middleman-core/application.rb
+++ b/middleman-core/lib/middleman-core/application.rb
@@ -300,8 +300,6 @@ module Middleman
         Encoding.default_external = config[:encoding]
       end
 
-      prune_tilt_templates!
-
       # After extensions have worked after_config
       execute_callbacks(:after_configuration)
 
@@ -341,17 +339,6 @@ module Middleman
 
       logger.debug "== Reading: #{config[:environment]} config"
       config_context.instance_eval File.read(env_config), env_config, 1
-    end
-
-    # Clean up missing Tilt exts
-    def prune_tilt_templates!
-      ::Tilt.default_mapping.lazy_map.each_key do |key|
-        begin
-          ::Tilt[".#{key}"]
-        rescue LoadError, NameError
-          ::Tilt.default_mapping.lazy_map.delete(key)
-        end
-      end
     end
 
     # Whether we're in a specific mode

--- a/middleman-core/lib/middleman-core/sources/source_watcher.rb
+++ b/middleman-core/lib/middleman-core/sources/source_watcher.rb
@@ -335,7 +335,7 @@ module Middleman
 
     Contract Pathname => Pathname
     def strip_extensions(p)
-      p = p.sub_ext('') while ::Tilt[p.to_s] || p.extname == '.html'
+      p = p.sub_ext('') while Middleman::Util.tilt_class(p.to_s) || p.extname == '.html'
       Pathname(p.to_s + '.*')
     end
 

--- a/middleman-core/lib/middleman-core/util/paths.rb
+++ b/middleman-core/lib/middleman-core/util/paths.rb
@@ -23,6 +23,8 @@ module Middleman
     Contract String => Any
     def tilt_class(path)
       ::Tilt[path]
+    rescue LoadError
+      nil
     end
     memoize :tilt_class
 


### PR DESCRIPTION
When using tilt 2.5, you get a lot of deprecation messages like this:

```
Lazy loading of org templates is deprecated and will be removed in Tilt 3.  Require org-ruby manually.
```

And similarly with many other templates.

This change seems to fix the problem by not eagerly looping through all templates to remove the ones not available.

`:Tilt.default_mapping.lazy_map` is explicitly documented as [private](https://github.com/jeremyevans/tilt/blob/17af3a300ce4bcc79a93901ade7b2e48b6105cbf/lib/tilt/mapping.rb#L128-L129), so not using that seems like a good change too.