### PR TITLE
Fix erb preview regression

### DIFF
--- a/middleman-core/features/preview_changes.feature
+++ b/middleman-core/features/preview_changes.feature
@@ -27,3 +27,14 @@ Feature: Preview Changes
     And the file "source/a-page.html.erb" is removed
     When I go to "/a-page.html"
     Then I should see "File Not Found"
+
+  Scenario: A template with apostrophe is reloaded during preview
+    Given the Server is running at "preview-app"
+    And the file "source/a-page.html.erb" has the contents
+      """
+      Matz's Ruby Interpreter
+      """
+    When I go to "/a-page.html"
+    Then I should see "Matz's Ruby Interpreter"
+    When I go to "/a-page.html"
+    Then I should see "Matz's Ruby Interpreter"

--- a/middleman-core/lib/middleman-core/file_renderer.rb
+++ b/middleman-core/lib/middleman-core/file_renderer.rb
@@ -68,14 +68,8 @@ module Middleman
 
       # Read compiled template from disk or cache
       template = ::Tilt.new(path, 1, options) { body }
-      # template = cache.fetch(:compiled_template, extension, options, body) do
-      #   ::Tilt.new(path, 1, options) { body }
-      # end
 
       # Render using Tilt
-      # content = ::Middleman::Util.instrument 'render.tilt', path: path do
-      #   template.render(context, locs, &block)
-      # end
       content = template.render(context, locs, &block)
 
       # Allow hooks to manipulate the result after render

--- a/middleman-core/lib/middleman-core/file_renderer.rb
+++ b/middleman-core/lib/middleman-core/file_renderer.rb
@@ -67,7 +67,7 @@ module Middleman
       end
 
       # Read compiled template from disk or cache
-      template = ::Tilt.new(path, 1, options) { body }
+      template = ::Tilt.new(path, 1, options) { body.dup }
 
       # Render using Tilt
       content = template.render(context, locs, &block)


### PR DESCRIPTION
The ERB engine was switched to Erubi recently. The Erubi template modifies template data in-place, when it has apostrophes. Since the data we pass to the template holds a reference to the front matter file cache, it will be modified for the subsequent request.

We need to pass a copy instead.