### PR TITLE
Respect configured encoding when rendering erb templates

### DIFF
--- a/middleman-core/lib/middleman-core/renderers/erb.rb
+++ b/middleman-core/lib/middleman-core/renderers/erb.rb
@@ -7,12 +7,25 @@ module Middleman
       end
 
       class Template < ::Tilt::ErubiTemplate
+        def initialize(*args, &block)
+          super
+
+          @context = @options[:context]
+        end
+
         ##
         # In preamble we need a flag `__in_erb_template` for padrino apps.
         #
         def precompiled_preamble(locals)
           original = super
           "__in_erb_template = true\n" << original
+        end
+
+        ##
+        # Force the template the use the configured encoding.
+        #
+        def precompiled_template(locals)
+          super.dup.force_encoding(@context.app.config[:encoding])
         end
       end
     end

--- a/middleman-core/lib/middleman-core/renderers/erb.rb
+++ b/middleman-core/lib/middleman-core/renderers/erb.rb
@@ -8,12 +8,11 @@ module Middleman
 
       class Template < ::Tilt::ErubiTemplate
         ##
-        # In preamble we need a flag `__in_erb_template` and SafeBuffer for padrino apps.
+        # In preamble we need a flag `__in_erb_template` for padrino apps.
         #
         def precompiled_preamble(locals)
           original = super
           "__in_erb_template = true\n" << original
-          # .rpartition("\n").first << "#{@outvar} = _buf = ActiveSupport::SafeBuffer.new\n"
         end
       end
     end

--- a/middleman-core/lib/middleman-core/renderers/haml.rb
+++ b/middleman-core/lib/middleman-core/renderers/haml.rb
@@ -23,7 +23,7 @@ module Middleman
       def initialize(*args, &block)
         super
 
-        @context = @options[:context] if @options.key?(:context)
+        @context = @options[:context]
       end
 
       def prepare; end

--- a/middleman-core/lib/middleman-core/renderers/kramdown.rb
+++ b/middleman-core/lib/middleman-core/renderers/kramdown.rb
@@ -7,7 +7,7 @@ module Middleman
       def initialize(*args, &block)
         super
 
-        @context = @options[:context] if @options.key?(:context)
+        @context = @options[:context]
       end
 
       def evaluate(context, *)

--- a/middleman-core/lib/middleman-core/renderers/redcarpet.rb
+++ b/middleman-core/lib/middleman-core/renderers/redcarpet.rb
@@ -13,7 +13,7 @@ module Middleman
       def initialize(*args, &block)
         super
 
-        @context = @options[:context] if @options.key?(:context)
+        @context = @options[:context]
       end
 
       # Overwrite built-in Tilt version.

--- a/middleman-core/lib/middleman-core/renderers/sass.rb
+++ b/middleman-core/lib/middleman-core/renderers/sass.rb
@@ -32,7 +32,7 @@ module Middleman
         def initialize(*args, &block)
           super
 
-          @context = @options[:context] if @options.key?(:context)
+          @context = @options[:context]
         end
 
         # Define the expected syntax for the template


### PR DESCRIPTION
This addresses test failures in https://github.com/middleman/middleman-blog/pull/390.