### PR TITLE
Add concurrent-ruby-1.3.4 as a dependency to address issues with activesupport

### DIFF
--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
 
   # Helpers
   s.add_dependency('activesupport', ['>= 6.1'])
+  s.add_dependency("concurrent-ruby", "1.3.4")
   s.add_dependency('padrino-helpers', ['~> 0.15.0'])
   s.add_dependency("addressable", ["~> 2.4"])
   s.add_dependency('memoist', ['~> 0.14'])


### PR DESCRIPTION
As mentioned in https://github.com/middleman/middleman/issues/2788 a fresh install of Middleman breaks when trying to use the CLI to create a new project. This PR adds `concurrent-ruby-1.3.4` as a dependency to `middleman-core` to address the issue as described in https://github.com/alphagov/tech-docs-gem/commit/a7dc7dc409ec127a6a951f5c1d9c11833aa9a86a

Verified that this fixes the issue with the CLI on a locally built and installed gem.