### PR TITLE
Workaround activesupport issue

### DIFF
--- a/middleman-core/lib/middleman-core/util.rb
+++ b/middleman-core/lib/middleman-core/util.rb
@@ -1,3 +1,9 @@
+if RUBY_VERSION < "3.2"
+  require "active_support/version"
+
+  require "logger" if ActiveSupport.version < Gem::Version.new("8.0.0")
+end
+
 require 'active_support/all'
 
 require 'middleman-core/application'

--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |s|
 
   # Helpers
   s.add_dependency('activesupport', ['>= 6.1'])
-  s.add_dependency("concurrent-ruby", "1.3.4")
   s.add_dependency('padrino-helpers', ['~> 0.15.0'])
   s.add_dependency("addressable", ["~> 2.4"])
   s.add_dependency('memoist', ['~> 0.14'])


### PR DESCRIPTION
The missing logger require is fixed in activesupport v8 or higher. And middleman can be used with Rails 8 as long as Ruby 3.2 or higher is used.

So add the missing logger dependency whenever activesupport is not modern enough, and old Ruby is used.

Users of more modern rubies may still run into the issue, but in that case the preferred fix is to upgrade activesupport.