### PR TITLE
Allow upgrade to thor 1.3.x by correcting `init` behaviour

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: middleman-cli
   specs:
     middleman-cli (4.6.0)
-      thor (>= 0.17.0, < 1.3.0)
+      thor (>= 0.17.0, < 2)
 
 PATH
   remote: middleman-core
@@ -266,7 +266,7 @@ GEM
     sys-uname (1.3.1)
       ffi (~> 1.1)
     temple (0.10.3)
-    thor (1.2.2)
+    thor (1.3.2)
     tilt (2.6.0)
     timers (4.0.4)
       hitimes

--- a/middleman-cli/lib/middleman-cli/init.rb
+++ b/middleman-cli/lib/middleman-cli/init.rb
@@ -74,7 +74,7 @@ module Middleman::Cli
           if File.exist?(thorfile)
             ::Thor::Util.load_thorfile(thorfile)
 
-            invoke 'middleman:generator'
+            invoke 'middleman:generator:copy_default_files'
           else
             source_paths << dir
             directory dir, '.', exclude_pattern: /\.git\/|\.gitignore$/

--- a/middleman-cli/middleman-cli.gemspec
+++ b/middleman-cli/middleman-cli.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.7.0'
 
   # CLI
-  s.add_dependency('thor', ['>= 0.17.0', '< 1.3.0'])
+  s.add_dependency('thor', ['>= 0.17.0', '< 2'])
 end


### PR DESCRIPTION
In https://github.com/middleman/middleman/commit/ad0e0ee9ba5e017e4f3f1cc861f4fa2a4c04f198 thor was locked at `< 1.3.0` due to #2665 and #2666 .

At root, the issue is because of https://github.com/rails/thor/releases/tag/v1.3.0 and the changes in https://github.com/rails/thor/pull/754 (and related commits such as https://github.com/rails/thor/commit/a601ca9342729350529ee8235abdf9447e77474e) regarding the way Thor 1.3 locates namespaces/classes/commands.

What happens currently is that Thor 1.3 gets completely confused and determines `klass = nil`, `command = middleman`, hence the error `'invoke': Missing Thor class for invoke middleman:generator (RuntimeError)`.

It seems to be that the namespace/class location logic no longer works the same way if the `invoke` instruction does not have the task/command included. Perhaps the previous logic assumed if there was only a single function/task that it would select it.

There are two possible solutions/workarounds I've found
1. Update all templates to declare `namespace :middleman` explicitly
2. The change here, to explicitly include the `command`.

Both options seem backward compatible, at least with thor 1.2.x. I chose the second, as it seemed more straightforward than updating all of the template repos, and seems more explicit.and the task to run.

I'm not enough of a thor export to know if this change was intentional on thor side, or if middleman was unintentionally relying on undocumented thor behavior of invoke where one doesn't explicitly note the command.

Templates
- https://github.com/middleman/middleman-templates-default/blob/master/Thorfile
- https://github.com/middleman/middleman-templates-blog/blob/master/Thorfile
- https://github.com/middleman/middleman-templates-default-v5/blob/master/Thorfile

If the maintainers think that this is a bug in the way thor now works I can instead look at fixing upstream instead.

**Testing**
- Have also run the GHA tests across Ruby versions with the existing latest thor 1.2.2 version