### PR TITLE
Use lowercase headers in preview app

### DIFF
--- a/middleman-core/lib/middleman-core/meta_pages.rb
+++ b/middleman-core/lib/middleman-core/meta_pages.rb
@@ -101,7 +101,7 @@ module Middleman
 
       # Respond to an HTML request
       def response(content)
-        [200, { 'Content-Type' => 'text/html' }, Array(content)]
+        [200, { 'content-type' => 'text/html' }, Array(content)]
       end
 
       def extension_options(extension)


### PR DESCRIPTION
Since Rack 3 is more strict about it.

Fixes #2838.