### PR TITLE
Fix implicit 1x scale in srcset crashing middleman

### DIFF
--- a/middleman-core/features/image_srcset_paths.feature
+++ b/middleman-core/features/image_srcset_paths.feature
@@ -4,4 +4,4 @@ Feature: Support srcset property as params for image_tag helper
   Scenario: Rendering an image with the feature enabled
     Given the Server is running at "image-srcset-paths-app"
     When I go to "/image-srcset-paths.html"
-    Then I should see '//example.com/remote-image.jpg 2x, /images/blank_3x.jpg 3x'
+    Then I should see '/images/blank.jpg, //example.com/remote-image.jpg 2x, /images/blank_3x.jpg 3x'

--- a/middleman-core/fixtures/image-srcset-paths-app/image-srcset-paths.html.erb
+++ b/middleman-core/fixtures/image-srcset-paths-app/image-srcset-paths.html.erb
@@ -1,1 +1,1 @@
-<%= image_tag 'blank.jpg', srcset: '//example.com/remote-image.jpg 2x, blank_3x.jpg 3x, http://example.com/remoteimage.jpg 4x' %>
+<%= image_tag 'blank.jpg', srcset: 'blank.jpg, //example.com/remote-image.jpg 2x, blank_3x.jpg 3x, http://example.com/remoteimage.jpg 4x' %>

--- a/middleman-core/lib/middleman-core/core_extensions/default_helpers.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/default_helpers.rb
@@ -274,19 +274,24 @@ class Middleman::CoreExtensions::DefaultHelpers < ::Middleman::Extension
       params.symbolize_keys!
 
       if params.key?(:srcset)
-        images_sources = params[:srcset].split(',').map do |src_def|
-          if src_def.include?('//')
-            src_def
+        images_sources = params[:srcset].split(",").map do |src_def|
+          if src_def.include?("//")
+            src_def.strip
           else
-            image_def, size_def = src_def.strip.split(/\s+/)
-            asset_path(:images, image_def) + ' ' + size_def
+            image_def, size_def = src_def.strip.split(/\s+/, 2)
+            image_path = asset_path(:images, image_def)
+            if size_def
+              "#{image_path} #{size_def}"
+            else
+              image_path
+            end
           end
         end
 
-        params[:srcset] = images_sources.join(', ')
+        params[:srcset] = images_sources.join(", ")
       end
 
-      params[:alt] ||= ''
+      params[:alt] ||= ""
 
       super(path, params)
     end


### PR DESCRIPTION
I've stumbled upon a problem where if you write a syntaxically correct srcset for fixed size with implicit `1x` descriptor that can be omitted ([MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Responsive_images#resolution_switching_same_size_different_resolutions)), middleman crashes when opening the page because ruby cannot concat string with `nil` and throws an error. This fix allows for implicit descriptors in `srcset` while using `image_tag`.