### PR TITLE
fix syntax error in kramdown.rb

### DIFF
--- a/middleman-core/lib/middleman-core/renderers/kramdown.rb
+++ b/middleman-core/lib/middleman-core/renderers/kramdown.rb
@@ -8,7 +8,7 @@ module Middleman
 
       def _prepare_output
         @context = @options[:context]
-        MiddlemanKramdownHTML.scope = @context || context
+        MiddlemanKramdownHTML.scope = @context
 
         @engine = Kramdown::Document.new(data, options)
         output, warnings = MiddlemanKramdownHTML.convert(@engine.root, @engine.options)


### PR DESCRIPTION
```
undefined local variable or method `context' for an instance of Middleman::Renderers::KramdownTemplate (NameError)

        MiddlemanKramdownHTML.scope = @context || context
                                                  ^^^^^^^
```