### PR TITLE
Relax bundler version constraint to allow 4.x

### DIFF
--- a/middleman-core/middleman-core.gemspec
+++ b/middleman-core/middleman-core.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.7.0'
 
   # Core
-  s.add_dependency('bundler', '~> 2.0')
+  s.add_dependency('bundler', '> 2.0')
   s.add_dependency('rack', '>= 3')
   s.add_dependency('rackup')
   s.add_dependency('tilt', ['~> 2.2'])


### PR DESCRIPTION
This PR relaxes the Bundler version constraint in the middleman-core gemspec from `~> 2.0` to `> 2.0`.

This constraint block to use `middleman` with the next bundler release that is 4.0.