### PR TITLE
Fix block helpers under Tilt >= 2.9 by registering 'html.erb' extension

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,7 +298,7 @@ GEM
       memoist3 (~> 1.0.0)
     temple (0.10.4)
     thor (1.5.0)
-    tilt (2.7.0)
+    tilt (2.9.0)
     timers (4.0.4)
       hitimes
     toml (0.3.0)

--- a/middleman-core/features/helpers_link_to.feature
+++ b/middleman-core/features/helpers_link_to.feature
@@ -4,6 +4,7 @@ Feature: link_to helper
     Given the Server is running at "link-to-app"
     When I go to "/link_to_erb.html"
     Then I should see "erb <s>with html tags</s>"
+    Then I should see '<a href="/">'
 
   Scenario: link_to works with absolute URLs (where the relative part matches a local path)
     Given a fixture app "link-to-app"

--- a/middleman-core/lib/middleman-core/renderers/erb.rb
+++ b/middleman-core/lib/middleman-core/renderers/erb.rb
@@ -3,7 +3,7 @@ module Middleman
   module Renderers
     class ERb < ::Middleman::Extension
       def after_configuration
-        ::Tilt.prefer(Template, :erb)
+        ::Tilt.prefer(Template, :erb, 'html.erb')
       end
 
       class Template < ::Tilt::ErubiTemplate


### PR DESCRIPTION
## Problem

Tilt 2.9.0 (released 2026-08-17) added Herb template support and now lazily registers templates under the compound extension `html.erb` in addition to `erb` ([tilt.rb](https://github.com/jeremyevans/tilt/blob/master/lib/tilt.rb)):

```ruby
register_lazy :ERBTemplate,    'tilt/erb',    'erb', 'rhtml', 'html.erb'
register_lazy :ErubiTemplate,  'tilt/erubi',  'erb', 'rhtml', 'erubi', 'html.erb'
register_lazy :HerbTemplate,   'tilt/herb',   'herb', 'html.erb'
```

Tilt prefers the longest registered extension when resolving a file, and a lazy registration is enough to make `registered?('html.erb')` return true. So every `*.html.erb` file now resolves through the `html.erb` key to a plain `Tilt::ErubiTemplate` — even when the herb gem is not installed — instead of `Middleman::Renderers::ERb::Template`, which is registered only for `erb`.

Middleman's `Template` subclass injects `__in_erb_template = true` via `precompiled_preamble`, and padrino-helpers' `ErbHandler#engine_matches?` relies on that flag to detect template blocks. Without it, `block_is_template?` returns false and the output of every block-style helper — `<% link_to ... do %>...<% end %>`, `capture`, etc. — is silently discarded, with no errors or warnings. On a real production site this removed every block-form link site-wide.

middleman-core's gemspec allows `tilt (~> 2.2)`, so a plain `bundle update` pulls in 2.9.0 and triggers this.

## Why the existing tests didn't catch it

The "link_to works with blocks (erb)" scenario only asserts the block's *inner text*, which survives the bug: the inner literals are written through padrino's buffer-swap side effect, and only the wrapping `<a>` tag returned by `content_tag` is discarded. This PR adds an assertion on the `<a href="/">` tag itself; it fails on main with tilt 2.9.0 and passes with the fix.

## Fix

Register the Middleman template class for the compound `html.erb` key as well:

```ruby
::Tilt.prefer(Template, :erb, 'html.erb')
```

This is a no-op with tilt < 2.9 and restores the correct template class with tilt >= 2.9.

`Gemfile.lock` is bumped to tilt 2.9.0 so CI actually exercises the regression — with 2.7.0 in the lock, the new assertion passes with or without the fix.
